### PR TITLE
fix: Party and Stash tables showing incorrect buttons

### DIFF
--- a/module/helpers/tables/consumables-table-renderer.mjs
+++ b/module/helpers/tables/consumables-table-renderer.mjs
@@ -17,8 +17,8 @@ export class ConsumablesTableRenderer extends FUTableRenderer {
 				{
 					hideFavorite: (item) => !item.actor.isCharacterType,
 					hideShare: (item) => item.actor.type !== 'party',
-					hideSell: (item) => item.actor.type !== 'stash' || !item.actor.system.merchant,
-					hideLoot: (item) => item.actor.type !== 'stash' || item.actor.system.merchant,
+					hideSell: (item) => !(item.actor.type === 'stash' && item.actor.system.merchant),
+					hideLoot: (item) => !(item.actor.type === 'stash' && !item.actor.system.merchant),
 				},
 			),
 		},

--- a/module/helpers/tables/equipment-table-renderer.mjs
+++ b/module/helpers/tables/equipment-table-renderer.mjs
@@ -117,10 +117,10 @@ export class EquipmentTableRenderer extends FUTableRenderer {
 			controls: CommonColumns.itemControlsColumn(
 				{ headerAlignment: 'end', custom: EquipmentTableRenderer.#renderCustomControlsHeader },
 				{
-					disableFavorite: (item) => !item.actor.isCharacterType,
-					disableShare: (item) => item.actor.type !== 'party',
-					disableSell: (item) => item.actor.type !== 'stash' || !item.actor.system.merchant,
-					disableLoot: (item) => item.actor.type !== 'stash' || item.actor.system.merchant,
+					hideFavorite: (item) => !item.actor.isCharacterType,
+					hideShare: (item) => item.actor.type !== 'party',
+					hideSell: (item) => !(item.actor.type === 'stash' && item.actor.system.merchant),
+					hideLoot: (item) => !(item.actor.type === 'stash' && !item.actor.system.merchant),
 				},
 			),
 		},

--- a/module/helpers/tables/other-items-table-renderer.mjs
+++ b/module/helpers/tables/other-items-table-renderer.mjs
@@ -14,10 +14,10 @@ export class OtherItemsTableRenderer extends FUTableRenderer {
 			controls: CommonColumns.itemControlsColumn(
 				{ custom: `<span></span>` },
 				{
-					disableFavorite: (item) => !item.actor.isCharacterType,
-					disableShare: (item) => item.actor.type !== 'party',
-					disableSell: (item) => item.actor.type !== 'stash' || !item.actor.system.merchant,
-					disableLoot: (item) => item.actor.type !== 'stash' || item.actor.system.merchant,
+					hideFavorite: (item) => !item.actor.isCharacterType,
+					hideShare: (item) => item.actor.type !== 'party',
+					hideSell: (item) => !(item.actor.type === 'stash' && item.actor.system.merchant),
+					hideLoot: (item) => !(item.actor.type === 'stash' && !item.actor.system.merchant),
 				},
 			),
 		},

--- a/module/helpers/tables/treasures-table-renderer.mjs
+++ b/module/helpers/tables/treasures-table-renderer.mjs
@@ -16,10 +16,10 @@ export class TreasuresTableRenderer extends FUTableRenderer {
 			controls: CommonColumns.itemControlsColumn(
 				{ type: 'treasure', label: 'FU.Treasure' },
 				{
-					disableFavorite: (item) => !item.actor.isCharacterType,
-					disableShare: (item) => item.actor.type !== 'party',
-					disableSell: (item) => item.actor.type !== 'stash' || !item.actor.system.merchant,
-					disableLoot: (item) => item.actor.type !== 'stash' || item.actor.system.merchant,
+					hideFavorite: (item) => !item.actor.isCharacterType,
+					hideShare: (item) => item.actor.type !== 'party',
+					hideSell: (item) => !(item.actor.type === 'stash' && item.actor.system.merchant),
+					hideLoot: (item) => !(item.actor.type === 'stash' && !item.actor.system.merchant),
 				},
 			),
 		},


### PR DESCRIPTION
- fix button configurations for the following tables shared across sheets:
  - consumables-table-renderer.mjs
  - equipment-table-renderer.mjs
  - other-items-table-renderer.mjs
  - treasures-table-renderer.mjs