### PR TITLE
Fix _doHudDrop not firing on combat-hud, add button to save position of dragged hud on reset/combat end

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Charakterbogen",
 		"CombatHudPortraitToken": "Token",
 		"CombatHudControlButtonTitle": "Konflikt-HUD ein/ausblenden",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Aktive Effekte anzeigen",
 		"CombatHudShowEffectsHint": "Zeigt auf Akteure wirkende Effekte im Konflikt-HUD.",
 		"CombatHudEffectsMarqueeDuration": "Geschwindigkeit der Effekt-Laufschrift",

--- a/lang/en.json
+++ b/lang/en.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Actor Image",
 		"CombatHudPortraitToken": "Token Image",
 		"CombatHudControlButtonTitle": "Toggle Combat HUD",
+		"CombatHudSaveButtonTitle": "Save Combat HUD Position",
 		"CombatHudShowEffects": "Show Combatant Effects",
 		"CombatHudShowEffectsHint": "Show the effects of the combatant in the Combat HUD.",
 		"CombatHudEffectsMarqueeDuration": "Effects Marquee Duration",

--- a/lang/en.json
+++ b/lang/en.json
@@ -931,7 +931,7 @@
 		"CombatHudPortraitActor": "Actor Image",
 		"CombatHudPortraitToken": "Token Image",
 		"CombatHudControlButtonTitle": "Toggle Combat HUD",
-		"CombatHudSaveButtonTitle": "Save Combat HUD Position",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Show Combatant Effects",
 		"CombatHudShowEffectsHint": "Show the effects of the combatant in the Combat HUD.",
 		"CombatHudEffectsMarqueeDuration": "Effects Marquee Duration",

--- a/lang/es.json
+++ b/lang/es.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Imagen de Actor",
 		"CombatHudPortraitToken": "Imagen de Token",
 		"CombatHudControlButtonTitle": "Activa/Desactiva HUD de Combate",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Muestra efectos de participantes",
 		"CombatHudShowEffectsHint": "Muestra efectos de participantes en el HUD de Combate.",
 		"CombatHudEffectsMarqueeDuration": "Duración de la muestra de efectos",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Image de l'Acteur",
 		"CombatHudPortraitToken": "Image du Token",
 		"CombatHudControlButtonTitle": "Activer/Désactiver l'ATH de Combat",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Montrer les effets des combattants",
 		"CombatHudShowEffectsHint": "Montrer les effets sur les combattants dans l'ATH de Combat.",
 		"CombatHudEffectsMarqueeDuration": "Durée du défilement des effets",

--- a/lang/it.json
+++ b/lang/it.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Immagine Personaggio",
 		"CombatHudPortraitToken": "Immagine Token",
 		"CombatHudControlButtonTitle": "Attiva/Disattiva Interfaccia di Conflitto",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Mostra Effetti dei Partecipanti",
 		"CombatHudShowEffectsHint": "Mostra Effetti Attivi dei Partecipanti nell'Interfaccia di Conflitto.",
 		"CombatHudEffectsMarqueeDuration": "Durata Scorrimento Effetti",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Actor Image",
 		"CombatHudPortraitToken": "Token Image",
 		"CombatHudControlButtonTitle": "Toggle Combat HUD",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Show Combatant Effects",
 		"CombatHudShowEffectsHint": "Show the effects of the combatant in the Combat HUD.",
 		"CombatHudEffectsMarqueeDuration": "Effects Marquee Duration",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Imagem (Personagem)",
 		"CombatHudPortraitToken": "Imagem (Token)",
 		"CombatHudControlButtonTitle": "Ativar/Desativar HUD de Combate",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Mostrar Efeitos dos Participantes",
 		"CombatHudShowEffectsHint": "Mostrar os efeitos dos participantes no HUD de Combate.",
 		"CombatHudEffectsMarqueeDuration": "Duração da amostra de efeitos",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -931,6 +931,7 @@
 		"CombatHudPortraitActor": "Изображение актера",
 		"CombatHudPortraitToken": "Изображение токена",
 		"CombatHudControlButtonTitle": "Включить/выключить боевой интерфейс",
+		"CombatHudSaveButtonTitle": "Save Combat HUD position and size",
 		"CombatHudShowEffects": "Показать эффекты участников",
 		"CombatHudShowEffectsHint": "Показывать эффекты участников в боевом интерфейсе",
 		"CombatHudEffectsMarqueeDuration": "Длительность прокрутки эффектов",

--- a/module/settings.js
+++ b/module/settings.js
@@ -33,6 +33,7 @@ export const SETTINGS = Object.freeze({
 	optionCombatHudShowOrderNumbers: 'optionCombatHudShowOrderNumbers',
 	optionCombatHudActorOrdering: 'optionCombatHudActorOrdering',
 	optionCombatHudDraggedPosition: 'optionCombatHudDraggedPosition',
+	optionCombatHudSaved: 'optionCombatHudSaved',
 	optionRenameCurrency: 'optionRenameCurrency',
 	metaCurrencyFabula: 'metaCurrencyFabula',
 	metaCurrencyUltima: 'metaCurrencyUltima',
@@ -299,6 +300,15 @@ export const registerSystemSettings = async function () {
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudMinimized, {
 		name: 'CombatHudMinimized',
+		scope: 'client',
+		config: false,
+		type: Boolean,
+		default: false,
+	});
+
+
+	game.settings.register(SYSTEM, SETTINGS.optionCombatHudSaved, {
+		name: 'CombatHudSaved',
 		scope: 'client',
 		config: false,
 		type: Boolean,

--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -806,7 +806,7 @@ export class CombatHUD extends Application {
 		return {
 			name: 'projectfu-combathud-saved-toggle',
 			title: game.i18n.localize('FU.CombatHudSaveButtonTitle'),
-			icon: 'fas fa-save',
+			icon: 'fas fa-lock',
 			button: false,
 			toggle: true,
 			visible: game.combat ? game.combat.isActive : false,

--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -624,20 +624,16 @@ export class CombatHUD extends Application {
 		const uiMiddle = $('#ui-middle');
 
 		const position = {};
-		if (draggedPosition && draggedPosition.x) {
-			position.left = draggedPosition.x;
-		} else {
-			position.left = uiMiddle.position().left - uiLeft.width() * 0.5;
-		}
 
+		position.left = draggedPosition && draggedPosition.x ? draggedPosition.x : uiMiddle.position().left - uiLeft.width() * 0.5;
 		if (positionFromTop) {
 			const uiTop = $('#ui-top');
 			position.top = draggedPosition && draggedPosition.y ? draggedPosition.y : uiTop.height() + 20;
-
 		} else {
 			const uiBottom = $('#ui-bottom');
 			position.bottom = draggedPosition && draggedPosition.y ? draggedPosition.y : uiBottom.height() + 20;
 		}
+		
 		return position;
 	}
 


### PR DESCRIPTION
👋 
I noticed that the position of the combat hud was not staying in place, seems that _doHudDrop was never firing. I also think there **might be issues on two other draggables**, however I haven't tried to play with either of those features, so I just commented on them.

I also made it so that if the user changes between the combat hud's default position being top/bottom in the settings, the drag position is relative to that (ie if they set it to the bottom, the drag position will be relative to the bottom, not top).

In addition, I added a button to lock the position and compact/non compact mode for people (like me) who have one specific place and layout they want to keep across battles. If it's enabled, the only thing the reset combat hud button does is unminimize it. 
I needed this feature as I was having issues with visibility. Having the hud right by the bottom ended up with my macro bar clipping over it and obscuring part of the contents. 

Since the hud seems to be your work, have a mention @KzMz 