### PR TITLE
Combat HUD settings user scope

### DIFF
--- a/module/settings.js
+++ b/module/settings.js
@@ -304,7 +304,7 @@ export const registerSystemSettings = async function () {
 		name: game.i18n.localize('FU.ExperimentalCombatHudSettings'),
 		hint: game.i18n.localize('FU.ExperimentalCombatHudSettingsHint'),
 		label: game.i18n.localize('FU.ExperimentalCombatHudSettingsLabel'),
-		scope: 'client',
+		scope: 'user',
 		icon: 'fas fa-book',
 		type: CombatHudSettings,
 	});
@@ -312,7 +312,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.experimentalCombatHud, {
 		name: game.i18n.localize('FU.ExperimentalCombatHud'),
 		hint: game.i18n.localize('FU.ExperimentalCombatHudHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Boolean,
 		default: false,
@@ -322,7 +322,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudOpacity, {
 		name: game.i18n.localize('FU.CombatHudOpacity'),
 		hint: game.i18n.localize('FU.CombatHudOpacityHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Number,
 		default: 100,
@@ -332,7 +332,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudWidth, {
 		name: game.i18n.localize('FU.CombatHudWidth'),
 		hint: game.i18n.localize('FU.CombatHudWidthHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Number,
 		default: 100,
@@ -342,7 +342,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudPositionButton, {
 		name: game.i18n.localize('FU.CombatHudPositionButton'),
 		hint: game.i18n.localize('FU.CombatHudPositionButtonHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: String,
 		default: 'top',
@@ -356,7 +356,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudPosition, {
 		name: game.i18n.localize('FU.CombatHudPosition'),
 		hint: game.i18n.localize('FU.CombatHudPositionHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: String,
 		default: 'bottom',
@@ -370,7 +370,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudPortrait, {
 		name: game.i18n.localize('FU.CombatHudPortrait'),
 		hint: game.i18n.localize('FU.CombatHudPortraitHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: String,
 		default: 'actor',
@@ -383,7 +383,7 @@ export const registerSystemSettings = async function () {
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudCompact, {
 		name: 'CombatHudCompact',
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Boolean,
 		default: false,
@@ -391,7 +391,7 @@ export const registerSystemSettings = async function () {
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudMinimized, {
 		name: 'CombatHudMinimized',
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Boolean,
 		default: false,
@@ -399,7 +399,7 @@ export const registerSystemSettings = async function () {
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudSaved, {
 		name: 'CombatHudSaved',
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Boolean,
 		default: false,
@@ -408,7 +408,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudShowEffects, {
 		name: game.i18n.localize('FU.CombatHudShowEffects'),
 		hint: game.i18n.localize('FU.CombatHudShowEffectsHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Boolean,
 		default: true,
@@ -417,7 +417,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudEffectsMarqueeDuration, {
 		name: game.i18n.localize('FU.CombatHudEffectsMarqueeDuration'),
 		hint: game.i18n.localize('FU.CombatHudEffectsMarqueeDurationHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Number,
 		default: 15,
@@ -426,7 +426,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudEffectsMarqueeMode, {
 		name: game.i18n.localize('FU.CombatHudEffectsMarqueeMode'),
 		hint: game.i18n.localize('FU.CombatHudEffectsMarqueeModeHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: String,
 		default: 'alternate',
@@ -449,7 +449,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudShowOrderNumbers, {
 		name: game.i18n.localize('FU.CombatHudShowOrderNumbers'),
 		hint: game.i18n.localize('FU.CombatHudShowOrderNumbersHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Boolean,
 		default: false,
@@ -471,7 +471,7 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudDraggedPosition, {
 		name: game.i18n.localize('FU.CombatHudDraggedPosition'),
 		hint: game.i18n.localize('FU.CombatHudDraggedPositionHint'),
-		scope: 'client',
+		scope: 'user',
 		config: false,
 		type: Object,
 		default: {},

--- a/module/settings.js
+++ b/module/settings.js
@@ -102,18 +102,18 @@ export const SETTINGS = Object.freeze({
  * @param {any} def - Default value to return
  * @returns
  */
-function getClientSetting(setting, def) {
+function getClientSetting(setting, defaultValue) {
 	const val = game.settings.storage.get('client')[`${SYSTEM}.${setting}`];
 
 	// If this setting was never set in the client scope, it will be undefined,
 	// which JSON.parse will fail to parse
-	if (val === undefined) return def;
+	if (val === undefined) return defaultValue;
 
 	try {
-		return JSON.parse(val ?? def);
+		return JSON.parse(val ?? defaultValue);
 	} catch (err) {
 		console.warn(`Unable to parse client setting!  Setting:`, setting, `Value:`, val);
-		return def;
+		return defaultValue;
 	}
 }
 

--- a/module/settings.js
+++ b/module/settings.js
@@ -99,7 +99,7 @@ export const SETTINGS = Object.freeze({
  * Used for the defaults for some user scope settings later, to migrate
  * them to user scope.
  * @param {string} setting - Key for the setting to retrieve
- * @param {any} def - Default value to return
+ * @param {any} defaultValue - Default value to return
  * @returns
  */
 function getClientSetting(setting, defaultValue) {

--- a/module/settings.js
+++ b/module/settings.js
@@ -95,6 +95,29 @@ export const SETTINGS = Object.freeze({
 });
 
 /**
+ * Attempts to retrieve a setting from the client scope specifically
+ * Used for the defaults for some user scope settings later, to migrate
+ * them to user scope.
+ * @param {string} setting - Key for the setting to retrieve
+ * @param {any} def - Default value to return
+ * @returns
+ */
+function getClientSetting(setting, def) {
+	const val = game.settings.storage.get('client')[`${SYSTEM}.${setting}`];
+
+	// If this setting was never set in the client scope, it will be undefined,
+	// which JSON.parse will fail to parse
+	if (val === undefined) return def;
+
+	try {
+		return JSON.parse(val ?? def);
+	} catch (err) {
+		console.warn(`Unable to parse client setting!  Setting:`, setting, `Value:`, val);
+		return def;
+	}
+}
+
+/**
  * @description Uses {@link https://foundryvtt.com/api/classes/client.ClientSettings.html#registerMenu}
  * @returns {Promise<void>}
  */
@@ -309,13 +332,19 @@ export const registerSystemSettings = async function () {
 		type: CombatHudSettings,
 	});
 
+	/**
+	 * The combat HUD options have been migrated from the client scope to user scope
+	 * In order to maintain backwards compatibility with the previous client-scoped settings,
+	 * the default values check for a key in localStorage, to bring old settings forward
+	 */
+
 	game.settings.register(SYSTEM, SETTINGS.experimentalCombatHud, {
 		name: game.i18n.localize('FU.ExperimentalCombatHud'),
 		hint: game.i18n.localize('FU.ExperimentalCombatHudHint'),
 		scope: 'user',
 		config: false,
 		type: Boolean,
-		default: false,
+		default: getClientSetting(SETTINGS.experimentalCombatHud, false),
 		requiresReload: true,
 	});
 
@@ -325,7 +354,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Number,
-		default: 100,
+		default: getClientSetting(SETTINGS.optionCombatHudOpacity, 100),
 		requiresReload: true,
 	});
 
@@ -335,7 +364,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Number,
-		default: 100,
+		default: getClientSetting(SETTINGS.optionCombatHudWidth, 100),
 		requiresReload: true,
 	});
 
@@ -345,7 +374,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: String,
-		default: 'top',
+		default: getClientSetting(SETTINGS.optionCombatHudPositionButton, 'top'),
 		choices: {
 			top: game.i18n.localize('FU.CombatHudPositionButtonTop'),
 			bottom: game.i18n.localize('FU.CombatHudPositionButtonBottom'),
@@ -359,7 +388,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: String,
-		default: 'bottom',
+		default: getClientSetting(SETTINGS.optionCombatHudPosition, 'bottom'),
 		choices: {
 			bottom: game.i18n.localize('FU.CombatHudPositionBottom'),
 			top: game.i18n.localize('FU.CombatHudPositionTop'),
@@ -373,7 +402,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: String,
-		default: 'actor',
+		default: getClientSetting(SETTINGS.optionCombatHudPortrait, 'actor'),
 		choices: {
 			actor: game.i18n.localize('FU.CombatHudPortraitActor'),
 			token: game.i18n.localize('FU.CombatHudPortraitToken'),
@@ -386,7 +415,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Boolean,
-		default: false,
+		default: getClientSetting(SETTINGS.optionCombatHudCompact, false),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudMinimized, {
@@ -394,7 +423,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Boolean,
-		default: false,
+		default: getClientSetting(SETTINGS.optionCombatHudMinimized, false),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudSaved, {
@@ -402,7 +431,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Boolean,
-		default: false,
+		default: getClientSetting(SETTINGS.optionCombatHudSaved, false),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudShowEffects, {
@@ -411,7 +440,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Boolean,
-		default: true,
+		default: getClientSetting(SETTINGS.optionCombatHudShowEffects, true),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudEffectsMarqueeDuration, {
@@ -420,7 +449,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Number,
-		default: 15,
+		default: getClientSetting(SETTINGS.optionCombatHudEffectsMarqueeDuration, 15),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudEffectsMarqueeMode, {
@@ -429,7 +458,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: String,
-		default: 'alternate',
+		default: getClientSetting(SETTINGS.optionCombatHudEffectsMarqueeMode, 'alternate'),
 		choices: {
 			normal: game.i18n.localize('FU.CombatHudEffectsMarqueeModeNormal'),
 			alternate: game.i18n.localize('FU.CombatHudEffectsMarqueeModeAlternate'),
@@ -452,7 +481,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Boolean,
-		default: false,
+		default: getClientSetting(SETTINGS.optionCombatHudShowOrderNumbers, false),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionCombatHudActorOrdering, {
@@ -474,7 +503,7 @@ export const registerSystemSettings = async function () {
 		scope: 'user',
 		config: false,
 		type: Object,
-		default: {},
+		default: getClientSetting(SETTINGS.optionCombatHudDraggedPosition, {}),
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.metaCurrencyFabula, {


### PR DESCRIPTION
v13 introduced a `user` scope for settings, separate from the `client` scope.
Many of the currently `client`-scoped system settings are either intended to be or are expected to be per *user* rather than per *device*.

This PR moves the combat HUD settings to the `user` scope, while setting their default values to the value of the same setting from the `client` scope, if set, or the usual static value.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f31ea975-a931-46c2-b1f0-097aaa710ce3" />
