### PR TITLE
Offensive Shield Checks

### DIFF
--- a/module/documents/actors/common/damage-bonuses-data-model.mjs
+++ b/module/documents/actors/common/damage-bonuses-data-model.mjs
@@ -1,6 +1,7 @@
 /**
- * @property {number} physical
- * @property {number} magic
+ * @property {number} melee
+ * @property {number} ranged
+ * @property {number} spell
  * @property {number} arcane
  * @property {number} bow
  * @property {number} brawling
@@ -16,8 +17,9 @@ export class DamageBonusesDataModel extends foundry.abstract.DataModel {
 	static defineSchema() {
 		const { NumberField } = foundry.data.fields;
 		return {
-			physical: new NumberField({ initial: 0, integer: true, nullable: false }),
-			magic: new NumberField({ initial: 0, integer: true, nullable: false }),
+			melee: new NumberField({ initial: 0, integer: true, nullable: false }),
+			ranged: new NumberField({ initial: 0, integer: true, nullable: false }),
+			spell: new NumberField({ initial: 0, integer: true, nullable: false }),
 			arcane: new NumberField({ initial: 0, integer: true, nullable: false }),
 			bow: new NumberField({ initial: 0, integer: true, nullable: false }),
 			brawling: new NumberField({ initial: 0, integer: true, nullable: false }),

--- a/module/documents/items/item.mjs
+++ b/module/documents/items/item.mjs
@@ -792,10 +792,11 @@ export class FUItem extends Item {
 		const { rollInfo, opportunity, description, summary, mpCost, target, duration } = this.system;
 		let checkDamage = undefined;
 		if (rollInfo?.damage?.hasDamage?.value) {
+			const damageBonus = this.actor.system.bonuses.damage.spell;
 			checkDamage = {
 				hrZero: rollInfo.useWeapon?.hrZero?.value || hrZero,
 				type: rollInfo.damage.type.value,
-				bonus: rollInfo.damage.value,
+				bonus: rollInfo.damage.value + damageBonus,
 			};
 		}
 
@@ -841,7 +842,8 @@ export class FUItem extends Item {
 		/** @type WeaponDataModel */
 		const dataModel = this.system;
 		const { accuracy, attributes, type, rollInfo, quality, damage, damageType, hands, description, category, summary } = dataModel;
-		const { accuracyCheck, [category.value]: categoryAccuracyBonus = 0 } = this.actor.system.bonuses.accuracy;
+		const { accuracyCheck = 0, [category.value]: categoryAccuracyBonus = 0 } = this.actor.system.bonuses.accuracy;
+		const { [type.value]: typeDamageBonus = 0, [category.value]: categoryDamageBonus = 0 } = this.actor.system.bonuses.damage;
 		/** @type CheckWeapon */
 		let details = {
 			_type: 'weapon',
@@ -874,7 +876,7 @@ export class FUItem extends Item {
 			damage: {
 				hrZero: rollInfo?.useWeapon?.hrZero?.value || hrZero,
 				type: damageType.value,
-				bonus: damage.value,
+				bonus: damage.value + categoryDamageBonus + typeDamageBonus,
 			},
 			speaker: ChatMessage.implementation.getSpeaker({ actor: this.actor }),
 		});

--- a/module/documents/items/shield/shield-data-model.mjs
+++ b/module/documents/items/shield/shield-data-model.mjs
@@ -1,6 +1,6 @@
-import {FU} from '../../../helpers/config.mjs';
-import {IsEquippedDataModel} from '../common/is-equipped-data-model.mjs';
-import {ItemAttributesDataModel} from '../common/item-attributes-data-model.mjs';
+import { FU } from '../../../helpers/config.mjs';
+import { IsEquippedDataModel } from '../common/is-equipped-data-model.mjs';
+import { ItemAttributesDataModel } from '../common/item-attributes-data-model.mjs';
 
 /**
  * @property {string} subtype.value
@@ -45,12 +45,12 @@ export class ShieldDataModel extends foundry.abstract.TypeDataModel {
 			def: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
 			mdef: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
 			init: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
-			attributes: new EmbeddedDataField(ItemAttributesDataModel, { initial: { primary: { value: 'ins' }, secondary: { value: 'mig' } } }),
+			attributes: new EmbeddedDataField(ItemAttributesDataModel, { initial: { primary: { value: 'mig' }, secondary: { value: 'mig' } } }),
 			accuracy: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
-			damage: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
+			damage: new SchemaField({ value: new NumberField({ initial: 5, integer: true, nullable: false }) }),
 			type: new SchemaField({ value: new StringField({ initial: 'melee', choices: Object.keys(FU.weaponTypes) }) }),
 			category: new SchemaField({ value: new StringField({ initial: 'brawling', choices: Object.keys(FU.weaponCategories) }) }),
-			hands: new SchemaField({ value: new StringField({ initial: 'one-handed', choices: Object.keys(FU.handedness) }) }),
+			hands: new SchemaField({ value: new StringField({ initial: 'two-handed', choices: Object.keys(FU.handedness) }) }),
 			impType: new SchemaField({ value: new StringField({ initial: 'minor', choices: ['minor', 'heavy', 'massive'] }) }),
 			damageType: new SchemaField({ value: new StringField({ initial: 'physical', blank: true, choices: Object.keys(FU.damageTypes) }) }),
 			isBehavior: new SchemaField({ value: new BooleanField() }),

--- a/templates/item/item-shield-sheet.hbs
+++ b/templates/item/item-shield-sheet.hbs
@@ -63,14 +63,7 @@
 							<label for="system.category.value" class="resource-label-m flexlarge align-left">{{localize
 								'FU.Category'}}</label>
 							<select name="system.category.value" class="resource-inputs select-dropdown-m">
-								<option value="brawling">Brawling</option>
-								<option value="sword">Sword</option>
-								<option value="thrown">Thrown</option>
-								<option value="spear">Spear</option>
-								<option value="heavy">Heavy</option>
-								<option value="flail">Flail</option>
-								<option value="firearm">Firearm</option>
-								<option value="dagger">Dagger</option>
+                                {{selectOptions weaponCategoriesWithoutCustom selected=system.category.value localize=true}}
 							</select>
 						</div>
 						<div class="resource-content flexcol flex-group-center">


### PR DESCRIPTION
- fix shield weapon category resetting
- adjust ShieldDataModel defaults to align with dual shield
- replace physical/magic damage bonuses with melee/ranged/spell
- adjust weapon and spell checks to take new bonuses for damage into account

fix #73 and #74 