### PR TITLE
Add support for multiple damage types for the affinity inline

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1380,6 +1380,7 @@
 		"ChatProgressAtMinimum": "The given progress track is already at its minimum value!",
 		"ChatMissingItemWithId": "No item was found in the actor with the given id",
 		"Reference": "Reference",
+		"All": "All",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/styles/static/icons/ful-sl-star.svg
+++ b/styles/static/icons/ful-sl-star.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 95.74 95.98">
+<svg id="Layer_2" width="946"
+	 height="1024" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 95.74 95.98">
   <defs>
     <style>
       .cls-1 {

--- a/styles/static/icons/fus-martial.svg
+++ b/styles/static/icons/fus-martial.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 408.98 412.19">
+<svg width="946" height="1024"  id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 408.98 412.19">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
When using `@TYPE[affinity....]`, one can now do the following:

- `@TYPE[affinity all resistance]`
- `@TYPE[affinity fire,ice vulnerability]`

![image](https://github.com/user-attachments/assets/225f67d0-cf15-47c8-9ccf-a297242d3486)
