### PR TITLE
Hide disabled/suppressed effects in the combat HUD

### DIFF
--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -165,11 +165,12 @@ export class CombatHUD extends Application {
 		for (const combatant of game.combat.combatants) {
 			if (!combatant.actor || !combatant.token) continue;
 
+			const activeEffects = (game.release.generation >= 11 ? Array.from(combatant.actor.allApplicableEffects()) : combatant.actor.effects).filter(e => !e.disabled && !e.isSuppressed);
 			const actorData = {
 				id: combatant.id,
 				actor: combatant.actor,
 				token: combatant.token,
-				effects: game.release.generation >= 11 ? Array.from(combatant.actor.allApplicableEffects()) : combatant.actor.effects,
+				effects: activeEffects,
 				img: game.settings.get(SYSTEM, SETTINGS.optionCombatHudPortrait) === 'token' ? combatant.token.texture.src : combatant.actor.img,
 				trackedResourcePart1: trackedResourcePart1,
 				trackedResourcePart2: trackedResourcePart2,


### PR DESCRIPTION
👋 
I felt the HUD was pretty useless for showing effects. You don't know if any of them are disabled, or suppressed, which ones are actually effecting the actor, etc. I filtered out disabled and suppressed effects, to show only things that are actively impacting the player in the current moment.

If there's use cases where people need to see disabled/suppressed effects, it feels like you'd want to look at the character sheet, which actually shows that kind of information in detail.

@KzMz 