### PR TITLE
Add expressions progress macro redirect

### DIFF
--- a/module/expressions/expressions.mjs
+++ b/module/expressions/expressions.mjs
@@ -398,12 +398,18 @@ function evaluateMacros(expression, context) {
 				}
 				return skill.system.level.value;
 			}
-			// Clock section
+			// Attribute size
+			case 'ats': {
+				const actor = context.resolveActorOrSource(match, redirect);
+				const attribute = parseIdentifier(splitArgs[0]);
+				return getAttributeSize(actor, attribute);
+			}
+			// Progress track
 			case 'pg':
 			case 'cs': {
-				context.assertActor();
+				const actor = context.resolveActorOrSource(match, redirect);
 				const id = parseIdentifier(splitArgs[0]);
-				const clock = context.actor.resolveProgress(id);
+				const clock = actor.resolveProgress(id);
 				if (!clock) {
 					ui.notifications.warn(`${game.i18n.localize('FU.ChatEvaluateNoProgress')}: '${id}'`, { localize: true });
 					throw new Error(`The progress track with id ${id} was not found`);

--- a/src/packs/skills/effect_Effect__Psychic_Shield_hNeylrus4Ii8hIKa.json
+++ b/src/packs/skills/effect_Effect__Psychic_Shield_hNeylrus4Ii8hIKa.json
@@ -37,19 +37,25 @@
           "tracking": "self",
           "remaining": 1
         },
-        "stack": 1
+        "stack": 1,
+        "rules": {
+          "progress": {
+            "id": "",
+            "name": ""
+          }
+        }
       },
       "changes": [
         {
           "key": "system.derived.mdef.value",
           "mode": 4,
-          "value": "$wlp+(&cs('brainwave-clock)*2)",
+          "value": "~&ats('wlp')+(~&cs('brainwave-clock)*2)",
           "priority": null
         },
         {
           "key": "system.derived.def.value",
           "mode": 4,
-          "value": "$wlp+(&cs('brainwave-clock)*2)",
+          "value": "~&ats('wlp')+(~&cs('brainwave-clock)*2)",
           "priority": null
         }
       ],
@@ -67,7 +73,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1743843067862,
-        "modifiedTime": 1743843349414,
+        "modifiedTime": 1746873248749,
         "lastModifiedBy": "JXPd932s9DHQRD0w"
       },
       "_key": "!items.effects!hNeylrus4Ii8hIKa.Xrd3uuRrv6x4lRnR"


### PR DESCRIPTION
- Adds new macro, `ats` for attribute size. It has redirect support.
- Adds redirect to `pg` macro.
- Psychic Shield updated to use the macros, allowing the psychic field heroic to work.
