### PR TITLE
Fix party names not showing letters that hang low.

### DIFF
--- a/styles/css/projectfu.css
+++ b/styles/css/projectfu.css
@@ -7880,7 +7880,8 @@ a.inline-roll i {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  min-height: 35px;
+  min-height: 45px;
+	margin-bottom: -10px;
   max-width: 100%;
 }
 .projectfu .party .overview .plate .identity {

--- a/styles/scss/components/_forms.scss
+++ b/styles/scss/components/_forms.scss
@@ -788,7 +788,8 @@
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
-				min-height: 35px;
+				min-height: 45px;
+				margin-bottom: -10px;
 				max-width: 100%;
 			}
 


### PR DESCRIPTION
BEFORE
![image](https://github.com/user-attachments/assets/e452aec0-e9b2-4b57-9172-af79df83c3bd)
AFTER
![image](https://github.com/user-attachments/assets/adb8d047-f86b-45f1-a5e8-1e91ae6348c0)

The party sheet was not correctly showing names that had letters that hang low, like 'g' in this example. 