### PR TITLE
fix isSuppressed reliant on 'crisis' being evaluated first

### DIFF
--- a/module/documents/effects/active-effect.mjs
+++ b/module/documents/effects/active-effect.mjs
@@ -75,7 +75,7 @@ export class FUActiveEffect extends ActiveEffect {
 		if (this.target instanceof FUActor) {
 			const flag = this.getFlag(SYSTEM, CRISIS_INTERACTION);
 			if (flag && flag !== 'none') {
-				if (this.target.statuses.has('crisis')) {
+				if (this.target.effects.find(e => e.statuses.has('crisis')) != null) {
 					return flag === 'inactive';
 				} else {
 					return flag === 'active';
@@ -85,7 +85,7 @@ export class FUActiveEffect extends ActiveEffect {
 		if (this.target instanceof FUItem && this.target.parent instanceof FUActor) {
 			const flag = this.getFlag(SYSTEM, CRISIS_INTERACTION);
 			if (flag && flag !== 'none') {
-				if (this.target.parent.statuses.has('crisis')) {
+				if (this.target.parent.effects.find(e => e.statuses.has('crisis')) != null) {
 					return flag === 'inactive';
 				} else {
 					return flag === 'active';
@@ -109,7 +109,7 @@ export class FUActiveEffect extends ActiveEffect {
 			}
 		}
 	}
-
+	
 	apply(target, change) {
 		if (change.value && typeof change.value === 'string') {
 			try {


### PR DESCRIPTION
Looked into the bug in the support forum:
![image](https://github.com/user-attachments/assets/7baa1563-5c46-4483-afbb-f9eb52b18787)

It seems target.statuses looks only at already applied statuses. Therefore anything evaluating isSuppressed relies on crisis to have been evaluated _first_ in the list, which doesn't seem to be a sure thing. (I'm not sure how the list is created, but it might be that any effect added is added in at the bottom. So crisis would always be evaluated pretty far down?)

Swapped out target.statuses for target.effects, which doesn't rely on them being evaluated in any order.

I think a problem might come up here as well if something can supress/disable crisis, target.effects is just a list of all effects the user has rather than filtering out disabled/suppressed things, but that seems far less likely than the current situation. And it would be homebrew, I think? Can't remember anything in cr/hf (i don't have any other of the books) that suppress crisis