### PR TITLE
Add progress data to active effect model

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -898,6 +898,7 @@
 		"ChatEvaluateAmountNoActor": "No reference to an actor provided",
 		"ChatEvaluateAmountNoSource": "No reference to a source provided",
 		"ChatEvaluateAmountNoItem": "No reference to an item provided",
+		"ChatEvaluateNoEffect": "No reference to an effect provided",
 		"ChatEvaluateNoSourceActor": "The given item must be added to an actor in order to evaluate",
 		"ChatEvaluateNoSkill": "The referenced skill was not found in the actor",
 		"ChatEvaluateNoProgress": "The referenced progress track with the given id was not found in the actor",
@@ -1385,6 +1386,7 @@
 		"ChatProgressAtMinimum": "The given progress track is already at its minimum value!",
 		"Reference": "Reference",
 		"All": "All",
+		"Identifier": "Identifier",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -25,11 +25,17 @@ export async function onRenderActiveEffectConfig(sheet, html, context) {
 	// Find the navigation element
 	let nav = html.find('nav.sheet-tabs.tabs');
 	if (nav.length) {
-		// Create the new navigation entry
+		const targetTab = nav.find('a[data-tab="effects"]');
+
+		// Predicates
 		const predicateLabel = game.i18n.localize('FU.Predicate');
-		let predicateTab = `<a class="item" data-tab="predicate"><i class="fas fa-book"></i>${predicateLabel}</a>`;
-		let targetTab = nav.find('a[data-tab="effects"]');
+		const predicateTab = `<a class="item" data-tab="predicate"><i class="fas fa-book"></i>${predicateLabel}</a>`;
 		targetTab.before(predicateTab);
+
+		// Rules
+		const rulesLabel = game.i18n.localize('FU.Rule');
+		const rulesTab = `<a class="item" data-tab="rules"><i class="fas fa-book"></i>${rulesLabel}</a>`;
+		targetTab.before(rulesTab);
 	}
 
 	// Duration Tab (Replace)
@@ -37,9 +43,15 @@ export async function onRenderActiveEffectConfig(sheet, html, context) {
 	durationTab.empty();
 	const durationTemplate = await renderTemplate(`systems/projectfu/templates/effects/active-effect-duration.hbs`, data);
 	durationTab.append(durationTemplate);
+
 	// Predicate Tab (Add)
 	const predicateTemplate = await renderTemplate(`systems/projectfu/templates/effects/active-effect-predicate.hbs`, data);
 	durationTab.before(predicateTemplate);
+
+	// Rules Tab (Add)
+	const effectsTab = html.find('.tab[data-tab=effects]');
+	const rulesTemplate = await renderTemplate(`systems/projectfu/templates/effects/active-effect-rules.hbs`, data);
+	effectsTab.before(rulesTemplate);
 
 	sheet.setPosition({ ...sheet.position, height: 'auto' });
 }

--- a/module/documents/effects/active-effect-model.mjs
+++ b/module/documents/effects/active-effect-model.mjs
@@ -1,4 +1,5 @@
 import { FU } from '../../helpers/config.mjs';
+import { ProgressDataModel } from '../items/common/progress-data-model.mjs';
 
 /**
  * @description THe active effect model for this system
@@ -8,7 +9,8 @@ import { FU } from '../../helpers/config.mjs';
  * @property {Number} duration.interval The number of occurrences between events
  * @property {Number} duration.remaining The number of intervals left.
  * @property {String} tracking Whom is the duration tracked on
- * @property {Number} stack Optional. Used for counting the number of stacks of an effect.
+ * @property {Object} rules Contains optional rules for this effect.
+ * @property {ProgressDataModel} rules.progress It can be used for tracking a clock, a resource, a counter, etc.
  * @remarks The remaining property is initialized, and must be updated.
  */
 export class FUActiveEffectModel extends foundry.abstract.TypeDataModel {
@@ -23,7 +25,9 @@ export class FUActiveEffectModel extends foundry.abstract.TypeDataModel {
 				tracking: new StringField({ initial: 'self', choices: Object.keys(FU.effectTracking) }),
 				remaining: new NumberField({ initial: 0, min: 0, integer: true, nullable: false }),
 			}),
-			stack: new NumberField({ initial: 1, min: 1, integer: true, nullable: false }),
+			rules: new SchemaField({
+				progress: new EmbeddedDataField(ProgressDataModel, { required: false }),
+			}),
 		};
 	}
 

