### PR TITLE
bugfix: PseudoDocument localization

### DIFF
--- a/module/documents/effects/pseudo-active-effect.mjs
+++ b/module/documents/effects/pseudo-active-effect.mjs
@@ -9,36 +9,36 @@ class BasePseudoActiveEffect extends PseudoDocument {
 	static defineSchema() {
 		const fields = foundry.data.fields;
 		return {
-			_id: new fields.DocumentIdField(),
-			name: new fields.StringField({ initial: () => game.i18n.format('DOCUMENT.New', { type: game.i18n.localize(this.metadata.label) }), required: true, blank: false, label: 'EFFECT.Name', textSearch: true }),
-			img: new fields.FilePathField({ categories: ['IMAGE'], label: 'EFFECT.Image' }),
+			_id: new fields.StringField({ initial: () => foundry.utils.randomID(), validate: foundry.data.validators.isValidId }),
+			name: new fields.StringField({ initial: () => game.i18n.format('DOCUMENT.New', { type: game.i18n.localize(this.metadata.label) }), required: true, blank: false, textSearch: true }),
+			img: new fields.FilePathField({ categories: ['IMAGE'] }),
 			type: new fields.DocumentTypeField(this, { initial: CONST.BASE_DOCUMENT_TYPE }),
 			system: new fields.TypeDataField(this),
 			changes: new fields.ArrayField(
 				new fields.SchemaField({
-					key: new fields.StringField({ required: true, label: 'EFFECT.ChangeKey' }),
-					value: new fields.StringField({ required: true, label: 'EFFECT.ChangeValue' }),
-					mode: new fields.NumberField({ integer: true, initial: CONST.ACTIVE_EFFECT_MODES.ADD, label: 'EFFECT.ChangeMode' }),
+					key: new fields.StringField({ required: true }),
+					value: new fields.StringField({ required: true }),
+					mode: new fields.NumberField({ required: true, nullable: false, integer: true, initial: CONST.ACTIVE_EFFECT_MODES.ADD }),
 					priority: new fields.NumberField(),
 				}),
 			),
 			disabled: new fields.BooleanField(),
 			duration: new fields.SchemaField({
-				startTime: new fields.NumberField({ initial: null, label: 'EFFECT.StartTime' }),
-				seconds: new fields.NumberField({ integer: true, min: 0, label: 'EFFECT.DurationSecs' }),
-				combat: new fields.ForeignDocumentField(foundry.documents.BaseCombat, { label: 'EFFECT.Combat' }),
+				startTime: new fields.NumberField({ initial: null }),
+				seconds: new fields.NumberField({ integer: true, min: 0 }),
+				combat: new fields.ForeignDocumentField(foundry.documents.BaseCombat),
 				rounds: new fields.NumberField({ integer: true, min: 0 }),
-				turns: new fields.NumberField({ integer: true, min: 0, label: 'EFFECT.DurationTurns' }),
+				turns: new fields.NumberField({ integer: true, min: 0 }),
 				startRound: new fields.NumberField({ integer: true, min: 0 }),
-				startTurn: new fields.NumberField({ integer: true, min: 0, label: 'EFFECT.StartTurns' }),
+				startTurn: new fields.NumberField({ integer: true, min: 0 }),
 			}),
-			description: new fields.HTMLField({ label: 'EFFECT.Description', textSearch: true }),
-			origin: new fields.StringField({ nullable: true, blank: false, initial: null, label: 'EFFECT.Origin' }),
-			tint: new fields.ColorField({ nullable: false, initial: '#ffffff', label: 'EFFECT.Tint' }),
-			transfer: new fields.BooleanField({ initial: true, label: 'EFFECT.Transfer' }),
+			description: new fields.HTMLField({ textSearch: true }),
+			origin: new fields.StringField({ nullable: true, blank: false, initial: null }),
+			tint: new fields.ColorField({ nullable: false, initial: '#ffffff' }),
+			transfer: new fields.BooleanField({ initial: true }),
 			statuses: new fields.SetField(new fields.StringField({ required: true, blank: false })),
 			sort: new fields.IntegerSortField(),
-			flags: new fields.ObjectField(),
+			flags: new fields.DocumentFlagsField(),
 		};
 	}
 
@@ -52,6 +52,8 @@ class BasePseudoActiveEffect extends PseudoDocument {
 			{ inplace: false },
 		),
 	);
