### PR TITLE
Clear Token Movement History

### DIFF
--- a/module/ui/combat.mjs
+++ b/module/ui/combat.mjs
@@ -322,6 +322,7 @@ export class FUCombat extends foundry.documents.Combat {
 			const turns = this.combatants.contents.sort(this._sortCombatants);
 			if (this.turn !== null) this.turn = Math.clamp(this.turn, 0, turns.length - 1);
 			this.current = this._getCurrentState(combatant);
+
 			// Notify
 			this.setupTurns();
 			this.notifyCombatTurnChange();
@@ -334,6 +335,7 @@ export class FUCombat extends foundry.documents.Combat {
 			}
 		}
 
+		await combatant.clearMovementHistory();
 		await this._onStartTurn(combatant);
 	}
 
@@ -372,6 +374,8 @@ export class FUCombat extends foundry.documents.Combat {
 				// TODO: Inform user?
 			}
 		}
+
+		await combatant.clearMovementHistory();
 	}
 
 	/**


### PR DESCRIPTION
Adds call to `combatant.clearMovementHistory()` in the start and end turn handlers to bring them in line with default Foundry behavior

Cause this gets really really cluttered if you don't.

<img width="493" height="378" alt="image" src="https://github.com/user-attachments/assets/e5fb4176-aa33-4fc6-a2f6-f30d4191a498" />
