### PR TITLE
Fix: Crisis Multiplier Settings

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Spells deal {amount} extra damage.",
 		"HoplosphereEffectFreeText": "Free Text",
 		"HoplosphereEffectFreeTextDefaultName": "Effect Name",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Zauber verursachen {amount} Bonusschaden.",
 		"HoplosphereEffectFreeText": "Freitext",
 		"HoplosphereEffectFreeTextDefaultName": "Effektname",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Spells deal {amount} extra damage.",
 		"HoplosphereEffectFreeText": "Free Text",
 		"HoplosphereEffectFreeTextDefaultName": "Effect Name",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Spells deal {amount} extra damage.",
 		"HoplosphereEffectFreeText": "Free Text",
 		"HoplosphereEffectFreeTextDefaultName": "Effect Name",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Les sorts infligent {amount} dégâts supplémentaires.",
 		"HoplosphereEffectFreeText": "Texte libre",
 		"HoplosphereEffectFreeTextDefaultName": "Nom d'effet",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Gli incantesimi infliggono {amount} danni extra.",
 		"HoplosphereEffectFreeText": "Testo libero",
 		"HoplosphereEffectFreeTextDefaultName": "Nome effetto",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Spells deal {amount} extra damage.",
 		"HoplosphereEffectFreeText": "Free Text",
 		"HoplosphereEffectFreeTextDefaultName": "Effect Name",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Os feitiços causam {amount} de dano extra.",
 		"HoplosphereEffectFreeText": "Texto Livre",
 		"HoplosphereEffectFreeTextDefaultName": "Nome do Efeito",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "ID Fabula Ultima",
 			"Short": "FUID",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1577,6 +1577,8 @@
 		"HoplosphereEffectIncreaseSpellDamageSummary": "Spells deal {amount} extra damage.",
 		"HoplosphereEffectFreeText": "Free Text",
 		"HoplosphereEffectFreeTextDefaultName": "Effect Name",
+		"CrisisMultiplier": "Crisis Multiplier",
+		"CrisisMultiplierHint": "Multiplier used to calculate base Crisis Score",
 		"FUID": {
 			"Long": "Fabula Ultima ID",
 			"Short": "FUID",

--- a/module/settings.js
+++ b/module/settings.js
@@ -844,7 +844,7 @@ export const registerSystemSettings = async function () {
 		name: 'FU.CrisisMultiplier',
 		hint: 'FU.CrisisMultiplierHint',
 		scope: 'world',
-		config: true,
+		config: false,
 		type: Number,
 		default: 0.5,
 		requiresReload: false,


### PR DESCRIPTION
- Added multiplier setting localization
- Set `config` to false for `optionCrisisMultiplier` to suppress it from main settings app
(woops)