### PR TITLE
fix: character type actor prototype token linked by default

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -754,6 +754,19 @@ export class FUActor extends Actor {
 		// Process additional NPC data here.
 	}
 
+  async _preCreate(createData, options, user) {
+    await super._preCreate(createData, options, user);
+
+    if (this.type === 'character') {
+        this.updateSource({
+            prototypeToken: {
+                actorLink: true,
+                disposition: CONST.TOKEN_DISPOSITIONS.FRIENDLY,
+            },
+        });
+    }
+  }
+
 	async _preUpdate(changed, options, user) {
 		const changedHP = changed.system?.resources?.hp;
 		const currentHP = this.system.resources.hp;

--- a/module/fabulaultima.mjs
+++ b/module/fabulaultima.mjs
@@ -253,18 +253,6 @@ Hooks.once('mmo-hud.ready', () => {
 	// Do this
 });
 
-Hooks.on('renderSheet', (app, html, data) => {
-	if (app.document.type === 'Actor' && app.document.isCharacter) {
-		const linkActorDataSetting = game.settings.get('fabulaultima', 'linkActorData');
-
-		// Check if the "Link Actor Data" setting is enabled (true or false)
-		if (linkActorDataSetting) {
-			// Modify the character sheet HTML to set "Link Actor Data" as default
-			html.find('.link-actor-data').prop('checked', true);
-		}
-	}
-});
-
 /* -------------------------------------------- */
 /*  Hotbar Macros                               */
 /* -------------------------------------------- */


### PR DESCRIPTION
Updating the prototypeToken in _precreate

Removed code likely intended to do a similar thing because I couldn't find the setting `linkActorData` in settings.js