### PR TITLE
Fix updating target results on magic check

### DIFF
--- a/module/checks/accuracy-check.mjs
+++ b/module/checks/accuracy-check.mjs
@@ -6,6 +6,20 @@ import { CommonSections } from './common-sections.mjs';
 import { CommonEvents } from './common-events.mjs';
 import { CheckConfiguration } from './check-configuration.mjs';
 
+/**
+ * @param {CheckV2} check
+ * @param {FUActor} actor
+ * @param {FUItem} [item]
+ * @param {CheckCallbackRegistration} registerCallback
+ */
+const onPrepareCheck = (check, actor, item, registerCallback) => {
+	const { type, modifiers } = check;
+	if (type === 'accuracy') {
+		handleGenericBonus(actor, modifiers);
+		registerCallback(handleWeaponTraitAccuracyBonuses, Number.MAX_VALUE);
+	}
+};
+
 function handleGenericBonus(actor, modifiers) {
 	if (actor.system.bonuses.accuracy.accuracyCheck) {
 		modifiers.push({
@@ -41,20 +55,6 @@ const handleWeaponTraitAccuracyBonuses = (check, actor, item) => {
 			label: 'FU.AccuracyCheckBonusRanged',
 			value: actor.system.bonuses.accuracy.accuracyRanged,
 		});
-	}
-};
-
-/**
- * @param {CheckV2} check
- * @param {FUActor} actor
- * @param {FUItem} [item]
- * @param {CheckCallbackRegistration} registerCallback
- */
-const onPrepareCheck = (check, actor, item, registerCallback) => {
-	const { type, modifiers } = check;
-	if (type === 'accuracy') {
-		handleGenericBonus(actor, modifiers);
-		registerCallback(handleWeaponTraitAccuracyBonuses, Number.MAX_VALUE);
 	}
 };
 

--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -307,6 +307,9 @@ class CheckConfigurer {
 	updateTargetResults() {
 		const targets = this.#check.additionalData[TARGETS];
 		if (targets?.length) {
+			if (!this.#check.result) {
+				return;
+			}
 			const targetedDefense = this.getTargetedDefense();
 			targets.forEach((target) => {
 				const difficulty = target[targetedDefense];

--- a/module/checks/magic-check.mjs
+++ b/module/checks/magic-check.mjs
@@ -16,8 +16,6 @@ import { Traits } from '../pipelines/traits.mjs';
 const onPrepareCheck = (check, actor, item, registerCallback) => {
 	const { type, modifiers } = check;
 	if (type === 'magic') {
-		CheckConfiguration.configure(check).setTargetedDefense('mdef');
-
 		if (actor.system.bonuses.accuracy.magicCheck) {
 			modifiers.push({
 				label: 'FU.MagicCheckBonusGeneric',
@@ -37,6 +35,7 @@ const onProcessCheck = (check, actor, item) => {
 	const { type, critical, fumble } = check;
 	if (type === 'magic') {
 		const configurer = CheckConfiguration.configure(check);
+		configurer.setTargetedDefense('mdef');
 		// TODO: Refactor alongside accuracy-checks
 		if (critical) {
 			configurer.addTraits('critical');


### PR DESCRIPTION
When updating the procedure for target results on accuracy check, the same was not done for magic check. That has now been addressed.

![image](https://github.com/user-attachments/assets/42bc63d0-6623-4b35-9d01-c531926791f1)
![image](https://github.com/user-attachments/assets/172abd56-3264-41dd-b3c9-977e0a794c43)
