### PR TITLE
bugfix: Pilot module class features break NPC sheet

### DIFF
--- a/module/documents/items/classFeature/pilot/armor-module-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/armor-module-data-model.mjs
@@ -68,7 +68,7 @@ export class ArmorModuleDataModel extends RollableClassFeatureDataModel {
 	}
 
 	transferEffects() {
-		return this.actor.system.vehicle.embarked && this.actor.system.vehicle.armor === this.item;
+		return this.actor.system.vehicle?.embarked && this.actor.system.vehicle.armor === this.item;
 	}
 
 	static async roll(model, item) {

--- a/module/documents/items/classFeature/pilot/support-module-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/support-module-data-model.mjs
@@ -36,6 +36,6 @@ export class SupportModuleDataModel extends ClassFeatureDataModel {
 	}
 
 	transferEffects() {
-		return this.actor.system.vehicle.embarked && this.actor.system.vehicle.supports.includes(this.item);
+		return this.actor.system.vehicle?.embarked && this.actor.system.vehicle.supports.includes(this.item);
 	}
 }

--- a/module/documents/items/classFeature/pilot/weapon-module-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/weapon-module-data-model.mjs
@@ -174,6 +174,6 @@ export class WeaponModuleDataModel extends RollableClassFeatureDataModel {
 	}
 
 	transferEffects() {
-		return this.actor.system.vehicle.embarked && this.actor.system.vehicle.weapons.includes(this.item);
+		return this.actor.system.vehicle?.embarked && this.actor.system.vehicle.weapons.includes(this.item);
 	}
 }


### PR DESCRIPTION
- fix pilot module 'transferEffects' implementation for NPC actors

I checked the other implementations of `tranferEffect` as well, they are okay.