+
+	static LOCALIZATION_PREFIXES = foundry.documents.ActiveEffect.LOCALIZATION_PREFIXES;
 
 	/**
 	 * Retrieve the Document that this ActiveEffect targets for modification.

--- a/module/documents/items/pseudo-item.mjs
+++ b/module/documents/items/pseudo-item.mjs
@@ -1,28 +1,27 @@
 import { PseudoDocumentCollectionField } from '../pseudo/pseudo-document-collection-field.mjs';
 import { PseudoDocument } from '../pseudo/pseudo-document.mjs';
 import { PseudoActiveEffect } from '../effects/pseudo-active-effect.mjs';
-import { FUItem } from './item.mjs';
 import { ItemBehaviourMixin } from './item-behaviour-mixin.mjs';
 
 class BasePseudoItem extends PseudoDocument {
 	static documentName = 'Item';
 
 	static defineSchema() {
-		const { FilePathField, ObjectField, StringField, IntegerSortField, DocumentTypeField, TypeDataField } = foundry.data.fields;
+		const fields = foundry.data.fields;
 		return {
-			_id: new StringField({ initial: () => foundry.utils.randomID(), validate: foundry.data.validators.isValidId }),
-			name: new StringField({ initial: () => game.i18n.format('DOCUMENT.New', { type: game.i18n.localize(this.metadata.label) }), required: true, blank: false, textSearch: true }),
-			type: new DocumentTypeField(this),
-			img: new FilePathField({
+			_id: new fields.StringField({ initial: () => foundry.utils.randomID(), validate: foundry.data.validators.isValidId }),
+			name: new fields.StringField({ initial: () => game.i18n.format('DOCUMENT.New', { type: game.i18n.localize(this.metadata.label) }), required: true, blank: false, textSearch: true }),
+			type: new fields.DocumentTypeField(this),
+			img: new fields.FilePathField({
 				categories: ['IMAGE'],
 				initial: (data) => {
-					return FUItem.getDefaultArtwork(data).img;
+					return foundry.documents.Item.implementation.getDefaultArtwork(data).img;
 				},
 			}),
-			system: new TypeDataField(this),
+			system: new fields.TypeDataField(this),
 			effects: new PseudoDocumentCollectionField(PseudoActiveEffect),
-			flags: new ObjectField(),
-			sort: new IntegerSortField(),
+			sort: new fields.IntegerSortField(),
+			flags: new fields.DocumentFlagsField(),
 		};
 	}
 

--- a/module/documents/pseudo/pseudo-document.mjs
+++ b/module/documents/pseudo/pseudo-document.mjs
@@ -64,6 +64,8 @@ export class PseudoDocument extends foundry.abstract.DataModel {
 		Object.defineProperty(this, 'nestedCollections', { value: {}, writable: false });
 	}
 
+	static LOCALIZATION_PREFIXES = foundry.abstract.Document.LOCALIZATION_PREFIXES;
+
 	_initialize(options) {
 		super._initialize(options);
 		if (!game._documentsReady) return;

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -94,6 +94,8 @@ import { HoplosphereSheet } from './documents/items/hoplosphere/hoplosphere-shee
 import { MnemosphereReceptacleDataModel } from './documents/items/mnemosphereReceptacle/mnemosphere-receptacle-data-model.mjs';
 import { MnemosphereReceptacleSheet } from './documents/items/mnemosphereReceptacle/mnemosphere-receptacle-sheet.mjs';
 import { FUItemArmorSheet } from './sheets/item-armor-sheet.mjs';
+import { PseudoItem } from './documents/items/pseudo-item.mjs';
+import { PseudoActiveEffect } from './documents/effects/pseudo-active-effect.mjs';
 
 globalThis.projectfu = {
 	ClassFeatureDataModel,
@@ -349,6 +351,14 @@ Hooks.once('init', async () => {
 
 	// Preload Handlebars templates.
 	return preloadHandlebarsTemplates();
+});
+
+const pseudoDocuments = [PseudoItem, PseudoActiveEffect];
+
+Hooks.once('i18nInit', () => {
+	for (const pseudoDocumentClass of pseudoDocuments) {
+		game.i18n.constructor.localizeDataModel(pseudoDocumentClass);
+	}
 });
 
 Hooks.once('setup', () => {});


### PR DESCRIPTION
- run one time localization of PseudoDocument schemas at load, this is similar to what Foundry does for normal Documents
- define localization prefixes for PseudoDocuments
- synchronize PseudoDocument schema definitions with primary Documents