### PR TITLE
added skill list to combat section

### DIFF
--- a/templates/actor/sections/actor-section-combat.hbs
+++ b/templates/actor/sections/actor-section-combat.hbs
@@ -31,6 +31,72 @@
 
     <ol class="items-list">
         <li class="item flexrow items-header">
+            <div class="item-name">{{localize 'FU.Skills'}}</div>
+            <div class="item-lg">{{localize 'FU.SkillLevel'}}</div>
+            <div class="item-m end">
+                <a class="item-control item-create" aria-describedby="tooltip"
+                   data-tooltip="{{localize 'FU.SkillCreate'}}" data-type="skill">
+                    <i class="fas fa-plus icon"></i>
+                    {{localize 'FU.Add'}}
+                </a>
+            </div>
+        </li>
+        {{#each skills as |item id|}}
+            <li class="item" data-item-id="{{ item._id }}">
+                <div class="flexrow" style="height: fit-content; align-items: flex-start;">
+                    <div class="flexcol">
+                        {{!-- Item Name--}}
+                        {{> "systems/projectfu/templates/actor/partials/actor-item-name.hbs" item=item}}
+                        {{#if item.quality}}
+                            <div class="item-quality">{{ item.quality }}</div>
+                        {{/if}}
+                    </div>
+                    {{!-- Resource Points --}}
+                    {{#if item.system.hasResource.value}}
+                        <div class="item-m flexcol flex-group-center resource-content">
+                            <label class="item-quality resource-text-sm">{{ item.system.rp.name }}</label>
+                            <div class="resource-text-m buttons-inc" style="padding: 0 4px;">
+                                <a class="decrement-button" data-type="resourceCounter"
+                                   data-item-id="{{ item._id }}">-</a>
+                                <span data-resource="item.rp">{{ item.system.rp.current }}</span>
+                                {{#if (gt item.system.rp.max 0)}}
+                                    <span>/</span>
+                                    <span>{{ item.system.rp.max }}</span>
+                                {{/if}}
+
+                                <a class="increment-button" data-type="resourceCounter"
+                                   data-item-id="{{ item._id }}">+</a>
+                            </div>
+                        </div>
+                    {{/if}}
+                    {{!-- Star Tracker--}}
+                    <div class="skillLevel item-lg sl-stars">
+                        {{#each item.skillArr as |level|}}
+                            <div class="star-radio-container">
+                                <input type="radio" name="skillLevel_{{ item._id }}"
+                                       id="skillLevel_{{ item._id }}_{{ level.id }}" value="{{ level.id }}" {{#if
+                                        level.checked}}checked{{/if}} data-item-id="{{ item._id }}"
+                                       class="hidden-radio">
+                                <label for="skillLevel_{{ item._id }}_{{ level.id }}"
+                                       class="star-label {{#if
+                                        (lte level.id item.system.level.value)}} fus-sl-star {{else}}ful-sl-star{{/if}}"></label>
+                            </div>
+                        {{/each}}
+                    </div>
+                    {{!-- Item Control--}}
+                    {{> "systems/projectfu/templates/actor/partials/actor-control.hbs" item=item}}
+                </div>
+                <div class="individual-description align-left">
+                    {{#if item.system.description}}
+                        {{{item.enrichedHtml.description}}}
+                    {{/if}}
+                </div>
+            </li>
+        {{/each}}
+    </ol>
+
+    <ol class="items-list">
+        <li class="item flexrow items-header">
             <div class="item-name">{{localize 'FU.Spells'}}</div>
             <div class="item-m">{{localize 'FU.Duration'}}</div>
             <div class="item-lg">{{localize 'FU.Target'}}</div>


### PR DESCRIPTION
Attempt to fix issue where NPC skills and class skills/features couldn't be dragged directly from compendium to NPC sheet, since it only considered items classified as "Misc Ability". 

Added a "Skills" list to the "Combat" tab (actor-section-combat.hbs), reutilizing code from the actor-section-classes.hbs skill section.