### PR TITLE
refactor: use `Document#_updateObject` for bond changes

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -758,20 +758,6 @@ export class FUActor extends Actor {
 			if (hpChange !== 0 && !levelChanged) options.damageTaken = hpChange * -1;
 		}
 
-		// Foundry's form update handlers send back bond information as an object {0: ..., 1: ....}
-		// So correct an update in that form and create an updated bond array to properly represent the changes
-		const bonds = changed.system?.resources?.bonds;
-		if (bonds) {
-			if (!Array.isArray(bonds)) {
-				const currentBonds = [];
-				const maxIndex = Object.keys(bonds).length
-				for (let i = 0; i < maxIndex; i++) {
-					currentBonds.push(bonds[i]);
-				}
-				changed.system.resources.bonds = currentBonds;
-			}
-		}
-
 		await super._preUpdate(changed, options, user);
 	}
 

--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -1124,6 +1124,23 @@ export class FUStandardActorSheet extends ActorSheet {
 			return roll;
 		}
 	}
+
+	async _updateObject(event, data){
+		// Foundry's form update handlers send back bond information as an object {0: ..., 1: ....}
+		// So correct an update in that form and create an updated bond array to properly represent the changes
+		const bonds = data.system?.resources?.bonds;
+		if (bonds) {
+			if (!Array.isArray(bonds)) {
+				const currentBonds = [];
+				const maxIndex = Object.keys(bonds).length
+				for (let i = 0; i < maxIndex; i++) {
+					currentBonds.push(bonds[i]);
+				}
+				data.system.resources.bonds = currentBonds;
+			}
+		}
+		super._updateObject(event,data)
+	}
 }
 
 /* Randomize array in-place using Durstenfeld shuffle algorithm */


### PR DESCRIPTION
While using `Actor#_preUpdate` works to tranform the sheet/form changes, some discussion in the Foundry discord makes it sound like adapting it at the sheet/form level would be better.

This patch moves the bond conversion of `{number: bond}` to `bond[] ` into the sheet that is actually handling that form.