### PR TITLE
Fix text editor check command

### DIFF
--- a/module/helpers/text-editor-command-dropdown.mjs
+++ b/module/helpers/text-editor-command-dropdown.mjs
@@ -111,7 +111,7 @@ async function promptCheckDialog(state, dispatch, view) {
 	});
 	if (result) {
 		const { first, second, level } = result;
-		dispatch(state.tr.insertText(` @CHECK[${first} ${second}] ${level}`));
+		dispatch(state.tr.insertText(` @CHECK[${first} ${second} ${level}]`));
 	}
 }
 


### PR DESCRIPTION
The text editor `@CHECK` command was not adding the bracket at the end, as it should have.

![image](https://github.com/user-attachments/assets/56349297-5db4-496f-8f39-3180e5c60b7d)
