### PR TITLE
Use journal sheet styling for actual journal content and not just the editor

### DIFF
--- a/styles/css/utils/typography.css
+++ b/styles/css/utils/typography.css
@@ -786,6 +786,7 @@
 /* Scoped CSS specifically for ProseMirror element */
 .application.journal-sheet,
 .application.projectfu {
+	.journal-entry-page,
 	.editor-content {
 		h1 {
 			font-family: var(--font-title);


### PR DESCRIPTION
Resolves issue with journal-specific css being scoped to the editor but not for actual output journal content

### Current
<img width="637" height="396" alt="image" src="https://github.com/user-attachments/assets/3358e726-9c88-475c-b6ee-7a48c72a95cc" />

### New
<img width="642" height="444" alt="image" src="https://github.com/user-attachments/assets/e268f3c0-0fe4-40c1-95e4-66e18715b9f6" />

