### PR TITLE
fix: update silk shirt mdef to correct value of 2

### DIFF
--- a/src/packs/basic-equipment/armor_Silk_Shirt_23VCQdoqi2lYsVbS.json
+++ b/src/packs/basic-equipment/armor_Silk_Shirt_23VCQdoqi2lYsVbS.json
@@ -33,7 +33,7 @@
       "value": 0
     },
     "mdef": {
-      "value": 1
+      "value": 2
     },
     "init": {
       "value": -1


### PR DESCRIPTION
In the core rulebook, the silk shirt gives INS die + 2 M. Defense

![image](https://github.com/user-attachments/assets/1a8cb598-7185-441b-9ed2-a92ae3df58e5)

However in the foundry module the value is incorrectly INS die + 1 M. Defense

![image](https://github.com/user-attachments/assets/c7646f1d-ca75-4529-9b96-6d79ffbc5a61)
