### PR TITLE
Refactor damage total calculation

### DIFF
--- a/module/checks/accuracy-check.mjs
+++ b/module/checks/accuracy-check.mjs
@@ -65,7 +65,7 @@ const onPrepareCheck = (check, actor, item, registerCallback) => {
  * @param {FUItem} [item]
  */
 const onProcessCheck = (check, actor, item) => {
-	const { type, result, critical, fumble, primary, secondary } = check;
+	const { type, result, critical, fumble } = check;
 	if (type === 'accuracy') {
 		const configurer = CheckConfiguration.configure(check);
 		configurer.modifyTargetedDefense((value) => value ?? 'def');
@@ -120,13 +120,6 @@ const onProcessCheck = (check, actor, item) => {
 				const damageTypeBonus = actor.system.bonuses.damage[damage.type];
 				if (damageTypeBonus) {
 					damage.modifiers.push({ label: `FU.DamageBonus${damage.type.capitalize()}`, value: damageTypeBonus });
-				}
-
-				damage.modifierTotal = damage.modifiers.reduce((agg, curr) => agg + curr.value, 0);
-				if (CheckConfiguration.inspect(check).getHrZero()) {
-					damage.total = damage.modifierTotal;
-				} else {
-					damage.total = Math.max(primary.result, secondary.result) + damage.modifierTotal;
 				}
 			}
 			return damage;

--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -38,13 +38,34 @@ const initHrZero = (hrZero) => (check) => {
  */
 
 /**
- * @typedef DamageData
+ * @class DamageData
+ * @property {Number} hr The high roll
  * @property {DamageType} type
  * @property {BonusDamage[]} modifiers
- * @property {number} modifierTotal
- * @property {number} [total]
+ * @property {Number} modifierTotal
  * @property {String} extra An expression to evaluate to add extra damage
  */
+export class DamageData {
+	constructor(data = {}) {
+		// eslint-disable-next-line no-unused-vars
+		const { modifierTotal, ..._data } = data;
+		Object.assign(this, _data);
+	}
+
+	/**
+	 * @returns {Number}
+	 */
+	get modifierTotal() {
+		return this.modifiers.reduce((agg, curr) => agg + curr.value, 0);
+	}
+
+	/**
+	 * @returns {Number}
+	 */
+	get total() {
+		return this.modifierTotal + this.hr;
+	}
+}
 
 /**
  * @typedef TemplateDamageData
@@ -104,10 +125,10 @@ class CheckConfigurer {
 	 * @return {CheckConfigurer}
 	 */
 	setDamage(type, baseDamage) {
-		this.#check.additionalData[DAMAGE] = {
+		this.#check.additionalData[DAMAGE] = new DamageData({
 			modifiers: [{ label: 'FU.BaseDamage', value: baseDamage }],
 			type,
-		};
+		});
 		return this;
 	}
 
@@ -175,7 +196,7 @@ class CheckConfigurer {
 	 * @return {CheckConfigurer}
 	 */
 	modifyDamage(callback) {
-		const damage = this.#check.additionalData[DAMAGE] ?? null;
+		const damage = this.#check.additionalData[DAMAGE] ?? new DamageData();
 		this.#check.additionalData[DAMAGE] = callback(damage);
 		return this;
 	}
@@ -380,9 +401,12 @@ class CheckInspector {
 
 	/**
 	 * @return {DamageData|null}
+	 * @remarks Embeds the high roll into the data
 	 */
 	getDamage() {
-		return this.#check.additionalData[DAMAGE] != null ? foundry.utils.duplicate(this.#check.additionalData[DAMAGE]) : null;
+		const raw = this.#check.additionalData[DAMAGE];
+		raw.hr = this.getHighRoll();
+		return raw != null ? new DamageData(foundry.utils.duplicate(raw)) : null;
 	}
 
 	/**
@@ -390,6 +414,13 @@ class CheckInspector {
 	 */
 	getHrZero() {
 		return this.#check.additionalData[HR_ZERO] ?? null;
+	}
+
+	/**
+	 * @return {Number}
+	 */
+	getHighRoll() {
+		return Math.max(this.#check.primary.result, this.#check.secondary.result);
 	}
 
 	/**
@@ -496,18 +527,22 @@ class CheckInspector {
 		const isBase = traits.includes(Traits.Base);
 		const damage = this.getDamage();
 		const hrZero = this.getHrZero();
+		const modifierTotal = damage.modifierTotal;
+		const primary = _check.primary.result;
+		const secondary = _check.secondary.result;
+		const total = hrZero ? modifierTotal : Math.max(primary, secondary) + modifierTotal;
 
 		let damageData = null;
 		if (damage) {
 			damageData = {
 				result: {
-					attr1: _check.primary.result,
-					attr2: _check.secondary.result,
+					attr1: primary,
+					attr2: secondary,
 				},
 				damage: {
 					hrZero: hrZero,
-					bonus: damage.modifierTotal,
-					total: damage.total,
+					bonus: modifierTotal,
+					total: total,
 					type: damage.type,
 					extra: damage.extra,
 					traits: traits,

--- a/module/checks/checks-v2.mjs
+++ b/module/checks/checks-v2.mjs
@@ -167,7 +167,8 @@ const modifyCheck = async (checkId, callback) => {
 		}
 		if (callbackResult) {
 			const { check = checkFromCheckResult(oldResult), roll = Roll.fromData(oldResult.roll) } = (typeof callbackResult === 'object' && callbackResult) ?? {};
-			const result = await processResult(check, roll, actor, item);
+			// Do not invoke the hook when modifying a check
+			const result = await processResult(check, roll, actor, item, false);
 			return renderCheck(result, actor, item, message.flags);
 		}
 	} else {
@@ -314,9 +315,10 @@ const extractDieResults = (term, actor) => {
  * @param {Roll} roll
  * @param {FUActor} actor
  * @param {FUItem} item
+ * @param {Boolean} callHook
  * @return {Promise<Readonly<CheckResultV2>>}
  */
-const processResult = async (check, roll, actor, item) => {
+const processResult = async (check, roll, actor, item, callHook = true) => {
 	if (!roll._evaluated) {
 		await roll.roll();
 	}
@@ -353,7 +355,9 @@ const processResult = async (check, roll, actor, item) => {
 		additionalData: check.additionalData,
 	});
 
-	Hooks.callAll(CheckHooks.processCheck, result, actor, item);
+	if (callHook) {
+		Hooks.callAll(CheckHooks.processCheck, result, actor, item);
+	}
 
 	return result;
 };

--- a/module/checks/magic-check.mjs
+++ b/module/checks/magic-check.mjs
@@ -45,7 +45,7 @@ const onPrepareCheck = (check, actor, item, registerCallback) => {
  * @param {FUItem} [item]
  */
 const onProcessCheck = (check, actor, item) => {
-	const { type, result, critical, fumble, primary, secondary } = check;
+	const { type, result, critical, fumble } = check;
 	if (type === 'magic') {
 		CheckConfiguration.configure(check)
 			.modifyTargets((targets) =>
@@ -81,12 +81,6 @@ const onProcessCheck = (check, actor, item) => {
 					const inspector = CheckConfiguration.inspect(check);
 					if (inspector.hasTrait(Traits.Base)) {
 						damage.modifiers = damage.modifiers.slice(0, 1);
-					}
-					damage.modifierTotal = damage.modifiers.reduce((agg, curr) => agg + curr.value, 0);
-					if (inspector.getHrZero()) {
-						damage.total = damage.modifierTotal;
-					} else {
-						damage.total = Math.max(primary.result, secondary.result) + damage.modifierTotal;
 					}
 				}
 				return damage;

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -78,8 +78,8 @@ function activateListeners(document, html) {
 				const context = ExpressionContext.fromSourceInfo(sourceInfo, targets);
 				const amount = await Expressions.evaluateAsync(this.dataset.amount, context);
 
-				const baseDamageInfo = { type, total: amount, modifierTotal: 0 };
-				const request = new DamageRequest(sourceInfo, targets, baseDamageInfo);
+				const damageData = { type, total: amount, modifierTotal: 0 };
+				const request = new DamageRequest(sourceInfo, targets, damageData);
 				if (this.dataset.traits) {
 					request.addTraits(...this.dataset.traits.split(','));
 				}
@@ -114,9 +114,9 @@ async function onDropActor(actor, sheet, { type, damageType, amount, _sourceInfo
 		const sourceInfo = InlineSourceInfo.fromObject(_sourceInfo);
 		const context = ExpressionContext.sourceInfo(sourceInfo, [actor]);
 		const _amount = await Expressions.evaluateAsync(amount, context);
-		const baseDamageInfo = { type: damageType, total: _amount, modifierTotal: 0 };
+		const damageData = { type: damageType, total: _amount, modifierTotal: 0 };
 
-		const request = new DamageRequest(sourceInfo, [actor], baseDamageInfo);
+		const request = new DamageRequest(sourceInfo, [actor], damageData);
 		if (traits) {
 			request.addTraits(...traits.split(','));
 		}

--- a/module/pipelines/damage-customizer.mjs
+++ b/module/pipelines/damage-customizer.mjs
@@ -29,7 +29,7 @@ import { getTargeted } from '../helpers/target-handler.mjs';
 /**
  * Displays a dialog to customize damage.
  *
- * @param {BaseDamageInfo} damage - The damage object containing type and total.
+ * @param {DamageData} damage - The damage object containing type and total.
  * @param {FUActor[]} targets - The specified targets.
  * @param {DamageCustomizerCallback} callback - The function to call when the user confirms.
  * @param {() => void} onCancel - The function to call when the user cancels.

--- a/module/pipelines/legacy-hook-data.mjs
+++ b/module/pipelines/legacy-hook-data.mjs
@@ -1,28 +1,4 @@
 // TODO: Deprecate once users switch to newer hooks
-/**
- * @property {Event | null} event
- * @property {FUActor[]} targets
- * @property {string | null} sourceUuid
- * @property {string | null} sourceName
- * @property {import('./typedefs.mjs').BaseDamageInfo} baseDamageInfo
- * @property {import('./damage-customizer.mjs').ExtraDamageInfo} extraDamageInfo
- * @property {ClickModifiers | null} clickModifiers
- * @deprecated Replaced in the newer pipeline by PipelineContext
- */
-export class BeforeApplyHookData {
-	/**
-	 * @param {DamageRequest} request
-	 */
-	constructor(request) {
-		this.event = request.event;
-		this.targets = request.targets;
-		this.sourceUuid = request.sourceInfo.actorUuid;
-		this.sourceName = request.sourceInfo.name;
-		this.baseDamageInfo = request.baseDamageInfo;
-		this.extraDamageInfo = request.extraDamageInfo;
-		this.clickModifiers = request.clickModifiers;
-	}
-}
 
 /**
  * @property {FUActor} target


### PR DESCRIPTION
The final calculation for initial damage has been pushed back all the way to the end, at the start of the damage pipeline. This will prevent timing issues where modifiers could be added throughout the check, then having the total modifier calculated right before yet another modifiers was then added.

This also fixes the issues when modifying checks.