### PR TITLE
Add combat event hooks

### DIFF
--- a/module/checks/accuracy-check.mjs
+++ b/module/checks/accuracy-check.mjs
@@ -3,6 +3,7 @@ import { CHECK_ROLL } from './default-section-order.mjs';
 import { SYSTEM } from '../helpers/config.mjs';
 import { Flags } from '../helpers/flags.mjs';
 import { CommonSections } from './common-sections.mjs';
+import { CommonEvents } from './common-events.mjs';
 import { CheckConfiguration } from './check-configuration.mjs';
 
 function handleGenericBonus(actor, modifiers) {
@@ -38,6 +39,11 @@ const onProcessCheck = (check, actor, item) => {
 	if (type === 'accuracy') {
 		const configurer = CheckConfiguration.configure(check);
 		configurer.modifyTargetedDefense((value) => value ?? 'def');
+		if (critical) {
+			configurer.addTraits('critical');
+		} else if (fumble) {
+			configurer.addTraits('fumble');
+		}
 		configurer.modifyTargets((targets) => {
 			if (targets?.length) {
 				const targetedDefense = CheckConfiguration.inspect(check).getTargetedDefense();
@@ -80,7 +86,6 @@ const onProcessCheck = (check, actor, item) => {
 function onRenderCheck(data, checkResult, actor, item, flags) {
 	if (checkResult.type === 'accuracy') {
 		const inspector = CheckConfiguration.inspect(checkResult);
-
 		const accuracyData = inspector.getAccuracyData();
 		const damageData = inspector.getDamageData();
 
@@ -97,6 +102,7 @@ function onRenderCheck(data, checkResult, actor, item, flags) {
 		/** @type TargetData[] */
 		const targets = inspector.getTargets();
 		CommonSections.damage(data, actor, item, targets, flags, accuracyData, damageData);
+		CommonEvents.attack(inspector, actor, item);
 
 		(flags[SYSTEM] ??= {})[Flags.ChatMessage.Item] ??= item.toObject();
 	}

--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -8,6 +8,7 @@ const TARGETS = 'targets';
 const TARGETED_DEFENSE = 'targetedDefense';
 const DIFFICULTY = 'difficulty';
 const DAMAGE = 'damage';
+const TRAITS = 'traits';
 
 /**
  *
@@ -68,6 +69,9 @@ const configure = (check) => {
 };
 
 class CheckConfigurer {
+	/**
+	 * @type {CheckV2, CheckResultV2}
+	 */
 	#check;
 
 	constructor(check) {
@@ -104,12 +108,40 @@ class CheckConfigurer {
 	}
 
 	/**
+	 * @param {String[]|String} traits
+	 * @returns {CheckConfigurer}
+	 */
+	addTraits(...traits) {
+		if (!this.#check.additionalData[TRAITS]) {
+			this.#check.additionalData[TRAITS] = [];
+		}
+		traits.forEach((t) => this.#check.additionalData[TRAITS].push(t.toLowerCase()));
+		return this;
+	}
+
+	/**
 	 * @param {FUItem} item
 	 * @param {FUActor} actor
 	 * @return {CheckConfigurer}
 	 */
 	addItemAccuracyBonuses(item, actor) {
 		return this.addModelAccuracyBonuses(item.system, actor);
+	}
+
+	/**
+	 * @description Add the common traits of a weapon
+	 * @param {WeaponDataModel} system
+	 */
+	addWeaponTraits(system) {
+		return this.addTraits(system.category.value, system.type.value, system.hands.value);
+	}
+
+	/**
+	 * @description Add the common traits of an NPC attack
+	 * @param {BasicItemDataModel} system
+	 */
+	addAttackTraits(system) {
+		return this.addTraits(system.type.value, system.damageType.value);
 	}
 
 	/**
@@ -367,8 +399,12 @@ const inspect = (check) => {
 
 /**
  * @description Given a {@link CheckResultV2} object, provides additional information from it
+ * @remarks Provides read-only access, to be used after {@linkcode CheckConfigurer}
  */
 class CheckInspector {
+	/**
+	 * @type CheckResultV2
+	 */
 	#check;
 
 	constructor(check) {
@@ -411,6 +447,13 @@ class CheckInspector {
 	}
 
 	/**
+	 * @return {String[]|null}
+	 */
+	getTraits() {
+		return this.#check.additionalData[TRAITS] ?? null;
+	}
+
+	/**
 	 * @return {TargetData[]|null}
 	 */
 	getTargets() {
@@ -422,6 +465,20 @@ class CheckInspector {
 	 */
 	getTargetsOrDefault() {
 		return this.getTargets() || [];
+	}
+
+	/**
+	 * @returns {Boolean}
+	 */
+	isCritical() {
+		return this.getCheck().critical;
+	}
+
+	/**
+	 * @returns {Boolean}
+	 */
+	isFumble() {
+		return this.getCheck().fumble;
 	}
 
 	/**
@@ -475,6 +532,7 @@ class CheckInspector {
 					total: damage.total,
 					type: damage.type,
 					extra: damage.extra,
+					traits: this.getTraits(),
 				},
 				translation: {
 					damageTypes: FU.damageTypes,

--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -447,14 +447,14 @@ class CheckInspector {
 	}
 
 	/**
-	 * @return {String[]|null}
+	 * @return {String[]}
 	 */
 	getTraits() {
 		return this.#check.additionalData[TRAITS] ?? null;
 	}
 
 	/**
-	 * @return {TargetData[]|null}
+	 * @return {TargetData[]}
 	 */
 	getTargets() {
 		return this.#check.additionalData[TARGETS] ? foundry.utils.duplicate(this.#check.additionalData[TARGETS]) : null;

--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -450,7 +450,7 @@ class CheckInspector {
 	 * @return {String[]}
 	 */
 	getTraits() {
-		return this.#check.additionalData[TRAITS] ?? null;
+		return this.#check.additionalData[TRAITS] ?? [];
 	}
 
 	/**

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -1,0 +1,263 @@
+import { FUHooks } from '../hooks.mjs';
+import { Targeting } from '../helpers/targeting.mjs';
+
+/**
+ * @description Contains both information about a target in a combat event
+ * @typedef EventTarget
+ * @property {Token} token
+ * @property {FUActor} actor
+ * @property {TargetData|null} data
+ */
+
+/**
+ * @typedef ItemReference
+ * @property {String} name
+ * @property {String} fuid
+ */
+
+/**
+ * @param {FUItem} item
+ * @returns {ItemReference}
+ */
+function toItemReference(item) {
+	return {
+		name: item.name,
+		fuid: item.system.fuid,
+	};
+}
+
+/**
+ * @description Dispatched when an actor makes an attack (skill/spell)
+ * @typedef AttackEvent
+ * @property {ItemReference} item
+ * @property {FU.damageTypes} type
+ * @property {Set<String>} traits
+ * @property {FUActor} actor
+ * @property {Token} token
+ * @property {EventTarget[]} targets
+ */
+
+/**
+ * @description Dispatches an event to signal an attack event
+ * @param {CheckInspector} inspector
+ * @param {FUActor} actor
+ * @param {FUItem} item
+ */
+function attack(inspector, actor, item) {
+	const traits = inspector.getTraits();
+	const targets = inspector.getTargets();
+	const eventTargets = getEventTargets(targets);
+
+	/** @type AttackEvent  **/
+	const event = {
+		item: toItemReference(item),
+		actor: actor,
+		type: inspector.getDamage()?.type,
+		token: actor.resolveToken(),
+		targets: eventTargets,
+		traits: new Set(traits),
+	};
+	Hooks.call(FUHooks.ATTACK_EVENT, event);
+}
+
+/**
+ * @description Dispatched when an actor suffers damage
+ * @typedef DamageEvent
+ * @property {FU.damageTypes} type
+ * @property {Number} amount
+ * @property {FUActor} actor
+ * @property {Token} token
+ * @property {EventTarget} source
+ * @property {Set<String>} traits
+ */
+
+/**
+ * @description Dispatches an event to signal damage taken by an actor
+ * @param {FU.damageTypes} type
+ * @param {Number} amount
+ * @param {Set<String>} traits
+ * @param {FUActor} actor
+ * @param {FUActor} sourceActor
+ */
+function damage(type, amount, traits, actor, sourceActor) {
+	const source = getEventTargetFromActor(sourceActor);
+	/** @type DamageEvent  **/
+	const damageEvent = {
+		amount: amount,
+		type: type,
+		actor: actor,
+		token: actor.resolveToken(),
+		source: source,
+		traits: traits,
+	};
+	Hooks.call(FUHooks.DAMAGE_EVENT, damageEvent);
+}
+
+/**
+ * @description Dispatched when an actor enters crisis
+ * @typedef CrisisEvent
+ * @property {FUActor} actor
+ */
+
+/**
+ * @description Dispatched when an actor is reduced to 0 HP
+ * @typedef DefeatEvent
+ * @property {FUActor} actor
+ */
+
+/**
+ * @description Dispatched when an actor has a status toggled.
+ * @typedef StatusEvent
+ * @property {FUActor} actor
+ * @property {Token} token
+ * @property {String} status The id of the status effect
+ * @property {String} enabled Whether the effect is enabled
+ */
+
+/**
+ * @description Dispatches an event to signal an effect has been applied onto an actor
+ * @param {FUActor} actor
+ * @param {String} statusEffectId
+ * @param {Boolean} enabled
+ */
+function status(actor, statusEffectId, enabled) {
+	Hooks.call(
+		FUHooks.STATUS_EVENT,
+		/** @type StatusEvent **/
+		{
+			actor: actor,
+			token: actor.resolveToken(),
+			status: statusEffectId,
+			enabled: enabled,
+		},
+	);
+}
+
+/**
+ * @description Dispatched when an actor recovers resources (such as HP, MP)
+ * @typedef GainEvent
+ * @property {FU.resources} resource
+ * @property {Number} amount
+ * @property {FUActor} actor
+ * @property {Token} token
+ */
+
+/**
+ *
+ * @param {FUActor} actor
+ * @param {String} resource
+ * @param {Number} amount
+ */
+function gain(actor, resource, amount) {
+	/** @type GainEvent  **/
+	const gainEvent = {
+		amount: amount,
+		resource: resource,
+		actor: actor,
+		token: actor.resolveToken(),
+	};
+	Hooks.call(FUHooks.GAIN_EVENT, gainEvent);
+}
+
+/**
+ * @description Dispatched when an actor gains resources (such as HP, MP)
+ * @typedef LossEvent
+ * @property {FU.resources} resource
+ * @property {Number} amount
+ * @property {FUActor} actor
+ * @property {Token} token
+ */
+
+/**
+ * @description Dispatched when an actor loses resources (such as HP, MP)
+ * @param {FUActor} actor
+ * @param {String} resource
+ * @param {Number} amount
+ */
+function loss(actor, resource, amount) {
+	/** @type LossEvent  **/
+	const lossEvent = {
+		amount: amount,
+		resource: resource,
+		actor: actor,
+		token: actor.resolveToken(),
+	};
+	Hooks.call(FUHooks.LOSS_EVENT, lossEvent);
+}
+
+/**
+ * @description Dispatched when an actor performs a spell without a magic check.
+ * @typedef SpellEvent
+ * @property {ItemReference} item
+ * @property {Set<String>} traits
+ * @property {FUActor} actor
+ * @property {Token} token
+ * @property {EventTarget[]} targets
+ */
+
+/**
+ * @description Dispatches an event to signal a spell event
+ * @param {FUActor} actor
+ * @param {FUItem} item
+ */
+function spell(actor, item) {
+	/** @type SpellDataModel **/
+	const spell = item.system;
+	const traits = new Set();
+	traits.add('spell');
+	traits.add(spell.cost.resource);
+
+	const targets = Targeting.getSerializedTargetData();
+	const eventTargets = getEventTargets(targets);
+
+	/** @type SpellEvent  **/
+	const event = {
+		item: toItemReference(item),
+		actor: actor,
+		token: actor.resolveToken(),
+		targets: eventTargets,
+		traits: traits,
+	};
+	Hooks.call(FUHooks.SPELL_EVENT, event);
+}
+
+/**
+ * @param {TargetData[]} targets
+ * @returns {EventTarget[]}
+ */
+function getEventTargets(targets) {
+	return targets.map((t) => {
+		const actor = fromUuidSync(t.uuid);
+		const token = actor.resolveToken();
+		/** @type EventTarget  **/
+		return {
+			actor: actor,
+			token: token,
+			data: t,
+		};
+	});
+}
+
+/** *
+ * @param {FUActor} actor
+ * @returns {EventTarget}
+ */
+function getEventTargetFromActor(actor) {
+	if (!actor) {
+		return null;
+	}
+	const token = actor.resolveToken();
+	return {
+		actor: actor,
+		token: token,
+	};
+}
+
+export const CommonEvents = Object.freeze({
+	attack,
+	damage,
+	status,
+	gain,
+	loss,
+	spell,
+});

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -2,7 +2,7 @@ import { FUHooks } from '../hooks.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
 
 /**
- * @description Contains both information about a target in a combat event
+ * @description Contains information about a target in a combat event
  * @typedef EventTarget
  * @property {Token} token
  * @property {FUActor} actor
@@ -67,8 +67,8 @@ function attack(inspector, actor, item) {
  * @property {Number} amount
  * @property {FUActor} actor
  * @property {Token} token
- * @property {EventTarget} source
  * @property {Set<String>} traits
+ * @property {EventTarget|null} source
  */
 
 /**
@@ -97,12 +97,14 @@ function damage(type, amount, traits, actor, sourceActor) {
  * @description Dispatched when an actor enters crisis
  * @typedef CrisisEvent
  * @property {FUActor} actor
+ * @property {Token} token
  */
 
 /**
  * @description Dispatched when an actor is reduced to 0 HP
  * @typedef DefeatEvent
  * @property {FUActor} actor
+ * @property {Token} token
  */
 
 /**

--- a/module/checks/magic-check.mjs
+++ b/module/checks/magic-check.mjs
@@ -4,6 +4,7 @@ import { SYSTEM } from '../helpers/config.mjs';
 import { CheckConfiguration } from './check-configuration.mjs';
 import { Flags } from '../helpers/flags.mjs';
 import { CommonSections } from './common-sections.mjs';
+import { CommonEvents } from './common-events.mjs';
 
 /**
  * @param {CheckV2} check
@@ -100,6 +101,7 @@ function renderCombatMagicCheck(checkResult, inspector, data, actor, item, flags
 
 	const targets = inspector.getTargets();
 	CommonSections.damage(data, actor, item, targets, flags, accuracyData, damageData);
+	CommonEvents.attack(inspector, actor, item);
 }
 
 /**

--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -13,6 +13,19 @@ import { Flags } from '../../helpers/flags.mjs';
  * @property {Boolean} inCombat
  * @property {String} id The canonical identifier for this Document.
  * @property {String} uuid A Universally Unique Identifier (uuid) for this Document instance.
+ * @property {Function<Boolean, Boolean,[Token]>} getActiveTokens Retrieve an Array of active tokens which represent this Actor in the current
+ * canvas Scene. If the canvas is not currently active, or there are no linked actors, the returned Array will be empty.
+ * If the Actor is a synthetic token actor, only the exact Token which it represents will be returned.
+ */
+
+/**
+ * @typedef Token
+ * @description A Token is an implementation of PlaceableObject which represents an Actor within a viewed Scene on the game canvas.
+ * @property {String} name Convenience access to the token's nameplate string
+ * @property {Actor} actor A convenient reference to the Actor object associated with the Token embedded document.
+ * @property {Combatant} combatant Return a reference to a Combatant that represents this Token, if one is present in the current encounter.
+ * @property {Boolean} isTargeted An indicator for whether the Token is currently targeted by the active game User
+ * @property {Point} center The Token's current central position
  */
 
 /**
@@ -170,6 +183,11 @@ export class FUActor extends Actor {
 		await super._preUpdate(changed, options, user);
 	}
 
+	/**
+	 * @returns {Promise<void>}
+	 * @private
+	 * @override
+	 */
 	async _onUpdate(changed, options, userId) {
 		const { hp } = this.system?.resources || {};
 
@@ -178,6 +196,14 @@ export class FUActor extends Actor {
 			const shouldBeInCrisis = hp.value <= crisisThreshold;
 			const isInCrisis = this.statuses.has('crisis');
 			if (shouldBeInCrisis !== isInCrisis) {
+				Hooks.call(
+					FUHooks.CRISIS_EVENT,
+					/** @type CrisisEvent **/
+					{
+						actor: this,
+						token: this.resolveToken(),
+					},
+				);
 				await toggleStatusEffect(this, 'crisis');
 			}
 
@@ -185,6 +211,14 @@ export class FUActor extends Actor {
 			const shouldBeKO = hp.value === 0; // KO when HP is 0
 			const isKO = this.statuses.has('ko');
 			if (shouldBeKO !== isKO) {
+				Hooks.call(
+					FUHooks.DEFEAT_EVENT,
+					/** @type DefeatEvent **/
+					{
+						actor: this,
+						token: this.resolveToken(),
+					},
+				);
 				await toggleStatusEffect(this, 'ko');
 			}
 		}
@@ -350,6 +384,23 @@ export class FUActor extends Actor {
 			ui.notifications.info(game.i18n.format('FU.UseMetaCurrencyNotificationInsufficientPoints', { actor: this.name, type: metaCurrency }));
 			return false;
 		}
+	}
+
+	/**
+	 * @returns {Token}
+	 * @remarks https://foundryvtt.com/api/classes/client.TokenDocument.html
+	 */
+	resolveToken() {
+		// For unlinked actors (usually NPCs)
+		if (this.token) {
+			return this.token.object;
+		}
+		// For linked actors (PCs, sometimes villains?)
+		const tokens = this.getActiveTokens();
+		if (tokens) {
+			return tokens[0];
+		}
+		throw Error(`Failed to get token for ${this.uuid}`);
 	}
 
 	/**

--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -1,6 +1,6 @@
 import { FUItem } from '../items/item.mjs';
 import { FUHooks } from '../../hooks.mjs';
-import { toggleStatusEffect } from '../../pipelines/effects.mjs';
+import { Effects, toggleStatusEffect } from '../../pipelines/effects.mjs';
 import { SYSTEM } from '../../helpers/config.mjs';
 import { Flags } from '../../helpers/flags.mjs';
 
@@ -420,7 +420,7 @@ export class FUActor extends Actor {
 	}
 
 	/**
-	 * @description Deletes all temporary effets on the actor
+	 * @description Deletes all temporary effects on the actor
 	 */
 	clearTemporaryEffects() {
 		// Collect effects to delete
@@ -433,7 +433,7 @@ export class FUActor extends Actor {
 					return immunity;
 				}
 			}
-			return effect.isTemporary;
+			return effect.isTemporary && Effects.canBeRemoved(effect);
 		});
 
 		// Delete all collected effects

--- a/module/documents/items/basic/basic-item-data-model.mjs
+++ b/module/documents/items/basic/basic-item-data-model.mjs
@@ -23,6 +23,7 @@ const prepareCheck = (check, actor, item, registerCallback) => {
 		AccuracyCheck.configure(check)
 			.setDamage(item.system.damageType.value, item.system.damage.value)
 			.setTargetedDefense(item.system.defense)
+			.addAttackTraits(item.system)
 			.addItemAccuracyBonuses(item, actor)
 			.addItemDamageBonuses(item, actor)
 			.modifyHrZero((hrZero) => hrZero || item.system.rollInfo.useWeapon.hrZero.value);

--- a/module/documents/items/basic/basic-item-data-model.mjs
+++ b/module/documents/items/basic/basic-item-data-model.mjs
@@ -5,6 +5,7 @@ import { AccuracyCheck } from '../../../checks/accuracy-check.mjs';
 import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
 import { ChecksV2 } from '../../../checks/checks-v2.mjs';
 import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
+import { CommonSections } from '../../../checks/common-sections.mjs';
 
 /**
  * @param {CheckV2} check
@@ -47,11 +48,10 @@ function onRenderCheck(data, result, actor, item) {
 				basic: {
 					type: item.system.type.value,
 					quality: item.system.quality.value,
-					summary: item.system.summary.value,
-					description: await TextEditor.enrichHTML(item.system.description),
 				},
 			},
 		}));
+		CommonSections.description(data, item.system.description, item.system.summary.value, CHECK_DETAILS);
 	}
 }
 

--- a/module/documents/items/classFeature/chanter/verses-application.mjs
+++ b/module/documents/items/classFeature/chanter/verses-application.mjs
@@ -5,8 +5,6 @@ import { Flags } from '../../../../helpers/flags.mjs';
 import { CommonSections } from '../../../../checks/common-sections.mjs';
 import { Targeting } from '../../../../helpers/targeting.mjs';
 
-const SCALING_FORMULA = '($wlp*2)+&step(0,10,20)';
-
 async function getDescription(model, useAttributes = false) {
 	const key = model.key;
 	const tone = model.tone;
@@ -35,15 +33,14 @@ async function getDescription(model, useAttributes = false) {
 		// Set rollData based on the key
 		const keyData = key.system.data;
 		rollData.key = {
-			type: game.i18n.localize(FU.damageTypes[keyData.type]),
-			damage: `@DMG[${SCALING_FORMULA} ${keyData.type}]`,
-			status: `@EFFECT[${keyData.status}]`,
-			attribute: game.i18n.localize(FU.attributeAbbreviations[keyData.attribute]),
-			boost: `@EFFECT[${keyData.attribute}-up]`,
-			resistance: `@AFFINITY[${keyData.type} resistance]`,
-			normal: `@AFFINITY[${keyData.type} none]`,
-			vulnerability: `@AFFINITY[${keyData.type} vulnerability]`,
-			recovery: `@GAIN[${SCALING_FORMULA} ${keyData.recovery}]`,
+			type: keyData.type,
+			typeLocal: game.i18n.localize(FU.damageTypes[keyData.type]),
+			status: keyData.status,
+			statusLocal: game.i18n.localize(FU.statusEffects[keyData.status]),
+			attribute: keyData.attribute,
+			attributeLocal: game.i18n.localize(FU.attributeAbbreviations[keyData.attribute]),
+			resource: keyData.recovery,
+			resourceLocal: game.i18n.localize(FU.resources[keyData.recovery]),
 		};
 
 		const actor = model.parent?.parent?.actor;

--- a/module/documents/items/item.mjs
+++ b/module/documents/items/item.mjs
@@ -22,11 +22,13 @@ const capitalizeFirst = (string) => (typeof string === 'string' ? string.charAt(
 /**
  * @typedef Item
  * @property {Actor} actor
- * @proeprty {String} uuid
+ * @property {String} uuid
+ * @property {String} name
  */
 
 /**
  * @description Extend the basic Item document with some very simple modifications.
+ * @property {foundry.abstract.TypeDataModel} system
  * @extends {Item}
  * @inheritDoc
  */

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -62,7 +62,7 @@ Hooks.on(CheckHooks.renderCheck, (sections, check, actor, item, flags) => {
 			CommonSections.opportunity(sections, ability.system.opportunity, CHECK_DETAILS);
 		}
 
-		CommonSections.description(sections, ability.system.description, ability.system.summary.value, CHECK_DETAILS);
+		CommonSections.description(sections, ability.system.description, ability.system.summary.value, CHECK_DETAILS, true);
 	}
 });
 

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -13,6 +13,7 @@ import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
 import { CommonSections } from '../../../checks/common-sections.mjs';
 import { ActionCostDataModel } from '../common/action-cost-data-model.mjs';
 import { TargetingDataModel } from '../common/targeting-data-model.mjs';
+import { Traits } from '../../../pipelines/traits.mjs';
 
 Hooks.on(CheckHooks.renderCheck, (sections, check, actor, item, flags) => {
 	if (item?.system instanceof MiscAbilityDataModel) {
@@ -210,6 +211,7 @@ export class MiscAbilityDataModel extends foundry.abstract.TypeDataModel {
 
 			const inspect = CheckConfiguration.inspect(weaponCheck);
 			const configure = CheckConfiguration.configure(check);
+			configure.addTraits(Traits.Skill);
 
 			if (this.accuracy) {
 				check.modifiers.push({

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -14,6 +14,7 @@ import { ItemAttributesDataModelV2 } from '../common/item-attributes-data-model-
 import { DamageDataModelV2 } from '../common/damage-data-model-v2.mjs';
 import { SkillMigrations } from './skill-migrations.mjs';
 import { ExpressionContext, Expressions } from '../../../expressions/expressions.mjs';
+import { Traits } from '../../../pipelines/traits.mjs';
 
 const weaponUsedBySkill = 'weaponUsedBySkill';
 const skillForAttributeCheck = 'skillForAttributeCheck';
@@ -248,6 +249,8 @@ export class SkillDataModel extends foundry.abstract.TypeDataModel {
 
 			const inspect = CheckConfiguration.inspect(weaponCheck);
 			const configure = CheckConfiguration.configure(check);
+
+			configure.addTraits(Traits.Skill, item.system.damage.type).addWeaponTraits(weapon.system);
 
 			if (this.accuracy) {
 				check.modifiers.push({

--- a/module/documents/items/spell/spell-data-model.mjs
+++ b/module/documents/items/spell/spell-data-model.mjs
@@ -65,11 +65,11 @@ function onRenderCheck(data, result, actor, item, flags) {
 					max: item.system.targeting.max,
 					mpCost: item.system.cost.amount,
 					opportunity: item.system.opportunity,
-					summary: item.system.summary.value,
-					description: await TextEditor.enrichHTML(item.system.description),
 				},
 			},
 		}));
+
+		CommonSections.description(data, item.system.description, item.system.summary.value, CHECK_DETAILS);
 
 		const targets = CheckConfiguration.inspect(result).getTargetsOrDefault();
 

--- a/module/documents/items/spell/spell-data-model.mjs
+++ b/module/documents/items/spell/spell-data-model.mjs
@@ -11,6 +11,8 @@ import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
 import { ActionCostDataModel } from '../common/action-cost-data-model.mjs';
 import { TargetingDataModel } from '../common/targeting-data-model.mjs';
 import { CommonSections } from '../../../checks/common-sections.mjs';
+import { Traits } from '../../../pipelines/traits.mjs';
+import { CommonEvents } from '../../../checks/common-events.mjs';
 
 /**
  * @param {CheckV2} check
@@ -29,6 +31,7 @@ const prepareCheck = (check, actor, item, registerCallback) => {
 		check.additionalData.hasDamage = item.system.rollInfo.damage.hasDamage.value;
 		const configurer = MagicCheck.configure(check)
 			.setDamage(item.system.rollInfo.damage.type.value, item.system.rollInfo.damage.value)
+			.addTraits(item.system.rollInfo.damage.type.value, Traits.Spell)
 			.setTargetedDefense('mdef')
 			.setDamageOverride(actor, 'spell')
 			.modifyHrZero((hrZero) => hrZero || item.system.rollInfo.useWeapon.hrZero.value);
@@ -82,6 +85,7 @@ function onRenderCheck(data, result, actor, item, flags) {
 Hooks.on(CheckHooks.renderCheck, onRenderCheck);
 
 /**
+ * @property {String} fuid
  * @property {string} subtype.value
  * @property {string} summary.value
  * @property {string} description
@@ -159,6 +163,7 @@ export class SpellDataModel extends foundry.abstract.TypeDataModel {
 		if (this.hasRoll.value) {
 			return ChecksV2.magicCheck(this.parent.actor, this.parent, CheckConfiguration.initHrZero(modifiers.shift));
 		} else {
+			CommonEvents.spell(this.parent.actor, this.parent);
 			return ChecksV2.display(this.parent.actor, this.parent);
 		}
 	}

--- a/module/documents/items/weapon/weapon-data-model.mjs
+++ b/module/documents/items/weapon/weapon-data-model.mjs
@@ -6,6 +6,7 @@ import { AccuracyCheck } from '../../../checks/accuracy-check.mjs';
 import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
 import { ChecksV2 } from '../../../checks/checks-v2.mjs';
 import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
+import { CommonSections } from '../../../checks/common-sections.mjs';
 
 /**
  * @param {CheckV2} check
@@ -56,11 +57,10 @@ function onRenderCheck(data, result, actor, item) {
 					hands: item.system.hands.value,
 					type: item.system.type.value,
 					quality: item.system.quality.value,
-					summary: item.system.summary.value,
-					description: await TextEditor.enrichHTML(item.system.description),
 				},
 			},
 		}));
+		CommonSections.description(data, item.system.description, item.system.summary.value, CHECK_DETAILS);
 	}
 }
 

--- a/module/documents/items/weapon/weapon-data-model.mjs
+++ b/module/documents/items/weapon/weapon-data-model.mjs
@@ -28,6 +28,8 @@ const prepareCheck = (check, actor, item, registerCallback) => {
 		AccuracyCheck.configure(check)
 			.setDamage(item.system.damageType.value, item.system.damage.value)
 			.addItemAccuracyBonuses(item, actor)
+			.addWeaponTraits(item.system)
+			.addTraits(item.system.damageType.value)
 			.setTargetedDefense(item.system.defense)
 			.addItemDamageBonuses(item, actor)
 			.setDamageOverride(actor, 'attack')

--- a/module/helpers/target-handler.mjs
+++ b/module/helpers/target-handler.mjs
@@ -13,7 +13,7 @@ export async function targetHandler() {
 			targets = await getSelected();
 			break;
 		case 'tokenTargeted':
-			targets = await getTargeted();
+			targets = await getTargeted(false, false);
 			break;
 	}
 
@@ -61,15 +61,16 @@ export async function getSelected() {
 }
 
 /**
- * @param tokens returns targeted tokens instead of actors if true
+ * @param {Boolean} tokens returns targeted tokens instead of actors if true
+ * @param {Boolean} warn
  * @return {Actor[] | Token[]}
  */
-export function getTargeted(tokens = false) {
+export function getTargeted(tokens = false, warn = true) {
 	const targets = Array.from(game.user.targets)
 		.map((target) => (tokens ? target : target.actor))
 		.filter((element) => element);
 
-	if (targets.length === 0) {
+	if (targets.length === 0 && warn) {
 		ui.notifications.warn('FU.ChatApplyEffectNoActorsTargeted', { localize: true });
 	}
 	return targets || [];

--- a/module/helpers/targeting.mjs
+++ b/module/helpers/targeting.mjs
@@ -13,7 +13,6 @@ import { getTargeted } from './target-handler.mjs';
  * @property {string} uuid The uuid of the actor
  * @property {string} link An html link to the actor
  * @property {"none", "hit", "miss"} result
- * //TODO: Add a map of optional properties?
  * @property {number} difficulty Additional information
  */
 

--- a/module/helpers/targeting.mjs
+++ b/module/helpers/targeting.mjs
@@ -92,7 +92,7 @@ const defaultAction = new TargetAction('targetSingle', 'fa-bullseye', 'FU.ChatPi
  * @returns {TargetData[]}
  */
 function getSerializedTargetData() {
-	const targets = getTargeted();
+	const targets = getTargeted(false, false);
 	return serializeTargetData(targets);
 }
 

--- a/module/hooks.mjs
+++ b/module/hooks.mjs
@@ -77,7 +77,7 @@ export const FUHooks = {
 	 */
 	LOSS_EVENT: 'projectfu.events.loss',
 	/**
-	 * @description Dispatched after an actor enters or exits crisis.
+	 * @description Dispatched after an actor enters crisis.
 	 * @example callback(event)
 	 * @remarks Uses {@link CrisisEvent}. This can happen after a {@link DAMAGE_EVENT}.
 	 */
@@ -89,7 +89,7 @@ export const FUHooks = {
 	 */
 	DEFEAT_EVENT: 'projectfu.events.defeat',
 	/**
-	 * @description Dispatched after an actor has a status effect applied on them.
+	 * @description Dispatched after an actor has a status effect applied or removed on them.
 	 * @example callback(event)
 	 * @remarks Uses {@link StatusEvent}. It happens AFTER the status effect has been applied.
 	 */

--- a/module/hooks.mjs
+++ b/module/hooks.mjs
@@ -42,6 +42,56 @@ export const FUHooks = {
 	ROLL_STUDY: 'studyRoll',
 	/**
 	 * @description Invoked when there's a change in the combat state
+	 * @example callback(event)
+	 * @remarks Uses {@link CombatEvent}
 	 */
-	COMBAT_EVENT: 'projectfu.combat',
+	COMBAT_EVENT: 'projectfu.events.combat',
+	/**
+	 * @description Invoked after an attack (involving an accuracy check) has been performed by an actor
+	 * @example callback(event)
+	 * @remarks Uses {@link AttackEvent}
+	 */
+	ATTACK_EVENT: 'projectfu.events.attack',
+	/**
+	 * @description Invoked after a spell (without a magic check) has been performed by an actor
+	 * @example callback(event)
+	 * @remarks Uses {@link SpellEvent}
+	 */
+	SPELL_EVENT: 'projectfu.events.spell',
+	/**
+	 * @description Invoked after damage has been applied to an actor
+	 * @example callback(event)
+	 * @remarks Uses {@link DamageEvent}
+	 */
+	DAMAGE_EVENT: 'projectfu.events.damage',
+	/**
+	 * @description Invoked after resource gain has been applied to an actor
+	 * @example callback(event)
+	 * @remarks Uses {@link GainEvent}
+	 */
+	GAIN_EVENT: 'projectfu.events.gain',
+	/**
+	 * @description Dispatched after resource loss has been applied to an actor
+	 * @example callback(event)
+	 * @remarks Uses {@link LossEvent}.
+	 */
+	LOSS_EVENT: 'projectfu.events.loss',
+	/**
+	 * @description Dispatched after an actor enters or exits crisis.
+	 * @example callback(event)
+	 * @remarks Uses {@link CrisisEvent}. This can happen after a {@link DAMAGE_EVENT}.
+	 */
+	CRISIS_EVENT: 'projectfu.events.crisis',
+	/**
+	 * @description Invoked after an actor is reduced to 0 hit points
+	 * @example callback(event)
+	 * @remarks Uses {@link DefeatEvent}. This can happen after a {@link DAMAGE_EVENT}.
+	 */
+	DEFEAT_EVENT: 'projectfu.events.defeat',
+	/**
+	 * @description Dispatched after an actor has a status effect applied on them.
+	 * @example callback(event)
+	 * @remarks Uses {@link StatusEvent}. It happens AFTER the status effect has been applied.
+	 */
+	STATUS_EVENT: 'projectfu.events.status',
 };

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -11,6 +11,8 @@ import { ApplyTargetHookData, BeforeApplyHookData } from './legacy-hook-data.mjs
 import { ResourcePipeline, ResourceRequest } from './resource-pipeline.mjs';
 import { ChatMessageHelper } from '../helpers/chat-message-helper.mjs';
 import { ExpressionContext, Expressions } from '../expressions/expressions.mjs';
+import { Traits } from './traits.mjs';
+import { CommonEvents } from '../checks/common-events.mjs';
 
 /**
  * @typedef {"incomingDamage.all", "incomingDamage.air", "incomingDamage.bolt", "incomingDamage.dark", "incomingDamage.earth", "incomingDamage.fire", "incomingDamage.ice", "incomingDamage.light", "incomingDamage.poison"} DamagePipelineStepIncomingDamage
@@ -112,12 +114,6 @@ export class DamageRequest extends PipelineRequest {
  * @property {String} effect
  * @property {String} total
  */
-
-// TODO: Decide whether to define in config.mjs. Though it's probably fine if they are all in english
-const Traits = {
-	IgnoreResistance: 'ignore-resistance',
-	IgnoreImmunity: 'ignore-immunity',
-};
 
 /**
  * @property {Number} affinity The index of the affinity
@@ -382,6 +378,10 @@ async function process(request) {
 		const damageTaken = -context.result;
 		updates.push(actor.modifyTokenAttribute('resources.hp', damageTaken, true));
 		actor.showFloatyText(`${damageTaken} HP`, `red`);
+
+		// Dispatch event
+		CommonEvents.damage(request.damageType, context.result, context.traits, actor, context.sourceActor);
+
 		// Chat message
 		const affinityString = await renderTemplate('systems/projectfu/templates/chat/partials/inline-damage-icon.hbs', {
 			damage: context.result,
@@ -433,9 +433,13 @@ function onRenderChatMessage(message, jQuery) {
 	let baseDamageInfo;
 	/** @type InlineSourceInfo **/
 	let sourceInfo = null;
+	let traits = [];
 
 	if (ChecksV2.isCheck(message)) {
-		const damage = CheckConfiguration.inspect(message).getDamage();
+		const inspector = CheckConfiguration.inspect(message);
+		const damage = inspector.getDamage();
+		traits = inspector.getTraits();
+
 		if (damage) {
 			sourceInfo = getSourceInfoFromChatMessage(message);
 			baseDamageInfo = damage;
@@ -447,7 +451,7 @@ function onRenderChatMessage(message, jQuery) {
 			baseDamageInfo,
 			targets,
 			async (extraDamageInfo) => {
-				await handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, extraDamageInfo);
+				await handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, extraDamageInfo, traits);
 				disabled = false;
 			},
 			() => {
@@ -457,7 +461,7 @@ function onRenderChatMessage(message, jQuery) {
 	};
 
 	const applyDefaultDamage = async (event, targets) => {
-		return handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, {});
+		return handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, {}, traits);
 	};
 
 	const handleClick = async (event, getTargetsFunction, action, alternateAction) => {
@@ -486,7 +490,7 @@ function onRenderChatMessage(message, jQuery) {
 				baseDamageInfo,
 				targets,
 				(extraDamageInfo) => {
-					handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, extraDamageInfo);
+					handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, extraDamageInfo, traits);
 					disabled = false;
 				},
 				() => {
@@ -519,11 +523,13 @@ function onRenderChatMessage(message, jQuery) {
  * @param {InlineSourceInfo} sourceInfo
  * @param {import('../helpers/typedefs.mjs').BaseDamageInfo} baseDamageInfo
  * @param {import('./damage-customizer.mjs').ExtraDamageInfo} extraDamageInfo
+ * @param {String[]} traits
  * @returns {void}
  */
-async function handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, extraDamageInfo) {
+async function handleDamageApplication(event, targets, sourceInfo, baseDamageInfo, extraDamageInfo, traits) {
 	const request = new DamageRequest(sourceInfo, targets, baseDamageInfo, extraDamageInfo);
 	request.event = event;
+	traits.forEach((t) => request.traits.add(t));
 	if (event.shiftKey) {
 		request.traits.add(Traits.IgnoreResistance);
 		if (event.ctrlKey || event.metaKey) {

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -91,8 +91,13 @@ export async function onManageActiveEffect(event, owner) {
 			return createTemporaryEffect(owner, listItem.dataset.effectType);
 		case 'edit':
 			return resolveEffect().sheet.render(true);
-		case 'delete':
-			return resolveEffect().delete();
+		case 'delete': {
+			const _effect = resolveEffect();
+			if (canBeRemoved(_effect)) {
+				return resolveEffect().delete();
+			}
+			break;
+		}
 		case 'toggle': {
 			const effect = resolveEffect();
 			return effect.update({ disabled: !effect.disabled });
@@ -167,6 +172,14 @@ export async function toggleStatusEffect(actor, statusEffectId, source = undefin
 		}
 		return true;
 	}
+}
+
+/**
+ * @param effect
+ * @returns {boolean} True if the effect can only be managed by the system
+ */
+function canBeRemoved(effect) {
+	return !effect.statuses.has('crisis') && !effect.statuses.has('ko');
 }
 
 // Helper function to generate the @EFFECT format string
@@ -426,6 +439,7 @@ export const Effects = Object.freeze({
 	initialize,
 	onRemoveEffectFromActor,
 	onApplyEffectToActor,
+	canBeRemoved,
 	BOONS_AND_BANES,
 	DAMAGE_TYPES,
 	STATUS_EFFECTS,

--- a/module/pipelines/resource-pipeline.mjs
+++ b/module/pipelines/resource-pipeline.mjs
@@ -3,6 +3,7 @@ import { FU, SYSTEM } from '../helpers/config.mjs';
 import { InlineSourceInfo } from '../helpers/inline-helper.mjs';
 import { Flags } from '../helpers/flags.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
+import { CommonEvents } from '../checks/common-events.mjs';
 
 /**
  * @property {Number} amount
@@ -120,6 +121,8 @@ async function processRecovery(request) {
 			}
 		}
 
+		CommonEvents.gain(actor, request.resourceType, amountRecovered);
+
 		actor.showFloatyText(`${amountRecovered} ${request.resourceType.toUpperCase()}`, `lightgreen`);
 		updates.push(
 			ChatMessage.create({
@@ -171,6 +174,9 @@ async function processLoss(request) {
 		} else {
 			updates.push(actor.modifyTokenAttribute(request.attributeKey, amountLost, true));
 		}
+
+		// Dispatch event
+		CommonEvents.loss(actor, request.resourceType, amountLost);
 
 		actor.showFloatyText(`${amountLost} ${request.resourceType.toUpperCase()}`, `lightyellow`);
 		updates.push(

--- a/module/pipelines/traits.mjs
+++ b/module/pipelines/traits.mjs
@@ -1,0 +1,11 @@
+// TODO: Decide whether to define in config.mjs. Though it's probably fine if they are all in english
+
+/**
+ * @description A non-comprehensive list of traits supported by the pipelines.
+ */
+export const Traits = {
+	IgnoreResistance: 'ignore-resistance',
+	IgnoreImmunity: 'ignore-immunity',
+	Skill: 'skill',
+	Spell: 'spell',
+};

--- a/src/packs/skills/classFeature_Calm_Tone_XCtijox9eBrBNSno.json
+++ b/src/packs/skills/classFeature_Calm_Tone_XCtijox9eBrBNSno.json
@@ -13,7 +13,7 @@
     },
     "featureType": "projectfu.tone",
     "data": {
-      "description": "<p>Each target recovers <strong>【@DATA[key.recovery]】.</strong></p><p><span><em>If this tone causes MP recovery, it has <strong>no effect</strong> on the character who sings it.</em></span></p>"
+      "description": "<p>Each target recovers <strong>【</strong>@GAIN[(($wlp*2)+&step(10,20,30)) @DATA[key.resource]]<strong>】</strong></p><p><span><em>If this tone causes MP recovery, it has <strong>no effect</strong> on the character who sings it.</em></span></p>"
     },
     "source": "FUHF139",
     "fuid": "calm-tone"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "12.330",
     "createdTime": 1710038336377,
-    "modifiedTime": 1739302048901,
+    "modifiedTime": 1740682056122,
     "lastModifiedBy": "esOkelwPNblkbxW3",
     "compendiumSource": null,
     "duplicateSource": null

--- a/src/packs/skills/classFeature_Energetic_Tone_XvkMOHPXUg0ikDkf.json
+++ b/src/packs/skills/classFeature_Energetic_Tone_XvkMOHPXUg0ikDkf.json
@@ -13,7 +13,7 @@
     },
     "featureType": "projectfu.tone",
     "data": {
-      "description": "<p>Until the <strong>start of your next turn</strong>, when a target <strong>succeeds</strong> on a <strong>Check</strong> that includes <strong>【@DATA[key.attribute]】</strong> and that Check allows them to advance or turn back a Clock, they may <strong>fill or erase</strong> an additional section of that Clock.</p>"
+      "description": "<p>Until the <strong>start of your next turn</strong>, when a target <strong>succeeds</strong> on a <strong>Check</strong> that includes <strong>【@DATA[key.attributeLocal]】</strong> and that Check allows them to advance or turn back a Clock, they may <strong>fill or erase</strong> an additional section of that Clock.</p>"
     },
     "source": "FUHF139",
     "fuid": "energetic-tone"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "12.330",
     "createdTime": 1710039830425,
-    "modifiedTime": 1739382369014,
+    "modifiedTime": 1740682129104,
     "lastModifiedBy": "esOkelwPNblkbxW3",
     "compendiumSource": null,
     "duplicateSource": null

--- a/src/packs/skills/classFeature_Frantic_Tone_mtKts9zjHlweSVk4.json
+++ b/src/packs/skills/classFeature_Frantic_Tone_mtKts9zjHlweSVk4.json
@@ -13,7 +13,7 @@
     },
     "featureType": "projectfu.tone",
     "data": {
-      "description": "<p>Each target suffers<strong>【@DATA[key.damage]】</strong> damage.</p>"
+      "description": "<p>Each target suffers<strong>【</strong>@DMG[($wlp*2)+&step(0,10,20) @DATA[key.type]]<strong>】</strong>damage.</p>"
     },
     "source": "FUHF139",
     "fuid": "frantic-tone"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "12.330",
     "createdTime": 1710039980800,
-    "modifiedTime": 1739301576275,
+    "modifiedTime": 1740682576141,
     "lastModifiedBy": "esOkelwPNblkbxW3",
     "compendiumSource": null,
     "duplicateSource": null

--- a/src/packs/skills/classFeature_Lively_Tone_zLxqETSi6zbRkWKu.json
+++ b/src/packs/skills/classFeature_Lively_Tone_zLxqETSi6zbRkWKu.json
@@ -13,7 +13,7 @@
     },
     "featureType": "projectfu.tone",
     "data": {
-      "description": "<p>Each target gains<strong>【@DATA[key.boost]】</strong>until the <strong>start of your next turn.</strong></p>"
+      "description": "<p>Each target gains<strong>【</strong>@EFFECT[@DATA[key.attribute]-up]<strong>】</strong>until the <strong>start of your next turn.</strong></p>"
     },
     "source": "FUHF139",
     "fuid": "lively-tone"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "12.330",
     "createdTime": 1710040149139,
-    "modifiedTime": 1739302712373,
+    "modifiedTime": 1740682637675,
     "lastModifiedBy": "esOkelwPNblkbxW3",
     "compendiumSource": null,
     "duplicateSource": null

--- a/src/packs/skills/classFeature_Solemn_Tone_yidpNKJQMA7dSBsc.json
+++ b/src/packs/skills/classFeature_Solemn_Tone_yidpNKJQMA7dSBsc.json
@@ -13,7 +13,7 @@
     },
     "featureType": "projectfu.tone",
     "data": {
-      "description": "<p>Each target recovers from<strong>【@DATA[key.status]】</strong>. Each target also gains <strong>【@DATA[key.resistance]】</strong>until the <strong>start of your next turn</strong>.</p>"
+      "description": "<p>Each target recovers from<strong>【@DATA[key.statusLocal]】</strong>and also gains <strong>【@AFFINITY[@DATA[key.type] resistance]】</strong>until the <strong>start of your next turn</strong>.</p>"
     },
     "source": "FUHF139",
     "fuid": "solemn-tone"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "12.330",
     "createdTime": 1710040272509,
-    "modifiedTime": 1739381734057,
+    "modifiedTime": 1740682372716,
     "lastModifiedBy": "esOkelwPNblkbxW3",
     "compendiumSource": null,
     "duplicateSource": null


### PR DESCRIPTION
Add a variety of combat event hooks that can be used by modules (and the system) . These can all be found in `FUHooks`.
- ATTACK_EVENT
- DAMAGE_EVENT 
- COMBAT_EVENT
- GAIN_EVENT
- LOSS_EVENT
- CRISIS_EVENT
- DEFEAT_EVENT
- STATUS_EVENT

## Examples

```js
    Hooks.on('projectfu.events.damage', async event => {
        Azurecompendia.log(`Playing sound effect for damage event: ${event.type} on token: ${event.token.name}`);
        switch (event.type) {
            case "physical":
                playSoundEffect('physical');
                break;
            default:
                break;
        }
    });

    Hooks.on('projectfu.events.gain', async event => {
        Azurecompendia.log(`Playing sound effect for gain event: ${event.resource} on token: ${event.token.name}`);
    });

    Hooks.on('projectfu.events.loss', async event => {
        Azurecompendia.log(`Playing sound effect for loss event: ${event.resource} on token: ${event.token.name}`);
    });

    Hooks.on('projectfu.events.crisis', async event => {
        Azurecompendia.log(`Playing sound effect for crisis event on token: ${event.token.name}`);
    });

    Hooks.on('projectfu.events.combat', async event => {        
        switch (event.type) {
            case 'FU.StartOfCombat':
            case 'FU.EndOfCombat':
                Azurecompendia.log(`Playing sound effect for combat event: ${event.type}`);
                break;

            case 'FU.StartOfTurn':
                Azurecompendia.log(`Playing sound effect for combat event ${event.type} on token ${event.token.name}`);
                break;
            case 'FU.EndOfTurn':
                Azurecompendia.log(`Playing sound effect for combat event ${event.type} on token ${event.token.name}`);
                break;
            default:
                break;
        }
    });
```