### PR TITLE
Fix inline source usage for events

### DIFF
--- a/module/expressions/expressions.mjs
+++ b/module/expressions/expressions.mjs
@@ -13,6 +13,25 @@ export class ExpressionContext {
 		this.item = item;
 		this.targets = targets;
 	}
+
+	/**
+	 * @param {String} actorUuid
+	 * @param {String} itemUuid
+	 * @param {FUActor[]} targets
+	 * @returns {ExpressionContext}
+	 */
+	static fromUuid(actorUuid, itemUuid, targets) {
+		let actor = undefined;
+		if (actorUuid !== undefined) {
+			actor = fromUuidSync(actorUuid);
+		}
+
+		let item = undefined;
+		if (itemUuid !== undefined) {
+			item = fromUuidSync(itemUuid);
+		}
+		return new ExpressionContext(actor, item, targets);
+	}
 }
 
 // DSL supported by the inline amount expression
@@ -169,6 +188,7 @@ function evaluateMacros(expression, context) {
 			case `sl`: {
 				assertActorInContext(context, match);
 				const skillId = splitArgs[0].match(/(\w+-*\s*)+/gm)[0];
+				console.debug(`Resolved actor ${context.actor} from chat message`);
 				const skill = context.actor.getSingleItemByFuid(skillId, 'skill');
 				if (!skill) {
 					ui.notifications.warn('FU.ChatEvaluateNoSkill', { localize: true });

--- a/module/expressions/expressions.mjs
+++ b/module/expressions/expressions.mjs
@@ -172,7 +172,7 @@ function evaluateVariables(expression, context) {
 			// Item level / skill level
 			case 'il':
 			case 'sl':
-				context.assertActor(match);
+				context.assertItem(match);
 				return context.item.system.level.value;
 			default:
 				throw new Error(`Unsupported symbol ${symbol}`);

--- a/module/expressions/expressions.mjs
+++ b/module/expressions/expressions.mjs
@@ -6,6 +6,8 @@ import { MathHelper } from '../helpers/math-helper.mjs';
  * @property {FUActor} actor
  * @property {FUItem} item
  * @property {FUActor[]} targets
+ * @remarks Do not serialize this class, as it references full objects. Instead store their uuids
+ * and resolve them with the static constructor
  */
 export class ExpressionContext {
 	constructor(actor, item, targets) {
@@ -31,6 +33,26 @@ export class ExpressionContext {
 			item = fromUuidSync(itemUuid);
 		}
 		return new ExpressionContext(actor, item, targets);
+	}
+
+	/**
+	 * @param {String} match
+	 */
+	assertActor(match) {
+		if (this.actor == null) {
+			ui.notifications.warn('FU.ChatEvaluateAmountNoActor', { localize: true });
+			throw new Error(`No reference to an actor provided while evaluating expression "${match}"`);
+		}
+	}
+
+	/**
+	 * @param {String} match
+	 */
+	assertItem(match) {
+		if (this.item == null) {
+			ui.notifications.warn('FU.ChatEvaluateAmountNoItem', { localize: true });
+			throw new Error(`No reference to an item provided while evaluating expression "${match}"`);
+		}
 	}
 }
 
@@ -82,20 +104,6 @@ function evaluate(expression, context) {
 	return result;
 }
 
-function assertActorInContext(context, match) {
-	if (context.actor == null) {
-		ui.notifications.warn('FU.ChatEvaluateAmountNoActor', { localize: true });
-		throw new Error(`No reference to an actor provided while evaluating "${match}"`);
-	}
-}
-
-function assertItemInContext(context, match) {
-	if (context.item == null) {
-		ui.notifications.warn('FU.ChatEvaluateAmountNoItem', { localize: true });
-		throw new Error(`No reference to an item provided while evaluating expression "${match}"`);
-	}
-}
-
 /**
  * @description Evaluates functions within the expression using the available context
  * @param {String}  expression
@@ -107,7 +115,7 @@ function evaluateReferencedFunctions(expression, context) {
 
 	function evaluate(match, label, path, p3, args, groups) {
 		if (match.includes(actorLabel)) {
-			assertActorInContext(context, match);
+			context.assertActor(match);
 			let splitArgs = args.split(',');
 
 			const functionPath = `system.${path}`;
@@ -159,12 +167,12 @@ function evaluateVariables(expression, context) {
 				return ImprovisedEffect.calculateAmountFromContext(symbol, context);
 			// Character level
 			case 'cl':
-				assertActorInContext(context, match);
+				context.assertActor(match);
 				return context.actor.system.level.value;
 			// Item level / skill level
 			case 'il':
 			case 'sl':
-				assertItemInContext(context, match);
+				context.assertActor(match);
 				return context.item.system.level.value;
 			default:
 				throw new Error(`Unsupported symbol ${symbol}`);
@@ -186,7 +194,7 @@ function evaluateMacros(expression, context) {
 		const splitArgs = params.split(',');
 		switch (name) {
 			case `sl`: {
-				assertActorInContext(context, match);
+				context.assertActor(match);
 				const skillId = splitArgs[0].match(/(\w+-*\s*)+/gm)[0];
 				console.debug(`Resolved actor ${context.actor} from chat message`);
 				const skill = context.actor.getSingleItemByFuid(skillId, 'skill');
@@ -239,11 +247,11 @@ function evaluateReferencedProperties(expression, context) {
 		let propertyPath = '';
 
 		if (match.includes(itemLabel)) {
-			assertItemInContext(context, match);
+			context.assertItem(match);
 			root = context.item;
 			propertyPath = match.replace(`${referenceSymbol}${itemLabel}.`, 'system.');
 		} else if (match.includes(actorLabel)) {
-			assertActorInContext(context, match);
+			context.assertActor(match);
 			root = context.actor;
 			propertyPath = match.replace(`${referenceSymbol}${actorLabel}.`, 'system.');
 		}

--- a/module/helpers/improvised-effect.mjs
+++ b/module/helpers/improvised-effect.mjs
@@ -62,7 +62,7 @@ function calculateAmountFromContext(effect, context) {
 	}
 
 	let level = 5;
-	if (context.actor !== undefined) {
+	if (context.actor) {
 		level = context.actor.system.level.value;
 		console.debug(`Used the source actor to calculate level`);
 	} else {

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -61,11 +61,11 @@ function activateListeners(document, html) {
 			if (targets.length > 0) {
 				const sourceInfo = InlineHelper.determineSource(document, this);
 				const type = this.dataset.type;
-				const context = new ExpressionContext(sourceInfo.actor, sourceInfo.item, targets);
+				const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, targets);
 				const amount = Expressions.evaluate(this.dataset.amount, context);
 
 				const baseDamageInfo = { type, total: amount, modifierTotal: 0 };
-				await applyDamagePipelineWithHook({ event: null, targets, sourceUuid: sourceInfo.uuid, sourceName: sourceInfo.name || 'inline damage', baseDamageInfo, extraDamageInfo: {}, clickModifiers: null });
+				await applyDamagePipelineWithHook({ event: null, targets, sourceUuid: sourceInfo.actorUuid, sourceName: sourceInfo.name || 'inline damage', baseDamageInfo, extraDamageInfo: {}, clickModifiers: null });
 			}
 		})
 		.on('dragstart', function (event) {
@@ -78,7 +78,7 @@ function activateListeners(document, html) {
 			const sourceInfo = InlineHelper.determineSource(document, this);
 			const data = {
 				type: INLINE_DAMAGE,
-				source: sourceInfo,
+				sourceInfo: sourceInfo,
 				damageType: this.dataset.type,
 				amount: this.dataset.amount,
 			};
@@ -88,12 +88,12 @@ function activateListeners(document, html) {
 }
 
 // TODO: Implement
-function onDropActor(actor, sheet, { type, damageType, amount, source, ignore }) {
+function onDropActor(actor, sheet, { type, damageType, amount, sourceInfo, ignore }) {
 	if (type === INLINE_DAMAGE) {
-		const context = new ExpressionContext(source.actor, source.item, [actor]);
+		const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, [actor]);
 		const _amount = Expressions.evaluate(amount, context);
 		const baseDamageInfo = { type: damageType, total: _amount, modifierTotal: 0 };
-		applyDamagePipelineWithHook({ event: null, targets: [actor], sourceUuid: source.uuid, sourceName: source.name || 'inline damage', baseDamageInfo, extraDamageInfo: {}, clickModifiers: null });
+		applyDamagePipelineWithHook({ event: null, targets: [actor], sourceUuid: sourceInfo.actorUuid, sourceName: sourceInfo.name || 'inline damage', baseDamageInfo, extraDamageInfo: {}, clickModifiers: null });
 		return false;
 	}
 }

--- a/module/helpers/inline-resources.mjs
+++ b/module/helpers/inline-resources.mjs
@@ -120,7 +120,7 @@ function activateListeners(document, html) {
 				const sourceInfo = InlineHelper.determineSource(document, this);
 				const type = this.dataset.type;
 				const uncapped = this.dataset.uncapped === 'true';
-				const context = new ExpressionContext(sourceInfo.actor, sourceInfo.item, targets);
+				const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, targets);
 				const amount = Expressions.evaluate(this.dataset.amount, context);
 
 				if (this.classList.contains(classInlineRecovery)) {
@@ -136,8 +136,8 @@ function activateListeners(document, html) {
 			if (!(this instanceof HTMLElement) || !event.dataTransfer) {
 				return;
 			}
-			const sourceInfo = InlineHelper.determineSource(document, this);
 
+			const sourceInfo = InlineHelper.determineSource(document, this);
 			const data = {
 				type: this.classList.contains(classInlineRecovery) ? INLINE_RECOVERY : INLINE_LOSS,
 				sourceInfo: sourceInfo,
@@ -151,7 +151,7 @@ function activateListeners(document, html) {
 }
 
 function onDropActor(actor, sheet, { type, recoveryType, amount, sourceInfo, uncapped }) {
-	const context = new ExpressionContext(sourceInfo.actor, sourceInfo.item, [actor]);
+	const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, [actor]);
 	amount = Expressions.evaluate(amount, context);
 
 	if (type === INLINE_RECOVERY && !Number.isNaN(amount)) {


### PR DESCRIPTION
Fixes the issue where the actor's methods could not be resolved for drag events.

It came to be due to non-primitives being passed in the `.dragstart` event, which get serialized then deserialized without type information. 

I had to refactor the events and the API involved so that we only pass in the uuids for the item/actor instead then resolve it at the very end.