### PR TITLE
fix: calculate absorb skill point cost in cheapest way

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -415,9 +415,11 @@ export class FUActor extends Actor {
 				this.usedSkills.initiativeBonus = this.calcUsedSkillsFromExtraInit(systemData);
 				this.usedSkills.accuracyCheck = this.calcUsedSkillsFromExtraPrecision(systemData);
 				this.usedSkills.magicCheck = this.calcUsedSkillsFromExtraMagic(systemData);
-				this.usedSkills.resistances = this.calcUsedSkillsFromResistances(systemData);
-				this.usedSkills.immunities = this.calcUsedSkillsFromImmunities(systemData);
 				this.usedSkills.absorption = this.calcUsedSkillsFromAbsorbs(systemData);
+				const [immunities, remainingFromAbsorb] = this.calcUsedSkillsFromImmunities(systemData, this.usedSkills.absorption);
+				this.usedSkills.immunities = immunities
+				this.usedSkills.resistances = this.calcUsedSkillsFromResistances(systemData, remainingFromAbsorb);
+				
 				this.usedSkills.specialRules = this.calcUsedSkillsFromSpecial(actorData);
 				this.usedSkills.equipment = this.calcUsedSkillsFromEquipment(actorData);
 				this.spUsed = Object.values(this.usedSkills).reduce((total, value) => total + value, 0);
@@ -534,8 +536,8 @@ export class FUActor extends Actor {
 				return Math.floor((sum - 1) / 3) + 1;
 			},
 
-			calcUsedSkillsFromResistances() {
-				let sum = 0;
+			calcUsedSkillsFromResistances(systemData,fromAbsorb) {
+				let sum = fromAbsorb*0.5;
 
 				Object.entries(systemData.affinities).forEach((el) => {
 					const isConstructWithEarth = systemData.species.value === 'construct' && el[0] === 'earth';
@@ -554,7 +556,7 @@ export class FUActor extends Actor {
 				return sum;
 			},
 
-			calcUsedSkillsFromImmunities() {
+			calcUsedSkillsFromImmunities(systemData, fromAbsorb) {
 				let sum = 0;
 				Object.entries(systemData.affinities).forEach((el) => {
 					if (el[1].base === 2) {
@@ -577,25 +579,19 @@ export class FUActor extends Actor {
 				}
 
 				if (sum < 0) {
-					sum = 0;
+					return[0,Math.max(0,fromAbsorb+sum)]
 				}
-
-				return Math.ceil(sum);
+				return [sum,fromAbsorb];
 			},
 
-			calcUsedSkillsFromAbsorbs() {
+			calcUsedSkillsFromAbsorbs(systemData) {
 				let sum = 0;
 				Object.entries(systemData.affinities).forEach((el) => {
 					if (el[1].base === 3) {
 						sum++;
 					}
 				});
-
-				if (sum < 0) {
-					sum = 0;
-				}
-
-				return Math.ceil(sum) * 2;
+				return sum;
 			},
 
 


### PR DESCRIPTION
When I make an npc with the following:

Elemental
Immunity - Poison
Resistance - Physical, Fire
Absorbtion - Bolt

the SP tracker shows:

SP Used 3
Used skills from resistances 1
Used skills from absorption 2

However using the pdf I should be able to do it with 2 skills:
Elemental - Free Immunity - Poison, Bolt
Damage Resistance - Physical, Fire
Damage Absorbtion - Bolt

Similarly creating:

Demon
Skill 1: Resistance - Dark, Earth, Fire
Skill 2: Absorbtion - Ice

the SP tracker shows:

SP Used 2.5
Used skills from resistances 0.5
Used skills from absorption 2

However using the pdf I should be able to do it with 2 skills:
Demon - Free Resistance - Dark, Ice
Skill 1: Damage Resistance - Earth, Fire
Skill 2: Damage Absorbtion - Ice

This patch changes the skill used calculation to only count absorption as 1 skill point.  Then it keeps track of how many resistances and immunities are required for absorption.  Any free immunities are used and the remaining requirements are treated as resistances as a resistance is 0.5 points vs an immunity is 1 point.

The resulting SP tracker for both above situations shows:

SP Used 2
Used skills from resistances 1
Used skills from absorption 1