### PR TITLE
Update InvocationSelectionApplication to v2

### DIFF
--- a/module/documents/items/classFeature/invoker/invocation-selection-application.mjs
+++ b/module/documents/items/classFeature/invoker/invocation-selection-application.mjs
@@ -1,23 +1,17 @@
 import { systemTemplatePath } from '../../../../helpers/system-utils.mjs';
+import FUApplication from '../../../../ui/application.mjs';
 import { WELLSPRINGS } from './invoker-integration.mjs';
 
-export class InvocationSelectionApplication extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2) {
+export class InvocationSelectionApplication extends FUApplication {
 	static DEFAULT_OPTIONS = {
-		form: {
-			closeOnSubmit: false,
-			submitOnChange: true,
-			submitOnClose: true,
-		},
-		classes: ['form', 'projectfu', 'invocations-selection'],
+		classes: ['form', 'invocations-selection'],
 		window: {
 			title: 'FU.ClassFeatureInvocationsSelectDialogTitle',
-			resizable: true,
 		},
 		position: {
 			width: 350,
 			height: 'auto',
 		},
-		tag: 'form',
 		actions: {
 			useInvocation: InvocationSelectionApplication.UseInvocation,
 		},

--- a/styles/features/invoker/invocation-selection-application.css
+++ b/styles/features/invoker/invocation-selection-application.css
@@ -10,8 +10,4 @@
 	.fun {
 		display: inline-block;
 	}
-
-	.window-content {
-		background-color: #dad8cc;
-	}
 }


### PR DESCRIPTION
- Update InvocationSelectionApplication to ApplicationV2
- Added styling to preserve original window background color from v1 because it did not look all that great with the default black
- Update reference to `TextEditor` to `foundry.applications.ux.TextEditor.implementation` as per deprecation