--- a/module/documents/items/common/progress-data-model.mjs
+++ b/module/documents/items/common/progress-data-model.mjs
@@ -1,17 +1,22 @@
 /**
- * @property {string} name A label
+ * @description Models the tracking of progress, whether that be clocks or resources.
+ * @property {string} name A label, used for user-facing displays.
  * @property {number} current The current value
  * @property {number} step The step size (a multiplier for each increment/decrement)
  * @property {number} max The maximum value
+ * @property {Boolean} enabled Whether this progress track should be used
+ * @property {string} id Optionally, a unique identifier for internal lookups.
  */
 export class ProgressDataModel extends foundry.abstract.DataModel {
 	static defineSchema() {
-		const { NumberField, StringField } = foundry.data.fields;
+		const { NumberField, StringField, BooleanField } = foundry.data.fields;
 		return {
-			name: new StringField({ initial: 'Name' }),
+			name: new StringField({ nullable: true }),
+			id: new StringField({ nullable: true }),
 			current: new NumberField({ initial: 0, min: 0, integer: true, nullable: false }),
 			step: new NumberField({ initial: 1, min: 1, integer: true, nullable: false }),
 			max: new NumberField({ initial: 6, min: 0, integer: true, nullable: false }),
+			enabled: new BooleanField({ initial: false }),
 		};
 	}
 

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -22,6 +22,7 @@ export const Flags = Object.freeze({
 		SupportCheck: 'Supporter',
 		GroupCheckSupporters: 'GroupCheckSupporters',
 		Item: 'Item',
+		Effect: 'Effect',
 		Damage: 'Damage',
 		Source: 'Source',
 		ResourceGain: 'ResourceGain',

--- a/module/helpers/inline-check.mjs
+++ b/module/helpers/inline-check.mjs
@@ -134,7 +134,7 @@ function activateListeners(document, html) {
 					let modifier = 0;
 
 					if (this.dataset.modifier !== undefined) {
-						const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, targets);
+						const context = ExpressionContext.fromSourceInfo(sourceInfo, targets);
 						modifier = await Expressions.evaluateAsync(this.dataset.modifier, context);
 					}
 

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -31,6 +31,7 @@ function enricher(text, options) {
 		anchor.classList.add('inline', 'inline-damage');
 		anchor.dataset.type = type;
 		anchor.dataset.traits = traits;
+		anchor.dataset.label = label;
 		anchor.draggable = true;
 
 		// TOOLTIP
@@ -70,8 +71,9 @@ function activateListeners(document, html) {
 			let targets = await targetHandler();
 			if (targets.length > 0) {
 				const sourceInfo = InlineHelper.determineSource(document, this);
+				sourceInfo.name = this.dataset.label ? this.dataset.label : sourceInfo.name;
 				const type = this.dataset.type;
-				const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, targets);
+				const context = ExpressionContext.fromSourceInfo(sourceInfo, targets);
 				const amount = await Expressions.evaluateAsync(this.dataset.amount, context);
 
 				const baseDamageInfo = { type, total: amount, modifierTotal: 0 };
@@ -90,6 +92,7 @@ function activateListeners(document, html) {
 			}
 
 			const sourceInfo = InlineHelper.determineSource(document, this);
+			sourceInfo.name = this.dataset.label ? this.dataset.label : sourceInfo.name;
 			const data = {
 				type: INLINE_DAMAGE,
 				_sourceInfo: sourceInfo,
@@ -107,7 +110,7 @@ async function onDropActor(actor, sheet, { type, damageType, amount, _sourceInfo
 	if (type === INLINE_DAMAGE) {
 		// Need to rebuild the class after it was deserialized
 		const sourceInfo = InlineSourceInfo.fromObject(_sourceInfo);
-		const context = ExpressionContext.fromUuid(sourceInfo.actorUuid, sourceInfo.itemUuid, [actor]);
+		const context = ExpressionContext.sourceInfo(sourceInfo, [actor]);
 		const _amount = await Expressions.evaluateAsync(amount, context);
 		const baseDamageInfo = { type: damageType, total: _amount, modifierTotal: 0 };
 

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -61,10 +61,12 @@ export const preloadHandlebarsTemplates = async function () {
 
 		// Common partials
 		'systems/projectfu/templates/common/active-effects.hbs',
+
 		// Effects
 		'systems/projectfu/templates/effects/active-effect-details.hbs',
 		'systems/projectfu/templates/effects/active-effect-duration.hbs',
 		'systems/projectfu/templates/effects/active-effect-predicate.hbs',
+		'systems/projectfu/templates/effects/active-effect-rules.hbs',
 
 		// Dialogs
 		'systems/projectfu/templates/dialog/dialog-check.hbs',
@@ -80,6 +82,7 @@ export const preloadHandlebarsTemplates = async function () {
 		'systems/projectfu/templates/chat/chat-check-flavor-check.hbs',
 		'systems/projectfu/templates/chat/chat-check-flavor-item.hbs',
 		'systems/projectfu/templates/chat/chat-group-check-initiated.hbs',
+		'systems/projectfu/templates/chat/chat-active-effect.hbs',
 
 		// Chat Message Partials
 		'systems/projectfu/templates/chat/partials/chat-accuracy-check.hbs',

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -399,7 +399,7 @@ async function process(request) {
 
 		// TODO: Print message to chat
 		if (damageTaken === 0) {
-			ui.notifications.warn(`The actor ${actor.name} has already been defeated`);
+			ui.notifications.warn(`The damage to ${actor.name} was reduced to 0`);
 			continue;
 		}
 

--- a/templates/chat/chat-active-effect.hbs
+++ b/templates/chat/chat-active-effect.hbs
@@ -1,0 +1,16 @@
+<div class="chat-effect-message">
+	<header class="title-desc chat-header flexrow">
+		<img class="item-img" src="{{ effect.img }}" data-tooltip="{{ effect.name }}" style="animation-duration: {{this.effectsMarqueeDuration}}s;" />
+		<h2>{{effect.name}}</h2>t
+	</header>
+	{{#if description}}
+		<div class="chat-desc">
+			{{{description}}}
+		</div>
+	{{/if}}
+	{{#if effect.system.rules.progress.enabled}}
+		<div style="display: grid; margin-top: 4px;">
+			{{> "systems/projectfu/templates/chat/partials/chat-clock-details.hbs" data=effect.system.rules.progress arr=effect.system.rules.progress.progressArray}}
+		</div>
+	{{/if}}
+</div>

--- a/templates/common/active-effects.hbs
+++ b/templates/common/active-effects.hbs
@@ -74,6 +74,17 @@
                                        title="{{localize 'FU.EffectDelete'}}">
                                         <i class="fas fa-trash"></i>
                                     </a>
+									{{#if effect.system.rules.progress.enabled }}
+										<div class="effect-control buttons-inc">
+											<a class="decrement-button" style="color:unset" data-action="decrementProgress">-</a>
+											<span data-resource="progress">{{ effect.system.rules.progress.current }}</span>
+											{{#if (gt effect.system.rules.progress.max 0)}}
+												<span>/</span>
+												<span>{{ effect.system.rules.progress.max }}</span>
+											{{/if}}
+											<a class="increment-button" style="color:unset" data-action="incrementProgress">+</a>
+										</div>
+									{{/if}}
                                 </div>
                             </div>
                         </div>

--- a/templates/effects/active-effect-rules.hbs
+++ b/templates/effects/active-effect-rules.hbs
@@ -1,0 +1,42 @@
+<section class="tab" data-tab="rules">
+	{{!-- Progress --}}
+	<div class="form-group">
+			<div class="flexrow flex-wrap gap-2">
+				<!-- Toggle -->
+				<div class="flexrow flex-group-left">
+					<span>{{localize 'FU.Progress'}}</span>
+					<input type="checkbox" name="system.rules.progress.enabled" {{ checked system.rules.progress.enabled }} />
+				</div>
+				<!-- Identifier -->
+				<div class="flexrow flex-group-center">
+					<label class="resource-label-m">{{localize 'FU.Identifier'}}</label>
+					<input type="text" name="system.rules.progress.id" value="{{ system.rules.progress.id }}" data-dtype="String"
+						   placeholder="{{localize 'FU.Identifier'}}" class="resource-label-m resource-inputs select-dropdown-l" />
+				</div>
+					<!-- Name -->
+					<div class="flexrow flex-group-center">
+						<label class="resource-label-m">{{localize 'FU.Name'}}</label>
+						<input type="text" name="system.rules.progress.name" value="{{ system.rules.progress.name }}" data-dtype="String"
+									 placeholder="{{localize 'FU.Name'}}" class="resource-label-m resource-inputs select-dropdown-l" />
+					</div>
+				<!-- Current -->
+				<div class="flexrow flex-group-center">
+					<label class="resource-label-m">{{localize 'FU.Current'}}</label>
+					<input type="number" name="system.rules.progress.current" value="{{ system.rules.progress.current }}"
+						   class="resource-inputs select-dropdown-m" />
+				</div>
+				<!-- Step -->
+				<div class="flexrow flex-group-center">
+					<label class="resource-label-m">{{localize 'FU.Step'}}</label>
+					<input type="number" name="system.rules.progress.step" value="{{ system.rules.progress.step }}"
+						   class="resource-inputs select-dropdown-m" />
+				</div>
+				<!-- Maximum -->
+				<div class="flexrow flex-group-center">
+					<label class="resource-label-m">{{localize 'FU.Max'}}</label>
+					<input type="number" name="system.rules.progress.max" value="{{ system.rules.progress.max }}"
+						   class="resource-inputs select-dropdown-m" />
+				</div>
+			</div>
+	</div>
+</section>

--- a/templates/optional/quirk/feature-quirk-sheet.hbs
+++ b/templates/optional/quirk/feature-quirk-sheet.hbs
@@ -23,7 +23,7 @@
     <div class="title-fieldset grid-2col">
         {{!-- Item Settings --}}
 
-        {{!-- Resource Pointts --}}
+        {{!-- Resource Points --}}
         {{> "systems/projectfu/templates/optional/partials/feature-resource-points-sheet.hbs"}}
 
         {{!-- Clocks --}}


### PR DESCRIPTION
## Description

Adds progress data to the active effect model, allowing us to embed progress tracks (to serve as either clocks or resource points) into any kind of item really. This will prevent the need to inject progress-tracking into all kinds of models when they could instead become an optional part of the foundational unit that all items share, _active effects_. 

I strongly believe this approach will be more flexible going forward, and also give us and users the chance to easily introduce temporary progress tracks through temporary effects that can be easily added onto existing actors at the click of a button. The potential of this approach will give both us and our users a great deal of creative freedom.

Furthermore, by having the progress data managed within the active effect model we will be able to manipulate it based on combat events. (For example, whenever a combat ends a progress track could be reset. This would work for the esper's brainwave clock).

## Changes

- Add support for progress tracks in active effects
- Add function to render an active effect to chat, FUActiveEffect.sendToChat
- Add enabled, id properties to the progress data model
- Add support for $pg macro to be used within effects.
- Refactor the progress track resolution on actor and item
- Add rules section for the active effect model
- Refactor the source info static ctor used in the inline actions
- Embed effect source information into InlineSourceInfo
- Add template for active effects rendered to chat messages
- Use labels in inline-damage, inline-resources for the damage pipeline

![image](https://github.com/user-attachments/assets/a0934ad2-032d-4a2b-90d1-e8ddca2e8ace)

![image](https://github.com/user-attachments/assets/6e0f362a-be8d-49f3-896c-e49aadb73532)

![image](https://github.com/user-attachments/assets/ea19fcb4-a62d-467d-9bf1-1034459f39dd)

