### PR TITLE
bugfix: Ensure meta currency values are parsed as integers in update function

### DIFF
--- a/module/ui/metacurrency/MetaCurrencyTrackerApplication.mjs
+++ b/module/ui/metacurrency/MetaCurrencyTrackerApplication.mjs
@@ -126,12 +126,12 @@ export class MetaCurrencyTrackerApplication extends FUApplication {
 	}
 
 	static async #updateMetaCurrency(event, form, formData) {
-		const fabula = formData.get('fabula');
+		const fabula = parseInt(formData.get('fabula')) || 0;
 		if (game.settings.get(SYSTEM, SETTINGS.metaCurrencyFabula) !== fabula) {
 			game.settings.set(SYSTEM, SETTINGS.metaCurrencyFabula, fabula);
 		}
 
-		const ultima = formData.get('ultima');
+		const ultima = parseInt(formData.get('ultima')) || 0;
 		if (game.settings.get(SYSTEM, SETTINGS.metaCurrencyUltima) !== ultima) {
 			game.settings.set(SYSTEM, SETTINGS.metaCurrencyUltima, ultima);
 		}


### PR DESCRIPTION
Manual modifications to the Metacurrency form cause it to incorrectly format as a string.

This change ensures values from form data are parsed as integers and default to zero if invalid.

### Repo Steps:
Use points
<img width="404" height="281" alt="image" src="https://github.com/user-attachments/assets/1bd44a2b-c0f6-4c80-a53d-7ab28d45a455" />

Change value from `2`
<img width="404" height="283" alt="image" src="https://github.com/user-attachments/assets/92ead551-cd48-4594-b0f6-78d70b47d26c" />
