### PR TITLE
Fix: Twin Shield Tweaks

### DIFF
--- a/src/packs/skills/weapon_Twin_Shields_2LyT2btVVPDPYY4h.json
+++ b/src/packs/skills/weapon_Twin_Shields_2LyT2btVVPDPYY4h.json
@@ -96,7 +96,7 @@
         {
           "key": "system.derived.def.bonus",
           "mode": 2,
-          "value": "2",
+          "value": "4",
           "priority": null
         }
       ],

--- a/src/packs/skills/weapon_Twin_Shields__Runic__BronzekX5gYvdtisphOnoj.json
+++ b/src/packs/skills/weapon_Twin_Shields__Runic__BronzekX5gYvdtisphOnoj.json
@@ -1,0 +1,157 @@
+{
+  "folder": "rh1Z5dIGbWFOZSll",
+  "name": "Twin Shields (Runic & Bronze)",
+  "type": "weapon",
+  "img": "systems/projectfu/styles/static/compendium/twin-shields/twin-shields.png",
+  "system": {
+    "source": {
+      "value": "FUCR196"
+    },
+    "summary": {
+      "value": ""
+    },
+    "category": {
+      "value": "brawling"
+    },
+    "hands": {
+      "value": "two-handed"
+    },
+    "type": {
+      "value": "melee"
+    },
+    "isFavored": {
+      "value": false
+    },
+    "showTitleCard": {
+      "value": false
+    },
+    "rollInfo": {
+      "useWeapon": {
+        "hrZero": {
+          "value": false
+        }
+      }
+    },
+    "isMartial": {
+      "value": false
+    },
+    "isCustomWeapon": {
+      "value": false
+    },
+    "quality": {
+      "value": "Deals extra damage equal to your【SL】in defensive mastery (above)."
+    },
+    "cost": {
+      "value": 100
+    },
+    "attributes": {
+      "primary": {
+        "value": "mig"
+      },
+      "secondary": {
+        "value": "mig"
+      }
+    },
+    "accuracy": {
+      "value": 0
+    },
+    "damageType": {
+      "value": "physical"
+    },
+    "damage": {
+      "value": 5
+    },
+    "subtype": {},
+    "description": "",
+    "isEquipped": {
+      "value": false
+    },
+    "impType": {
+      "value": "minor"
+    },
+    "isBehavior": {
+      "value": false
+    },
+    "weight": {
+      "value": 1
+    },
+    "defense": "def"
+  },
+  "effects": [
+    {
+      "duration": {
+        "rounds": 1,
+        "startTime": null,
+        "seconds": null,
+        "combat": null,
+        "turns": null,
+        "startRound": null,
+        "startTurn": null
+      },
+      "disabled": false,
+      "name": "Twin Shields (Runic)",
+      "_id": "oaHQT6sqi0iC32QB",
+      "changes": [
+        {
+          "key": "system.derived.def.bonus",
+          "mode": 2,
+          "value": "4",
+          "priority": null
+        },
+        {
+          "key": "system.derived.mdef.bonus",
+          "mode": 2,
+          "value": "2",
+          "priority": null
+        }
+      ],
+      "description": "",
+      "transfer": true,
+      "statuses": [],
+      "flags": {
+        "projectfu": {
+          "CrisisInteraction": "none"
+        }
+      },
+      "tint": "#ffffff",
+      "_stats": {
+        "coreVersion": "12.330",
+        "systemId": null,
+        "systemVersion": null,
+        "createdTime": null,
+        "modifiedTime": null,
+        "lastModifiedBy": null,
+        "compendiumSource": null,
+        "duplicateSource": null
+      },
+      "img": "modules/fabula-ultima-core-rulebook/artwork/items/Twin%20Shields.png",
+      "type": "base",
+      "system": {},
+      "origin": null,
+      "sort": 0,
+      "_key": "!items.effects!G7ia7CUo4fzXL4Lo.oaHQT6sqi0iC32QB"
+    }
+  ],
+  "ownership": {
+    "default": 2,
+    "hYECXwi6O8UUBuN4": 3,
+    "q7If7bbltkFLUNCj": 3,
+    "BwRsFvMHAq9vUtEO": 3
+  },
+  "flags": {
+    "core": {}
+  },
+  "_stats": {
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "coreVersion": "12.330",
+    "createdTime": 1707628405753,
+    "modifiedTime": 1719225927959,
+    "lastModifiedBy": "BwRsFvMHAq9vUtEO",
+    "compendiumSource": null,
+    "duplicateSource": null
+  },
+  "_id": "G7ia7CUo4fzXL4Lo",
+  "sort": 0,
+  "_key": "!items!G7ia7CUo4fzXL4Lo"
+}

--- a/src/packs/skills/weapon_Twin_Shields__Runic__G7ia7CUo4fzXL4Lo.json
+++ b/src/packs/skills/weapon_Twin_Shields__Runic__G7ia7CUo4fzXL4Lo.json
@@ -95,13 +95,13 @@
         {
           "key": "system.derived.def.bonus",
           "mode": 2,
-          "value": "2",
+          "value": "4",
           "priority": null
         },
         {
           "key": "system.derived.mdef.bonus",
           "mode": 2,
-          "value": "2",
+          "value": "4",
           "priority": null
         }
       ],


### PR DESCRIPTION
Hi there,

I made some tweaks to the Guardian Twin Shields ability as the book says that 'you gain the benefits of both items' (197) but in the compendium the bonus was only being applied once. I also added a Twin Shields item for when the player has one runic and one bronze shield

## Changes
- Twin Shields > set def bonus to 4
- Twin Shields (Runic) > set def to 4, set magic def to 4
- Twin Shields (Runic & Bronze) > set def to 4 and magic def to 2

Sorry if I've misunderstood the conventions on how you're building items. Thanks for all your hard work, the system is looking great.