### PR TITLE
Add mind point absorption trait, Fix spellblade weapon accuracy

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -955,6 +955,7 @@
 		"ChatResourceLoss": "<strong>{actor}</strong> lost <strong>{amount} {resource}</strong> from <strong>{from}</strong>",
 		"HealthPointLoss": "HP Loss",
 		"MindPointLoss": "MP Loss",
+		"MindPointAbsorption": "MP Absorption",
 		"InventoryPointLoss": "IP Loss",
 		"DragAndDropHowTo": "To apply, Drag & Drop this element onto an Actor Sheet or Token you control.",
 		"TextEditorTextCommands": "ProjectFU Text Commands",

--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -164,6 +164,18 @@ class CheckConfigurer {
 	}
 
 	/**
+	 * @param {WeaponDataModel} weapon
+	 * @returns {CheckConfigurer}
+	 */
+	addWeaponAccuracy(weapon) {
+		const baseAccuracy = weapon.accuracy.value;
+		if (baseAccuracy) {
+			this.addModifier('FU.AccuracyCheckBaseAccuracy', baseAccuracy);
+		}
+		return this;
+	}
+
+	/**
 	 * @param {WeaponTraits} traits
 	 * @return {CheckConfigurer}
 	 */

--- a/module/checks/magic-check.mjs
+++ b/module/checks/magic-check.mjs
@@ -162,5 +162,4 @@ const initialize = () => {
 
 export const MagicCheck = Object.freeze({
 	initialize,
-	configure: CheckConfiguration.configure,
 });

--- a/module/documents/items/weapon/weapon-data-model.mjs
+++ b/module/documents/items/weapon/weapon-data-model.mjs
@@ -15,27 +15,23 @@ import { CommonSections } from '../../../checks/common-sections.mjs';
  */
 const prepareCheck = (check, actor, item, registerCallback) => {
 	if (check.type === 'accuracy' && item.system instanceof WeaponDataModel) {
-		check.primary = item.system.attributes.primary.value;
-		check.secondary = item.system.attributes.secondary.value;
-		const baseAccuracy = item.system.accuracy.value;
-		if (baseAccuracy) {
-			check.modifiers.push({
-				label: 'FU.AccuracyCheckBaseAccuracy',
-				value: baseAccuracy,
-			});
-		}
+		/** @type WeaponDataModel **/
+		const weapon = item.system;
+		check.primary = weapon.attributes.primary.value;
+		check.secondary = weapon.attributes.secondary.value;
 
 		CheckConfiguration.configure(check)
-			.setDamage(item.system.damageType.value, item.system.damage.value)
+			.addWeaponAccuracy(weapon)
+			.setDamage(weapon.damageType.value, weapon.damage.value)
 			.setWeaponTraits({
-				weaponType: item.system.type.value,
-				weaponCategory: item.system.category.value,
-				handedness: item.system.hands.value,
+				weaponType: weapon.type.value,
+				weaponCategory: weapon.category.value,
+				handedness: weapon.hands.value,
 			})
-			.addTraits(item.system.damageType.value)
-			.setTargetedDefense(item.system.defense)
+			.addTraits(weapon.damageType.value)
+			.setTargetedDefense(weapon.defense)
 			.setDamageOverride(actor, 'attack')
-			.modifyHrZero((hrZero) => hrZero || item.system.rollInfo.useWeapon.hrZero.value);
+			.modifyHrZero((hrZero) => hrZero || weapon.rollInfo.useWeapon.hrZero.value);
 	}
 };
 

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -457,6 +457,9 @@ async function process(request) {
 
 		// Handle post-damage traits
 		if (damageTaken > 0) {
+			if (request.traits.has(Traits.MindPointAbsorption)) {
+				resource = 'mp';
+			}
 			if (request.traits.has(Traits.Absorb)) {
 				await absorbDamage(resource, damageTaken, context.sourceInfo, [context.sourceActor]);
 			} else if (request.traits.has(Traits.AbsorbHalf)) {

--- a/module/pipelines/traits.mjs
+++ b/module/pipelines/traits.mjs
@@ -11,6 +11,7 @@ export const Traits = Object.freeze({
 	AbsorbHalf: 'absorb-half',
 	Absorb: 'absorb',
 	MindPointLoss: 'mind-point-loss',
+	MindPointAbsorption: 'mind-point-absorption',
 	NonLethal: 'non-lethal',
 	Base: 'base',
 });


### PR DESCRIPTION
- Adds a trait, `MindPointAbsorption` to specify that MP should be regained on absorption.
- Fixes spellblade not accounting for weapon accuracy

![image](https://github.com/user-attachments/assets/ff07734c-f122-46df-8b41-0472e9383993)
