### PR TITLE
bugfix: CombatHUD button issues

### DIFF
--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -810,7 +810,18 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 		const actorTypeOver = combatRowOver.dataset.type;
 
 		const actualEvent = event.originalEvent ?? event;
-		const data = JSON.parse(actualEvent.dataTransfer.getData('text/plain'));
+		const rawData = actualEvent.dataTransfer.getData('text/plain');
+
+		if (!rawData) return;
+
+		let data;
+		try {
+			data = JSON.parse(rawData);
+		} catch (error) {
+			console.warn('Combat HUD: Invalid JSON data in drop event', error);
+			return;
+		}
+
 		const actorTypeDragged = data.type;
 
 		if (actorTypeOver !== actorTypeDragged) {

--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -911,9 +911,12 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 		if (typeof PopoutModule !== 'undefined' && PopoutModule.singleton) {
 			ui.windows[this.appId] = this;
 			this._poppedOut = true;
-			this.element.find('.window-popout').css('display', 'none');
-			this.element.find('.window-compact').css('display', 'none');
-			this.element.find('.window-minimize').css('display', 'none');
+			const popoutButton = this.element.querySelector('.window-popout');
+			const compactButton = this.element.querySelector('.window-compact');
+			const minimizeButton = this.element.querySelector('.window-minimize');
+			if (popoutButton) popoutButton.style.display = 'none';
+			if (compactButton) compactButton.style.display = 'none';
+			if (minimizeButton) minimizeButton.style.display = 'none';
 			PopoutModule.singleton.onPopoutClicked(this);
 		} else {
 			ui.notifications.warn('FU.CombatHudPopoutNotInstalled', { localize: true });


### PR DESCRIPTION
  - Refactored drag position calculations to use initial mouse coordinates and element positions - Fixes the position jumping bug
  - Empty data check + try/catch - Fixes the JSON.parse crash
  - `_doDragOver` implementation with preventDefault() - Required for HTML5 drag/drop to work
  - Dragover event listener wiring - Required for drops to work
  - popout functionality was using jQuery methods that don't exist in ApplicationV2