### PR TITLE
Fix "V12 Bug, creating items in stats tab don’t autofavorite/enable click" from discord

### DIFF
--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -1105,10 +1105,11 @@ export class FUStandardActorSheet extends ActorSheet {
 		const localizedKey = CONFIG.FU.itemTypes[type] || `TYPES.Item.${type}`;
 		const name = game.i18n.localize(localizedKey) || `${subtype ? subtype.split('.')[1].capitalize() : type.capitalize()}`;
 
+		const isV12OrLater = foundry.utils.isNewerVersion(game.version, '12.0.0');
 		const itemData = {
 			name: name,
 			type: type,
-			data: { isFavored: true, ...(clock && { hasClock: true }), ...(subtype && { featureType: subtype }), ...(subtype && { optionalType: subtype }) },
+			[isV12OrLater ? 'system' : 'data']: { isFavored: true, ...(clock && { hasClock: true }), ...(subtype && { featureType: subtype }), ...(subtype && { optionalType: subtype }) },
 		};
 
 		// Check if the type is 'zeroPower' and set clock to true
@@ -1119,7 +1120,6 @@ export class FUStandardActorSheet extends ActorSheet {
 
 		try {
 			let item = await Item.create(itemData, { parent: this.actor });
-			const isV12OrLater = foundry.utils.isNewerVersion(game.version, '12.0.0');
 
 			await item.update({
 				[`${isV12OrLater ? 'system' : 'data'}.hasClock.value`]: clock,

--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -947,8 +947,10 @@ export class FUStandardActorSheet extends ActorSheet {
 		// Check if the game option exists and is enabled
 		if (game.settings.get('projectfu', 'optionAlwaysFavorite')) {
 			let item = await Item.create(itemData, { parent: this.actor });
+			const isV12OrLater = foundry.utils.isNewerVersion(game.version, '12.0.0');
+
 			await item.update({
-				'data.isFavored.value': true,
+				[`${isV12OrLater ? 'system' : 'data'}.isFavored.value`]: true,
 			});
 			return item;
 		} else {
@@ -1117,11 +1119,13 @@ export class FUStandardActorSheet extends ActorSheet {
 
 		try {
 			let item = await Item.create(itemData, { parent: this.actor });
+			const isV12OrLater = foundry.utils.isNewerVersion(game.version, '12.0.0');
+
 			await item.update({
-				'data.hasClock.value': clock,
-				'data.isFavored.value': true,
-				'data.featureType': subtype,
-				'data.optionalType': subtype,
+				[`${isV12OrLater ? 'system' : 'data'}.hasClock.value`]: clock,
+				[`${isV12OrLater ? 'system' : 'data'}.isFavored.value`]: true,
+				[`${isV12OrLater ? 'system' : 'data'}.featureType`]: subtype,
+				[`${isV12OrLater ? 'system' : 'data'}.optionalType`]: subtype,
 			});
 			ui.notifications.info(`${name} created successfully.`);
 			item.sheet.render(true);


### PR DESCRIPTION
Hi! This should solve the issue with creating items not having the proper attributes attached.