### PR TITLE
fix: Technospheres in Party and Stash Sheet

### DIFF
--- a/module/helpers/tables/skills-table-renderer.mjs
+++ b/module/helpers/tables/skills-table-renderer.mjs
@@ -34,7 +34,7 @@ export class SkillsTableRenderer extends FUTableRenderer {
 		};
 
 		let mainWeapon;
-		if (item.actor) {
+		if (item.actor && item.actor.isCharacterType) {
 			const mainHandItem = item.actor.items.get(item.actor.system.equipped.mainHand);
 			if (item.system.useWeapon.accuracy) {
 				data.useWeapon = true;

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -21,6 +21,7 @@ import { Checks } from '../checks/checks.mjs';
 import { TreasuresTableRenderer } from '../helpers/tables/treasures-table-renderer.mjs';
 import { ConsumablesTableRenderer } from '../helpers/tables/consumables-table-renderer.mjs';
 import { OtherItemsTableRenderer } from '../helpers/tables/other-items-table-renderer.mjs';
+import { TechnospheresTableRenderer } from '../helpers/tables/technospheres-table-renderer.mjs';
 
 /**
  * @description Creates a sheet that contains the details of a party composed of {@linkcode FUActor}
@@ -112,6 +113,7 @@ export class FUPartySheet extends FUActorSheet {
 	};
 
 	#equipmentTable = new EquipmentTableRenderer();
+	#technospheresTable = new TechnospheresTableRenderer();
 	#treasuresTable = new TreasuresTableRenderer();
 	#consumablesTable = new ConsumablesTableRenderer();
 	#otherItemsTable = new OtherItemsTableRenderer('accessory', 'armor', 'consumable', 'shield', 'treasure', 'weapon');
@@ -166,12 +168,17 @@ export class FUPartySheet extends FUActorSheet {
 				break;
 			case 'overview':
 				break;
-			case 'inventory':
+			case 'inventory': {
+				const technoSphereMode = game.settings.get(SYSTEM, SETTINGS.technospheres);
 				context.equipmentTable = await this.#equipmentTable.renderTable(this.document);
+				if (technoSphereMode) {
+					context.technospheresTable = await this.#technospheresTable.renderTable(this.document);
+				}
 				context.treasuresTable = await this.#treasuresTable.renderTable(this.document);
 				context.consumablesTable = await this.#consumablesTable.renderTable(this.document);
-				context.otherItemsTable = await this.#otherItemsTable.renderTable(this.document);
+				context.otherItemsTable = await this.#otherItemsTable.renderTable(this.document, { exclude: technoSphereMode ? ['hoplosphere', 'mnemosphere'] : [] });
 				break;
+			}
 			case 'adversaries':
 				break;
 			case 'settings':
@@ -218,6 +225,7 @@ export class FUPartySheet extends FUActorSheet {
 	async _onFirstRender(context, options) {
 		await super._onFirstRender(context, options);
 		this.#equipmentTable.activateListeners(this);
+		this.#technospheresTable.activateListeners(this);
 		this.#treasuresTable.activateListeners(this);
 		this.#consumablesTable.activateListeners(this);
 		this.#otherItemsTable.activateListeners(this);

--- a/module/sheets/actor-stash-sheet.mjs
+++ b/module/sheets/actor-stash-sheet.mjs
@@ -7,6 +7,9 @@ import { TreasuresTableRenderer } from '../helpers/tables/treasures-table-render
 import { ConsumablesTableRenderer } from '../helpers/tables/consumables-table-renderer.mjs';
 import { OtherItemsTableRenderer } from '../helpers/tables/other-items-table-renderer.mjs';
 import { getPrioritizedUserTargeted } from '../helpers/target-handler.mjs';
+import { TechnospheresTableRenderer } from '../helpers/tables/technospheres-table-renderer.mjs';
+import { SYSTEM } from '../helpers/config.mjs';
+import { SETTINGS } from '../settings.js';
 
 /**
  * @property {FUActor} actor
@@ -47,6 +50,7 @@ export class FUStashSheet extends FUActorSheet {
 	};
 
 	#equipmentTable = new EquipmentTableRenderer();
+	#technospheresTable = new TechnospheresTableRenderer();
 	#treasuresTable = new TreasuresTableRenderer();
 	#consumablesTable = new ConsumablesTableRenderer();
 	#otherItemsTable = new OtherItemsTableRenderer('accessory', 'armor', 'consumable', 'shield', 'treasure', 'weapon');
@@ -65,16 +69,21 @@ export class FUStashSheet extends FUActorSheet {
 	async _prepareContext(options) {
 		const context = await super._prepareContext(options);
 		await ActorSheetUtils.prepareData(context, this);
+		const technoSphereMode = game.settings.get(SYSTEM, SETTINGS.technospheres);
 		context.equipmentTable = await this.#equipmentTable.renderTable(this.document);
+		if (technoSphereMode) {
+			context.technospheresTable = await this.#technospheresTable.renderTable(this.document);
+		}
 		context.treasuresTable = await this.#treasuresTable.renderTable(this.document);
 		context.consumablesTable = await this.#consumablesTable.renderTable(this.document);
-		context.otherItemsTable = await this.#otherItemsTable.renderTable(this.document);
+		context.otherItemsTable = await this.#otherItemsTable.renderTable(this.document, { exclude: technoSphereMode ? ['hoplosphere', 'mnemosphere'] : [] });
 		return context;
 	}
 
 	async _onFirstRender(context, options) {
 		await super._onFirstRender(context, options);
 		this.#equipmentTable.activateListeners(this);
+		this.#technospheresTable.activateListeners(this);
 		this.#treasuresTable.activateListeners(this);
 		this.#consumablesTable.activateListeners(this);
 		this.#otherItemsTable.activateListeners(this);

--- a/templates/actor/sections/actor-section-inventory.hbs
+++ b/templates/actor/sections/actor-section-inventory.hbs
@@ -51,6 +51,8 @@
 
 	{{{equipmentTable}}}
 
+	{{{technospheresTable}}}
+
 	{{{treasuresTable}}}
 
 	{{{consumablesTable}}}


### PR DESCRIPTION
- add bespoke technosphere table to party and stash sheets (when technospheres are enabled)
- fix SkillsTableRenderer throwing an error when the actor cannot equip equipment