### PR TITLE
ActorWellspringManager attempts to rerender actor sheet unnecessarily

### DIFF
--- a/module/documents/items/classFeature/invoker/actor-wellspring-manager.mjs
+++ b/module/documents/items/classFeature/invoker/actor-wellspring-manager.mjs
@@ -10,8 +10,12 @@ export class ActorWellspringManager {
 	constructor(actor) {
 		this.#actor = actor;
 
-		Hooks.on(FUHooks.HOOK_WELLSPRING_CHANGED, () => this.#actor.sheet.render());
-		Hooks.on('canvasReady', () => this.#actor.sheet.render());
+		Hooks.on(FUHooks.HOOK_WELLSPRING_CHANGED, () => {
+			if (this.#actor.sheet.rendered) this.#actor.sheet.render();
+		});
+		Hooks.on('canvasReady', () => {
+			if (this.#actor.sheet.rendered) this.#actor.sheet.render();
+		});
 	}
 
 	static onActorPrepared(actor) {


### PR DESCRIPTION
`ActorWellspringManager` rerenders its actor's sheet when the available wellsprings or current scene changes.  It does does so indiscriminately, attempting to rerender the sheet for *every* actor, which generates a warning for any actors for which the current user does not have Observer permission or higher.

This PR simply adds a check to make sure the sheet is rendered before attempting to rerender it, both to avoid this warning and to avoid trying to rerender sheets that aren't even rendered in the first place.