### PR TITLE
bugfix: Unable to give name to Rule clocks

### DIFF
--- a/module/documents/items/ritual/ritual-data-model.mjs
+++ b/module/documents/items/ritual/ritual-data-model.mjs
@@ -151,6 +151,12 @@ export class RitualDataModel extends FUStandardItemDataModel {
 		(this.dLevel ??= {}).value = potency.difficulty;
 		(this.clock ??= {}).value = potency.clock;
 		this.progress.max = potency.clock;
+
+		foundry.utils.setProperty(this.parent.overrides, 'system.progress.max', this.progress.max);
+	}
+
+	afterApplyActiveEffects() {
+		foundry.utils.setProperty(this.parent.overrides, 'system.progress.max', this.progress.max);
 	}
 
 	async _preUpdate(changes, options, user) {

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -195,9 +195,8 @@ const progressStyleTemplates = Object.freeze({
  * @returns {String}
  */
 function progress(document, path, options) {
-	const id = document._id;
 	const progress = foundry.utils.getProperty(document, path);
-	return renderProgress(progress, id, path, options.hash);
+	return renderProgress(progress, document, path, options.hash);
 }
 
 /**
@@ -208,21 +207,20 @@ function progress(document, path, options) {
  * @returns {String}
  */
 function progressCollection(document, path, index, options) {
-	const id = document._id;
 	const array = ObjectUtils.getProperty(document, path);
 	const progress = array[index];
-	return renderProgress(progress, id, path, options.hash, index);
+	return renderProgress(progress, document, path, options.hash, index);
 }
 
 /**
  * @param {ProgressDataModel} progress
- * @param {String} id The id of the document
+ * @param {FUActor, FUItem} document The document
  * @param {String} path The path of the property
  * @param {int} index Optionally, the index of the data model inside an array
  * @param {ProgressHandlebarOptions} options
  * @returns {String}
  */
-function renderProgress(progress, id, path, options, index = undefined) {
+function renderProgress(progress, document, path, options, index = undefined) {
 	const type = options.type;
 	const style = options.style ?? progress.style ?? 'clock';
 	const action = options.action ?? 'updateTrack';
@@ -234,7 +232,7 @@ function renderProgress(progress, id, path, options, index = undefined) {
 		typeof template === 'function'
 			? template({
 					arr: progress.progressArray,
-					id: id,
+					id: document._id,
 					index: index,
 					isCollection: index !== undefined,
 					data: progress,
@@ -243,7 +241,7 @@ function renderProgress(progress, id, path, options, index = undefined) {
 					controls: controls,
 					action: action,
 					prompt: options.prompt,
-					displayName: options.displayName && (progress.name || id.name),
+					displayName: options.displayName && (progress.name || document.name),
 				})
 			: '';
 

--- a/templates/item/partials/item-progress-field.hbs
+++ b/templates/item/partials/item-progress-field.hbs
@@ -5,21 +5,30 @@
 			<label class="resource-label-m">{{localize 'FU.Clock'}}</label>
 		</legend>
 		<div class="grid grid-3col">
-			<div class="resource-content flexcol flex-group-center">
-				<label class="resource-label-m">{{localize 'FU.Current'}}</label>
+
+			<label class="resource-label-m resource-content flexcol flex-group-center grid-span-3">
+				{{localize 'FU.Name'}}
+				<input type="text" name="system.progress.name" value="{{ system.progress.name }}"
+					   class="resource-inputs select-dropdown-full" />
+			</label>
+
+			<label class="resource-label-m resource-content flexcol flex-group-center">
+				{{localize 'FU.Current'}}
 				<input type="number" name="system.progress.current" value="{{ system.progress.current }}"
-					   max="{{ system.progress.max }}" class="resource-inputs select-dropdown-m" />
-			</div>
-			<div class="resource-content flexcol flex-group-center">
-				<label class="resource-label-m">{{localize 'FU.Step'}}</label>
+					   min="0" max="{{ system.progress.max }}" class="resource-inputs select-dropdown-m" />
+			</label>
+
+			<label class="resource-label-m resource-content flexcol flex-group-center">
+				{{localize 'FU.Step'}}
 				<input type="number" name="system.progress.step" value="{{ system.progress.step }}"
-					   class="resource-inputs select-dropdown-m" />
-			</div>
-			<div class="resource-content flexcol flex-group-center">
-				<label class="resource-label-m">{{localize 'FU.Max'}}</label>
-				<input type="number" value="{{ system.progress.max }}" class="resource-inputs select-dropdown-m"
-					   disabled>
-			</div>
+					   min="1" max="{{ system.progress.max }}" class="resource-inputs select-dropdown-m" />
+			</label>
+
+			<label class="resource-label-m resource-content flexcol flex-group-center">
+				{{localize 'FU.Max'}}
+				<input type="number" name="system.progress.max" value="{{ system.progress.max }}"
+					   min="2" class="resource-inputs select-dropdown-m">
+			</label>
 		</div>
 	</fieldset>
 {{/if}}


### PR DESCRIPTION
- add name field to item-progress-field.hbs
- make "max progress" field editable in item-progress-field.hbs
- fix pfuProgress helper so it properly defaults to the document name when no name for the progress track is set
- work around ritual clock size being fixed and thus not editable by pretending it is overridden by an active effect
- fixes #601