### PR TITLE
bugfix: Multiple Technosphere slots issues

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1534,6 +1534,7 @@
 		"Technospheres": "Technospheres",
 		"TechnospheresSlots": "Slots",
 		"TechnospheresSlotEmpty": "Empty slot",
+		"TechnospheresSlotOverCapacity": "Over capacity.",
 		"TechnosphereRemove": "Remove Technosphere",
 		"TechnospheresSlotsAlpha": "Slots α",
 		"TechnospheresSlotsBeta": "Slots β",

--- a/module/helpers/technospheres.mjs
+++ b/module/helpers/technospheres.mjs
@@ -61,7 +61,7 @@ export const getTechnosphereSlotInfo = (slottedTechnospheres, totalSlots, maxMne
 			}
 		}
 
-		if (unusedMnemosphereSlots && (!currentSlot.item || unusedSlots === unusedMnemosphereSlots)) {
+		if (unusedMnemosphereSlots > 0 && (!currentSlot.item || unusedSlots === unusedMnemosphereSlots)) {
 			currentSlot.type = 'mnemosphere';
 			unusedMnemosphereSlots--;
 		}

--- a/styles/css/components/table/description-with-slots.css
+++ b/styles/css/components/table/description-with-slots.css
@@ -33,6 +33,11 @@
 		line-height: 0;
 		width: max-content;
 		cursor: default;
+
+		display: grid;
+		grid-template-columns: repeat(5, min-content);
+		--pfu-technosphere-slot-spacing: 1px;
+		gap: var(--pfu-technosphere-slot-spacing);
 	}
 
 	.description-with-slots__slot {

--- a/templates/item/partials/technosphere-slots.hbs
+++ b/templates/item/partials/technosphere-slots.hbs
@@ -7,7 +7,7 @@
 		 	{{#if slot.occupied}} technosphere-slots__slot--occupied {{/if}}
 		 	{{#if (eq slot.type "mnemosphere")}} technosphere-slots__slot--mnemosphere {{else}} technosphere-slots__slot--hoplosphere {{/if}}"
 			{{#if slot.item}}data-item-id="{{ slot.item.id }}" data-uuid="{{ slot.item.uuid }}"{{/if}}
-			{{#if slot.overCapacity}}data-tooltip="{{localize "FU.TechnospheresOverCapacity"}}"{{/if}}
+			{{#if slot.overCapacity}}data-tooltip="{{localize "FU.TechnospheresSlotOverCapacity"}}"{{/if}}
 		>
 			{{#if slot.item}}
 				<span class="technosphere-slots__slot-image">
@@ -30,7 +30,7 @@
 				</span>
 			{{else if slot.occupied}}
 				<span class="technosphere-slots__slot-image"></span>
-				<span>{{localize "FU.HoplosphereRequiresTwoSlots"}}</span>
+				<span>{{localize "FU.HoplosphereTooltipRequiresTwoSlots"}}</span>
 			{{else}}
 				<span class="technosphere-slots__slot-image"></span>
 				<span>{{localize "FU.TechnospheresSlotEmpty"}}</span>

--- a/templates/table/expand/expand-item-description-with-slots.hbs
+++ b/templates/table/expand/expand-item-description-with-slots.hbs
@@ -28,7 +28,7 @@
 					   data-technosphere-id="{{ slot.item.id }}"
 					   data-technosphere-uuid="{{ slot.item.uuid }}"
 					   data-action="technosphere"
-					   data-tooltip="{{{ slot.tooltip }}}{{#if slot.overCapacity}}<br/>{{localize "FU.TechnospheresOverCapacity"}}{{/if}}"
+					   data-tooltip="{{#if slot.overCapacity}}{{localize "FU.TechnospheresSlotOverCapacity"}}<br/><br/>{{/if}}{{{ slot.tooltip }}}"
 					>
 						<img class="description-with-slots__item-icon" src="{{slot.item.img}}"
 							 alt="{{slot.item.name}}">
@@ -40,9 +40,9 @@
 						{{~#if (eq slot.type "mnemosphere")}} description-with-slots__slot--mnemosphere {{else}} description-with-slots__slot--hoplosphere {{/if~}}"
 						{{~#if (or slot.occupied slot.overCapacity)}}
 						  data-tooltip="
-							  {{~#if slot.occupied}}{{localize "FU.HoplosphereRequiresTwoSlots"}}{{/if~}}
+							  {{~#if slot.overCapacity}}{{localize "FU.TechnospheresSlotOverCapacity"}}{{/if~}}
 							  {{#if (and slot.overCapacity slot.occupied)}}<br/>{{/if}}
-							  {{~#if slot.overCapacity}}{{localize "FU.TechnospheresOverCapacity"}}{{/if~}}
+							  {{~#if slot.occupied}}{{localize "FU.HoplosphereTooltipRequiresTwoSlots"}}{{/if~}}
 							"
 						{{~/if}}
 					>


### PR DESCRIPTION
- fix wrong technosphere slot colors when more than the max number of allowed hoplospheres is socketed
- fix unlocalized tooltips
- allow technosphere slots in tables to gracefully break into a new row for 6+ used slots
- put "over capacity" warning at the top of tooltips for added emphasis