### PR TITLE
bugfix: Allow setting more than 3 targets

### DIFF
--- a/module/documents/items/common/targeting-data-model.mjs
+++ b/module/documents/items/common/targeting-data-model.mjs
@@ -10,7 +10,7 @@ export class TargetingDataModel extends foundry.abstract.DataModel {
 		const { NumberField, StringField } = foundry.data.fields;
 		return {
 			rule: new StringField({ initial: Targeting.rule.special, choices: Object.keys(Targeting.rule), required: true }),
-			max: new NumberField({ initial: 0, min: 0, max: 3, integer: true, nullable: false }),
+			max: new NumberField({ initial: 0, min: 0, max: 5, integer: true, nullable: false }),
 		};
 	}
 

--- a/templates/item/partials/item-targeting.hbs
+++ b/templates/item/partials/item-targeting.hbs
@@ -14,8 +14,7 @@
             <div class="resource-content flexcol flex-group-center">
                 <label class="resource-label-m">{{localize 'FU.MaxTargets'}}</label>
                 <input type="number" name="system.targeting.max"
-                       value="{{ system.targeting.max }}" class="resource-inputs"
-                       data-dtype="Number" />
+                       value="{{ system.targeting.max }}" max="5" class="resource-inputs" />
             </div>
         {{/if}}
     </div>


### PR DESCRIPTION
- adjust TargetingDataModel to allow up to 5 targets in "multiple" mode
  - the new maximum of 5 was chosen because we have existing translation keys up to 5 targets