### PR TITLE
feat: damage hooks

### DIFF
--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -1,4 +1,5 @@
 import { FUItem } from '../items/item.mjs';
+import { FUHooks } from '../../hooks.mjs';
 import { toggleStatusEffect } from '../../helpers/effects.mjs';
 
 /**
@@ -14,7 +15,7 @@ export class FUActor extends Actor {
 		// prepareBaseData(), prepareEmbeddedDocuments() (including active effects),
 		// prepareDerivedData().
 		super.prepareData();
-		Hooks.callAll('projectfu.actor.dataPrepared', this);
+		Hooks.callAll(FUHooks.DATA_PREPARED_ACTOR, this);
 	}
 
 	async getData(options = {}) {

--- a/module/documents/items/item.mjs
+++ b/module/documents/items/item.mjs
@@ -7,6 +7,7 @@ import { SOCKET } from '../../socket.mjs';
 import { SETTINGS } from '../../settings.js';
 import { ChecksV2 } from '../../checks/checks-v2.mjs';
 import { slugify } from '../../util.mjs';
+import { FUHooks } from '../../hooks.mjs';
 
 const capitalizeFirst = (string) => (typeof string === 'string' ? string.charAt(0).toUpperCase() + string.slice(1) : string);
 
@@ -33,7 +34,7 @@ export class FUItem extends Item {
 		// As with the actors class, items are documents that can have their data
 		// preparation methods overridden (such as prepareBaseData()).
 		super.prepareData();
-		Hooks.callAll('projectfu.item.dataPrepared', this);
+		Hooks.callAll(FUHooks.DATA_PREPARED_ITEM, this);
 	}
 
 	/**

--- a/module/helpers/apply-damage.mjs
+++ b/module/helpers/apply-damage.mjs
@@ -1,187 +1,179 @@
 import { FU, SYSTEM } from './config.mjs';
+import { FUHooks } from '../hooks.mjs';
 import { Flags } from './flags.mjs';
 import { ChecksV2 } from '../checks/checks-v2.mjs';
 import { CheckConfiguration } from '../checks/check-configuration.mjs';
 import { DamageCustomizer } from './damage-customizer.mjs';
 import { getSelected, getTargeted } from './target-handler.mjs';
 
-export function registerChatInteraction() {
-	Hooks.on('renderChatMessage', attachDamageApplicationHandler);
-}
+// Aliases
+
+/**
+ * @typedef BaseDamageInfo
+ * @type {import('./typedefs.mjs').BaseDamageInfo}
+*/
+
+/**
+ * @typedef ExtraDamageInfo
+ * @type {import('./damage-customizer.mjs').ExtraDamageInfo}
+ */
+
+/**
+ * @typedef DamageType
+ * @type {import('./config.mjs').DamageType}
+ */
+
+// Typedefs
+
+/**
+ * @typedef ClickModifiers
+ * @prop {boolean} alt
+ * @prop {boolean} ctrl
+ * @prop {boolean} shift
+ */
+
+/**
+ * @callback DamageModifier
+ * @param {number} baseDamage
+ * @param {ClickModifiers} modifiers
+ * @return {number}
+ */
+
 
 function attachDamageApplicationHandler(message, jQuery) {
 	const check = message.getFlag(SYSTEM, Flags.ChatMessage.CheckParams);
+	let sourceName;
+	let baseDamageInfo;
+	let disabled = false;
+
 	if (check && check.damage) {
-		let disabled = false;
-		const handleDamageApplication = async (event, targets, extraDamageInfo) => {
-			if (targets) {
-				const { total = 0, type: damageType, modifierTotal: modTotal } = check.damage;
-				// const modifiedTotal = total + (extraDamageInfo.damageBonus || 0);
-				const modifiedTotal = extraDamageInfo.hrZero ? extraDamageInfo.damageBonus + modTotal : total + (extraDamageInfo.damageBonus || 0);
-				const modifiedType = extraDamageInfo.damageType || damageType;
-				const modifiedTargets = extraDamageInfo.targets || targets;
-				await applyDamage(
-					modifiedTargets,
-					modifiedType,
-					modifiedTotal,
-					{
-						alt: event.altKey,
-						ctrl: event.ctrlKey || event.metaKey,
-						shift: event.shiftKey,
-					},
-					check.details.name,
-					extraDamageInfo,
-				);
-
-				if (extraDamageInfo.extraDamage > 0) {
-					await applyExtraDamage(
-						modifiedTargets,
-						extraDamageInfo.extraDamageType,
-						extraDamageInfo.extraDamage,
-						{
-							alt: event.altKey,
-							ctrl: event.ctrlKey || event.metaKey,
-							shift: event.shiftKey,
-						},
-						check.details.name,
-						extraDamageInfo,
-					);
-				}
-			}
-			disabled = false;
+		sourceName = check.details.name;
+		baseDamageInfo = {
+			total: check.damage.total,
+			type: check.damage.type,
+			modifierTotal: check.damage.modifierTotal,
 		};
-
-		const handleClick = async (event, getTargetsFunction) => {
-			if (!disabled) {
-				disabled = true;
-				const targets = await getTargetsFunction(event);
-				if (event.ctrlKey || event.metaKey) {
-					DamageCustomizer(
-						check.damage,
-						targets,
-						(extraDamageInfo) => handleDamageApplication(event, targets, extraDamageInfo),
-						() => {
-							disabled = false;
-						},
-					);
-				} else {
-					handleDamageApplication(event, targets, {});
-				}
-			}
-		};
-
-		jQuery.find(`a[data-action=applySingleDamage]`).click((event) => handleClick(event, getSingleTarget));
-		jQuery.find(`a[data-action=applySelectedDamage]`).click((event) => handleClick(event, getSelected));
-		jQuery.find(`a[data-action=applyTargetedDamage]`).click((event) => handleClick(event, getTargeted));
-		jQuery.find(`a[data-action=selectDamageCustomizer]`).click(async (event) => {
-			if (!disabled) {
-				disabled = true;
-				const targets = await getTargeted(event);
-				DamageCustomizer(
-					check.damage,
-					targets,
-					(extraDamageInfo) => handleDamageApplication(event, targets, extraDamageInfo),
-					() => {
-						disabled = false;
-					},
-				);
-			}
-		});
 	}
 
 	if (ChecksV2.isCheck(message)) {
 		const damage = CheckConfiguration.inspect(message).getDamage();
 		if (damage) {
-			let disabled = false;
-			const handleDamageApplication = async (event, targets, extraDamageInfo) => {
-				if (targets) {
-					// const modifiedTotal = damage.total + (extraDamageInfo.damageBonus || 0); // Add the damage bonus to the total damage
-					const modifiedTotal = extraDamageInfo.hrZero ? extraDamageInfo.damageBonus + damage.modifierTotal : damage.total + (extraDamageInfo.damageBonus || 0);
-					const modifiedType = extraDamageInfo.damageType || damage.type;
-					const modifiedTargets = extraDamageInfo.targets || targets;
-					await applyDamage(
-						modifiedTargets,
-						modifiedType,
-						modifiedTotal,
-						{
-							alt: event.altKey,
-							ctrl: event.ctrlKey || event.metaKey,
-							shift: event.shiftKey,
-						},
-						message.getFlag(SYSTEM, Flags.ChatMessage.Item)?.name,
-						extraDamageInfo,
-					);
-					if (extraDamageInfo.extraDamage > 0) {
-						await applyExtraDamage(
-							modifiedTargets,
-							extraDamageInfo.extraDamageType,
-							extraDamageInfo.extraDamage,
-							{
-								alt: event.altKey,
-								ctrl: event.ctrlKey || event.metaKey,
-								shift: event.shiftKey,
-							},
-							message.getFlag(SYSTEM, Flags.ChatMessage.Item)?.name,
-							extraDamageInfo,
-						);
-					}
-				}
-				disabled = false;
+			sourceName = message.getFlag(SYSTEM, Flags.ChatMessage.Item)?.name;
+			baseDamageInfo = {
+				total: damage.total,
+				type: damage.type,
+				modifierTotal: damage.modifierTotal,
 			};
-
-			const handleClick = async (event, getTargetsFunction) => {
-				if (!disabled) {
-					disabled = true;
-					const targets = await getTargetsFunction(event);
-					if (event.ctrlKey || event.metaKey) {
-						DamageCustomizer(
-							damage,
-							targets,
-							(extraDamageInfo) => handleDamageApplication(event, targets, extraDamageInfo),
-							() => {
-								disabled = false;
-							},
-						);
-					} else {
-						handleDamageApplication(event, targets, {});
-					}
-				}
-			};
-
-			jQuery.find(`a[data-action=applySingleDamage]`).click((event) => handleClick(event, getSingleTarget));
-			jQuery.find(`a[data-action=applySelectedDamage]`).click((event) => handleClick(event, getSelected));
-			jQuery.find(`a[data-action=applyTargetedDamage]`).click((event) => handleClick(event, getTargeted));
-			jQuery.find(`a[data-action=selectDamageCustomizer]`).click(async (event) => {
-				if (!disabled) {
-					disabled = true;
-					const targets = await getTargeted(event);
-					DamageCustomizer(
-						damage,
-						targets,
-						(extraDamageInfo) => handleDamageApplication(event, targets, extraDamageInfo),
-						() => {
-							disabled = false;
-						},
-					);
-				}
-			});
 		}
 	}
+
+	const handleClick = async (event, getTargetsFunction) => {
+		if (!disabled) {
+			disabled = true;
+			const targets = await getTargetsFunction(event);
+			if (event.ctrlKey || event.metaKey) {
+				DamageCustomizer(
+					baseDamageInfo,
+					targets,
+					(extraDamageInfo) => {
+						handleDamageApplication(event, targets, sourceName, baseDamageInfo, extraDamageInfo);
+						disabled = false;
+					},
+					() => {
+						disabled = false;
+					},
+				);
+			} else {
+				handleDamageApplication(event, targets, sourceName, baseDamageInfo, {});
+				disabled = false;
+			}
+		}
+	};
+
+	jQuery.find(`a[data-action=applySingleDamage]`).click((event) => handleClick(event, getSingleTarget));
+	jQuery.find(`a[data-action=applySelectedDamage]`).click((event) => handleClick(event, getSelected));
+	jQuery.find(`a[data-action=applyTargetedDamage]`).click((event) => handleClick(event, getTargeted));
+	jQuery.find(`a[data-action=selectDamageCustomizer]`).click(async (event) => {
+		if (!disabled) {
+			disabled = true;
+			const targets = await getTargeted(event);
+			DamageCustomizer(
+				baseDamageInfo,
+				targets,
+				(extraDamageInfo) => {
+					handleDamageApplication(event, targets, sourceName, baseDamageInfo, extraDamageInfo);
+					disabled = false;
+				},
+				() => {
+					disabled = false;
+				},
+			);
+		}
+	});
 }
 
 /**
- * @typedef ClickModifiers
- * @param {boolean} alt
- * @param {boolean} ctrl
- * @param {boolean} shift
+ * 
+ * @param {Event} event
+ * @param {FUActor[]} targets
+ * @param {string} sourceName
+ * @param {BaseDamageInfo} baseDamageInfo
+ * @param {ExtraDamageInfo} extraDamageInfo
+ * @returns {void}
  */
-/**
- * @typedef DamageModifier
- * @function
- * @param {number} baseDamage
- * @param {ClickModifiers} modifiers
- * @return {number}
- */
+async function handleDamageApplication(event, targets, sourceName, baseDamageInfo, extraDamageInfo) {
+	/** @type {ClickModifiers} */
+	let clickModifiers = {
+		alt: event.altKey,
+		ctrl: event.ctrlKey || event.metaKey,
+		shift: event.shiftKey
+	}
+
+	const hookData = {
+		event,
+		targets,
+		sourceName,
+		baseDamageInfo,
+		extraDamageInfo,
+		clickModifiers,
+	};
+
+	Hooks.callAll(FUHooks.DAMAGE_APPLY_BEFORE, hookData);
+
+	// Reassign in case the hookData's fields were replaced
+	targets = hookData.targets;
+	sourceName = hookData.sourceName;
+	baseDamageInfo = hookData.baseDamageInfo;
+	extraDamageInfo = hookData.extraDamageInfo;
+	clickModifiers = hookData.clickModifiers;
+
+	const modifiedTotal = extraDamageInfo.hrZero ? extraDamageInfo.damageBonus + baseDamageInfo.modifierTotal : baseDamageInfo.total + (extraDamageInfo.damageBonus || 0);
+	const modifiedType = extraDamageInfo.damageType || baseDamageInfo.type;
+	const modifiedTargets = extraDamageInfo.targets || targets;
+
+	if (!modifiedTargets) {
+		return;
+	}
+
+	await applyDamage(
+		modifiedTargets,
+		sourceName,
+		modifiedType,
+		modifiedTotal,
+		clickModifiers,
+		extraDamageInfo,
+	);
+	if (extraDamageInfo.extraDamage > 0) {
+		await applyExtraDamage(
+			modifiedTargets,
+			sourceName,
+			extraDamageInfo.extraDamageType,
+			extraDamageInfo.extraDamage,
+			clickModifiers,
+			extraDamageInfo,
+		);
+	}
+}
 
 /**
  * @type {Record<number, DamageModifier>}
@@ -202,120 +194,6 @@ const affinityKeys = {
 	[FU.affValue.absorption]: () => 'FU.ChatApplyDamageAbsorb',
 };
 
-/**
- *
- * @param {FUActor[]} targets
- * @param {DamageType} damageType
- * @param {number} total
- * @param {ClickModifiers} modifiers
- * @param {string} sourceName
- * @return {Promise<Awaited<unknown>[]>}
- */
-export async function applyDamage(targets, damageType, total, modifiers, sourceName, extraDamageInfo) {
-	if (!Array.isArray(targets)) {
-		console.error('Targets is not an array:', targets);
-		return;
-	}
-	const updates = [];
-	for (const actor of targets) {
-		let affinity = FU.affValue.none; // Default to no affinity
-		let affinityIcon = '';
-		let affinityString = '';
-		if (damageType in actor.system.affinities) {
-			affinity = actor.system.affinities[damageType].current;
-			affinityIcon = FU.affIcon[damageType];
-		}
-		affinityString = await renderTemplate('systems/projectfu/templates/chat/partials/inline-damage-icon.hbs', {
-			damageType: game.i18n.localize(FU.damageTypes[damageType]),
-			affinityIcon: affinityIcon,
-		});
-
-		// Check if affinity should be ignored
-		if (affinity === FU.affValue.vulnerability && extraDamageInfo.ignoreVulnerable) {
-			affinity = FU.affValue.none;
-		}
-		if (affinity === FU.affValue.resistance && extraDamageInfo.ignoreResistance) {
-			affinity = FU.affValue.none;
-		}
-		if (affinity === FU.affValue.immunity && extraDamageInfo.ignoreImmunities) {
-			affinity = FU.affValue.none;
-		}
-		if (affinity === FU.affValue.absorption && extraDamageInfo.ignoreAbsorption) {
-			affinity = FU.affValue.none;
-		}
-
-		const damageMod = affinityDamageModifier[affinity] ?? affinityDamageModifier[FU.affValue.none];
-		const damageTaken = -damageMod(total, modifiers);
-		updates.push(actor.modifyTokenAttribute('resources.hp', damageTaken, true));
-		updates.push(
-			ChatMessage.create({
-				speaker: ChatMessage.getSpeaker({ actor }),
-				flavor: game.i18n.localize(FU.affType[affinity]),
-				content: await renderTemplate('systems/projectfu/templates/chat/chat-apply-damage.hbs', {
-					message: affinityKeys[affinity](modifiers),
-					actor: actor.name,
-					damage: Math.abs(damageTaken),
-					type: affinityString,
-					from: sourceName,
-				}),
-			}),
-		);
-	}
-	return Promise.all(updates);
-}
-export async function applyExtraDamage(targets, damageType, total, modifiers, sourceName, extraDamageInfo) {
-	if (!Array.isArray(targets)) {
-		console.error('Targets is not an array:', targets);
-		return;
-	}
-	const updates = [];
-	for (const actor of targets) {
-		let affinity = FU.affValue.none; // Default to no affinity
-		let affinityIcon = '';
-		let affinityString = '';
-		if (damageType in actor.system.affinities) {
-			affinity = actor.system.affinities[damageType].current;
-			affinityIcon = FU.affIcon[damageType];
-		}
-		affinityString = await renderTemplate('systems/projectfu/templates/chat/partials/inline-damage-icon.hbs', {
-			damageType: game.i18n.localize(FU.damageTypes[damageType]),
-			affinityIcon: affinityIcon,
-		});
-
-		// Check if affinity should be ignored
-		if (affinity === FU.affValue.vulnerability && extraDamageInfo.ignoreVulnerable) {
-			affinity = FU.affValue.none;
-		}
-		if (affinity === FU.affValue.resistance && extraDamageInfo.ignoreResistance) {
-			affinity = FU.affValue.none;
-		}
-		if (affinity === FU.affValue.immunity && extraDamageInfo.ignoreImmunities) {
-			affinity = FU.affValue.none;
-		}
-		if (affinity === FU.affValue.absorption && extraDamageInfo.ignoreAbsorption) {
-			affinity = FU.affValue.none;
-		}
-
-		const damageMod = affinityDamageModifier[affinity] ?? affinityDamageModifier[FU.affValue.none];
-		const damageTaken = -damageMod(total, modifiers);
-		updates.push(actor.modifyTokenAttribute('resources.hp', damageTaken, true));
-		updates.push(
-			ChatMessage.create({
-				speaker: ChatMessage.getSpeaker({ actor }),
-				flavor: game.i18n.localize(FU.affType[affinity]),
-				content: await renderTemplate('systems/projectfu/templates/chat/chat-apply-extra-damage.hbs', {
-					message: affinityKeys[affinity](modifiers),
-					actor: actor.name,
-					damage: Math.abs(damageTaken),
-					type: affinityString,
-					from: sourceName,
-				}),
-			}),
-		);
-	}
-	return Promise.all(updates);
-}
-
 function getSingleTarget(e) {
 	// eslint-disable-next-line no-unused-vars, no-undef
 	const { type, id } = parseUuid($(e.target).closest('a').data('id'));
@@ -325,4 +203,137 @@ function getSingleTarget(e) {
 		return [];
 	}
 	return [actor];
+}
+
+/**
+ *
+ * @param {FUActor[]} targets
+ * @param {string} sourceName
+ * @param {DamageType} damageType
+ * @param {number} total
+ * @param {ClickModifiers} clickModifiers
+ * @param {ExtraDamageInfo} extraDamageInfo
+ * @param {string} chatTemplateName
+ * @return {Promise<Awaited<unknown>[]>}
+ */
+async function applyDamageInternal(targets, sourceName, damageType, total, clickModifiers, extraDamageInfo, chatTemplateName) {
+	if (!Array.isArray(targets)) {
+		console.error('Targets is not an array:', targets);
+		return;
+	}
+
+	const updates = [];
+	for (const actor of targets) {
+		const hookData = {
+			actor,
+			sourceName,
+			damageType,
+			total,
+			clickModifiers: {},
+			extraDamageInfo: {},
+			overrides: {
+				affinity: null,
+				total: null
+			}
+		};
+		// Copy to avoid overwriting for other calls
+		Object.assign(hookData.clickModifiers, clickModifiers);
+		Object.assign(hookData.extraDamageInfo, extraDamageInfo);
+		Hooks.callAll(FUHooks.DAMAGE_APPLY_TARGET, hookData);
+
+		let affinity = FU.affValue.none; // Default to no affinity
+		let affinityIcon = '';
+		let affinityString = '';
+		if (hookData.overrides?.affinity) {
+			affinity = hookData.overrides.affinity;
+			affinityIcon = FU.affIcon[hookData.damageType];
+		}
+		else if (hookData.damageType in actor.system.affinities) {
+			affinity = actor.system.affinities[hookData.damageType].current;
+			affinityIcon = FU.affIcon[hookData.damageType];
+		}
+		affinityString = await renderTemplate('systems/projectfu/templates/chat/partials/inline-damage-icon.hbs', {
+			damageType: game.i18n.localize(FU.damageTypes[hookData.damageType]),
+			affinityIcon: affinityIcon,
+		});
+
+		// Check if affinity should be ignored
+		if (affinity === FU.affValue.vulnerability && hookData.extraDamageInfo.ignoreVulnerable) {
+			affinity = FU.affValue.none;
+		}
+		if (affinity === FU.affValue.resistance && hookData.extraDamageInfo.ignoreResistance) {
+			affinity = FU.affValue.none;
+		}
+		if (affinity === FU.affValue.immunity && hookData.extraDamageInfo.ignoreImmunities) {
+			affinity = FU.affValue.none;
+		}
+		if (affinity === FU.affValue.absorption && hookData.extraDamageInfo.ignoreAbsorption) {
+			affinity = FU.affValue.none;
+		}
+
+		const damageMod = affinityDamageModifier[affinity] ?? affinityDamageModifier[FU.affValue.none];
+		const damageTaken = hookData.overrides?.total || -damageMod(hookData.total, hookData.clickModifiers);
+
+		updates.push(actor.modifyTokenAttribute('resources.hp', damageTaken, true));
+		updates.push(
+			ChatMessage.create({
+				speaker: ChatMessage.getSpeaker({ actor }),
+				flavor: game.i18n.localize(FU.affType[affinity]),
+				content: await renderTemplate(chatTemplateName, {
+					message: affinityKeys[affinity](hookData.clickModifiers),
+					actor: actor.name,
+					damage: Math.abs(damageTaken),
+					type: affinityString,
+					from: hookData.sourceName,
+				}),
+			}),
+		);
+	}
+	return Promise.all(updates);
+}
+
+/**
+ *
+ * @param {FUActor[]} targets
+ * @param {string} sourceName
+ * @param {DamageType} type
+ * @param {number} total
+ * @param {ClickModifiers} clickModifiers
+ * @param {ExtraDamageInfo} extraDamageInfo
+ * @return {Promise<Awaited<unknown>[]>}
+ */
+export async function applyDamage(targets, sourceName, type, total, clickModifiers, extraDamageInfo) {
+	return await applyDamageInternal(
+		targets,
+		sourceName,
+		type,
+		total,
+		clickModifiers,
+		extraDamageInfo,
+		'systems/projectfu/templates/chat/chat-apply-damage.hbs');
+}
+
+/**
+ *
+ * @param {FUActor[]} targets
+ * @param {string} sourceName
+ * @param {DamageType} type
+ * @param {number} total
+ * @param {ClickModifiers} clickModifiers
+ * @param {ExtraDamageInfo} extraDamageInfo
+ * @return {Promise<Awaited<unknown>[]>}
+ */
+export async function applyExtraDamage(targets, sourceName, type, total, clickModifiers, extraDamageInfo) {
+	return await applyDamageInternal(
+		targets,
+		sourceName,
+		type,
+		total,
+		clickModifiers,
+		extraDamageInfo,
+		'systems/projectfu/templates/chat/chat-apply-extra-damage.hbs');
+}
+
+export function registerChatInteraction() {
+	Hooks.on('renderChatMessage', attachDamageApplicationHandler);
 }

--- a/module/helpers/apply-damage.mjs
+++ b/module/helpers/apply-damage.mjs
@@ -129,9 +129,12 @@ async function handleDamageApplication(event, targets, sourceName, baseDamageInf
 		shift: event.shiftKey
 	}
 
+	const sourceItemId = findItemId(event);
+
 	const hookData = {
 		event,
 		targets,
+		sourceItemId,
 		sourceName,
 		baseDamageInfo,
 		extraDamageInfo,
@@ -157,6 +160,7 @@ async function handleDamageApplication(event, targets, sourceName, baseDamageInf
 
 	await applyDamage(
 		modifiedTargets,
+		sourceItemId,
 		sourceName,
 		modifiedType,
 		modifiedTotal,
@@ -166,6 +170,7 @@ async function handleDamageApplication(event, targets, sourceName, baseDamageInf
 	if (extraDamageInfo.extraDamage > 0) {
 		await applyExtraDamage(
 			modifiedTargets,
+			sourceItemId,
 			sourceName,
 			extraDamageInfo.extraDamageType,
 			extraDamageInfo.extraDamage,
@@ -206,8 +211,22 @@ function getSingleTarget(e) {
 }
 
 /**
+ * Determine's the source item's id from an event
+ * @param {Event} event
+ * @returns {string | null}
+ */
+function findItemId(event) {
+	const candidates = event.target?.closest('.chat-message')?.querySelectorAll('[data-item-id]');
+	if (candidates && candidates.length) {
+		return candidates[0].getAttribute('data-item-id');
+	}
+	return null;
+}
+
+/**
  *
  * @param {FUActor[]} targets
+ * @param {string} sourceItemId
  * @param {string} sourceName
  * @param {DamageType} damageType
  * @param {number} total
@@ -216,7 +235,7 @@ function getSingleTarget(e) {
  * @param {string} chatTemplateName
  * @return {Promise<Awaited<unknown>[]>}
  */
-async function applyDamageInternal(targets, sourceName, damageType, total, clickModifiers, extraDamageInfo, chatTemplateName) {
+async function applyDamageInternal(targets, sourceItemId, sourceName, damageType, total, clickModifiers, extraDamageInfo, chatTemplateName) {
 	if (!Array.isArray(targets)) {
 		console.error('Targets is not an array:', targets);
 		return;
@@ -226,6 +245,7 @@ async function applyDamageInternal(targets, sourceName, damageType, total, click
 	for (const actor of targets) {
 		const hookData = {
 			actor,
+			sourceItemId,
 			sourceName,
 			damageType,
 			total,
@@ -295,6 +315,7 @@ async function applyDamageInternal(targets, sourceName, damageType, total, click
 /**
  *
  * @param {FUActor[]} targets
+ * @param {string} sourceItemId
  * @param {string} sourceName
  * @param {DamageType} type
  * @param {number} total
@@ -302,9 +323,10 @@ async function applyDamageInternal(targets, sourceName, damageType, total, click
  * @param {ExtraDamageInfo} extraDamageInfo
  * @return {Promise<Awaited<unknown>[]>}
  */
-export async function applyDamage(targets, sourceName, type, total, clickModifiers, extraDamageInfo) {
+export async function applyDamage(targets, sourceItemId, sourceName, type, total, clickModifiers, extraDamageInfo) {
 	return await applyDamageInternal(
 		targets,
+		sourceItemId,
 		sourceName,
 		type,
 		total,
@@ -316,6 +338,7 @@ export async function applyDamage(targets, sourceName, type, total, clickModifie
 /**
  *
  * @param {FUActor[]} targets
+ * @param {string} sourceItemId
  * @param {string} sourceName
  * @param {DamageType} type
  * @param {number} total
@@ -323,9 +346,10 @@ export async function applyDamage(targets, sourceName, type, total, clickModifie
  * @param {ExtraDamageInfo} extraDamageInfo
  * @return {Promise<Awaited<unknown>[]>}
  */
-export async function applyExtraDamage(targets, sourceName, type, total, clickModifiers, extraDamageInfo) {
+export async function applyExtraDamage(targets, sourceItemId, sourceName, type, total, clickModifiers, extraDamageInfo) {
 	return await applyDamageInternal(
 		targets,
+		sourceItemId,
 		sourceName,
 		type,
 		total,

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -38,7 +38,7 @@ FU.currencies = {
 };
 
 /**
- * @typedef {"untyped", "physical","air","bolt","dark","earth","fire","ice","light","poison"} DamageType
+ * @typedef {"untyped" | "physical" | "air" | "bolt" | "dark" | "earth" | "fire" | "ice" | "light" | "poison"} DamageType
  */
 /**
  * @type {Object<DamageType, string>}

--- a/module/helpers/damage-customizer.mjs
+++ b/module/helpers/damage-customizer.mjs
@@ -1,12 +1,45 @@
+import { FUActor } from '../documents/actors/actor.mjs';
 import { FU } from './config.mjs';
 import { getTargeted } from './target-handler.mjs';
 
 /**
+ * @typedef BaseDamageInfo
+ * @type {import('./typedefs.mjs').BaseDamageInfo}
+ */
+
+/**
+ * @typedef DamageType
+ * @type {import('./config.mjs').DamageType}
+ */
+
+/**
+ * @typedef ExtraDamageInfo
+ * @prop {DamageType} damageType
+ * @prop {number} damageBonus
+ * @prop {number} extraDamage
+ * @prop {DamageType} extraDamageType
+ * @prop {boolean} hrZero
+ * @prop {boolean} ignoreVulnerable
+ * @prop {boolean} ignoreResistance
+ * @prop {boolean} ignoreImmunities
+ * @prop {boolean} ignoreAbsorption
+ * @prop {FUActor[]} targets
+ */
+
+/**
+ * @callback DamageCustomizerCallback
+ * @param {ExtraDamageInfo} extraDamageInfo
+ * @param {FUActor[]} targets
+ * @returns {void}
+ */
+
+/**
  * Displays a dialog to customize damage.
  *
- * @param {Object} damage - The damage object containing type and total.
- * @param {Function} callback - The function to call when the user confirms.
- * @param {Function} onCancel - The function to call when the user cancels.
+ * @param {BaseDamageInfo} damage - The damage object containing type and total.
+ * @param {FUActor[]} targets - The specified targets.
+ * @param {DamageCustomizerCallback} callback - The function to call when the user confirms.
+ * @param {() => void} onCancel - The function to call when the user cancels.
  */
 export function DamageCustomizer(damage, targets, callback, onCancel) {
 	// Map damage types to options with the current type selected
@@ -28,25 +61,25 @@ export function DamageCustomizer(damage, targets, callback, onCancel) {
 	// Create the content for the dialog
 	const content = `
         <form>
-			<div class="desc mb-3 gap-5">
-				<div class="flexrow form-group targets-container">${tokenInfo}</div>
-				<button type="button" id="retarget" class="btn">${game.i18n.localize('FU.ChatContextRetarget')}</button>
-			</div>
+            <div class="desc mb-3 gap-5">
+                <div class="flexrow form-group targets-container">${tokenInfo}</div>
+                <button type="button" id="retarget" class="btn">${game.i18n.localize('FU.ChatContextRetarget')}</button>
+            </div>
             <div class="desc mb-3 grid grid-2col gap-5">
                 <div class="inline-desc form-group" style="padding: 5px 10px;">
                     <label for="total-damage" class="resource-content resource-label" style="flex-grow: 8;"><b>${game.i18n.localize('FU.Total')}</b>
-						<span id="total-damage">
-							<b>${damage.total} ${game.i18n.localize(FU.damageTypes[damage.type])}</b>
-						</span>
-					</label>
+                        <span id="total-damage">
+                            <b>${damage.total} ${game.i18n.localize(FU.damageTypes[damage.type])}</b>
+                        </span>
+                    </label>
                     <i id="total-damage-icon" class="icon ${FU.affIcon[damage.type]}" style="flex: 0 1 auto;"></i>
                 </div>
                 <div class="inline-desc form-group" style="padding: 5px 10px;">
                     <label for="total-extra-damage" class="resource-content resource-label" style="flex-grow: 8;"><b>${game.i18n.localize('FU.DamageExtra')}</b>
-						<span id="extra-total-damage">
-							<b>0 ${game.i18n.localize(FU.damageTypes[damage.type])}</b>
-						</span>
-					</label>
+                        <span id="extra-total-damage">
+                            <b>0 ${game.i18n.localize(FU.damageTypes[damage.type])}</b>
+                        </span>
+                    </label>
                     <i id="extra-damage-icon" class="icon ${FU.affIcon[damage.type]}" style="flex: 0 1 auto;"></i>
                 </div>
             </div>
@@ -78,10 +111,10 @@ export function DamageCustomizer(damage, targets, callback, onCancel) {
             </div>
             <div class="desc grid grid-2col gap-5">
                 <div class="gap-2 grid-span-2">
-					<div class="form-group">
-                    	<button type="button" id="check-all" class="btn">${game.i18n.localize('FU.IgnoreAll')}</button>
-                    	<button type="button" id="check-none" class="btn">${game.i18n.localize('FU.IgnoreNone')}</button>
-					</div>
+                    <div class="form-group">
+                        <button type="button" id="check-all" class="btn">${game.i18n.localize('FU.IgnoreAll')}</button>
+                        <button type="button" id="check-none" class="btn">${game.i18n.localize('FU.IgnoreNone')}</button>
+                    </div>
                 </div>
                 <div class="gap-2">
                     <div class="form-group">

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -103,7 +103,7 @@ function activateListeners(document, html) {
 
 function onDropActor(actor, sheet, { type, damageType, amount, source, ignore }) {
 	if (type === INLINE_DAMAGE) {
-		applyDamage([actor], null, source || 'something', damageType, Number(amount), {}, {});
+		applyDamage([actor], null, source || 'inline damage', damageType, Number(amount), {}, {});
 		return false;
 	}
 }

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -79,7 +79,7 @@ function activateListeners(document, html) {
 			const source = determineSource(document, this);
 			let targets = await targetHandler();
 			if (targets.length > 0) {
-				applyDamage(targets, type, amount, {}, source || 'inline damage');
+				applyDamage(targets, null, source || 'inline damage', type, amount, {}, {});
 			}
 		})
 		.on('dragstart', function (event) {
@@ -103,7 +103,7 @@ function activateListeners(document, html) {
 
 function onDropActor(actor, sheet, { type, damageType, amount, source, ignore }) {
 	if (type === INLINE_DAMAGE) {
-		applyDamage([actor], damageType, Number(amount), {}, source || 'something');
+		applyDamage([actor], null, source || 'something', damageType, Number(amount), {}, {});
 		return false;
 	}
 }

--- a/module/helpers/study-roll.mjs
+++ b/module/helpers/study-roll.mjs
@@ -1,4 +1,5 @@
 import { FU } from './config.mjs';
+import { FUHooks } from '../hooks.mjs';
 
 /**
  * Handle the study roll interaction with targeted actors
@@ -443,5 +444,5 @@ async function handleStudyRollCallback(app, actor, studyValue) {
 		content: msg,
 	});
 
-	Hooks.callAll('studyRoll', actor, journalEntry);
+	Hooks.callAll(FUHooks.ROLL_STUDY, actor, journalEntry);
 }

--- a/module/helpers/typedefs.mjs
+++ b/module/helpers/typedefs.mjs
@@ -1,0 +1,10 @@
+// Place common/shared defs here to avoid circular
+
+/**
+ * @typedef BaseDamageInfo
+ * @prop {number} total
+ * @prop {import("./config.mjs").DamageType} type
+ * @prop {number} modifierTotal
+ */
+
+export {}

--- a/module/hooks.mjs
+++ b/module/hooks.mjs
@@ -1,0 +1,10 @@
+export const FUHooks = {
+	// Damage
+	DAMAGE_APPLY_BEFORE: 'projectfu.damage.beforeApply',
+	DAMAGE_APPLY_TARGET: 'projectfu.damage.applyTarget',
+
+	DATA_PREPARED_ACTOR: 'projectfu.actor.dataPrepared',
+	DATA_PREPARED_ITEM: 'projectfu.item.dataPrepared',
+
+	ROLL_STUDY: 'studyRoll',
+};

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -61,6 +61,7 @@ import { ChecksV2 } from './checks/checks-v2.mjs';
 import { CheckConfiguration } from './checks/check-configuration.mjs';
 import { slugify } from './util.mjs';
 import { ActionHandler } from './helpers/action-handler.mjs';
+import { FUHooks } from './hooks.mjs';
 
 globalThis.projectfu = {
 	ClassFeatureDataModel,
@@ -496,7 +497,7 @@ Hooks.once('ready', async function () {
 		return true; // Allow the effect to be created
 	});
 
-	Hooks.on('projectfu.actor.dataPrepared', (actor) => {
+	Hooks.on(FUHooks.DATA_PREPARED_ACTOR, (actor) => {
 		if (!actor.system || !actor.system.immunities) return;
 
 		// Iterate over the actor's active effects


### PR DESCRIPTION
Adds two hooks to the damage pipeline.
'projectfu.damage.beforeApply' => altering overall values just before any meaningful calculations start
'projectfu.damage.applyTarget' => altering data per-target just before application
The hooks can modify the provided data structure and the changes will be picked up and propagated to the logic.

Refactors out duplicate code

Repairs and adds some JSDoc typedefs

Centralizes some hook constants for ease of lookup, enumeration, and hopefully documentation