### PR TITLE
Update default / accuracy check rendering

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1235,6 +1235,7 @@
 		"ClassFeatureWeaponModuleWeaponType": "Type",
 		"ClassFeatureWeaponModuleWeaponCategory": "Category",
 		"ClassFeatureWeaponModuleComplex": "Complex Module",
+		"DifficultyLevelAbbr": "DL",
 		"ModAbbr": "MOD",
 		"Modifier": "Modifier",
 		"Martial": "Martial",

--- a/module/checks/check-prompt.mjs
+++ b/module/checks/check-prompt.mjs
@@ -191,7 +191,9 @@ async function promptForConfiguration(actor, type, initialConfig = {}) {
 	);
 
 	let context = {
+		actor: actor,
 		type: type,
+		typeLabel: StringUtils.localize(FU.checkTypes[type]),
 		attributes: FU.attributes,
 		attributeAbbr: FU.attributeAbbreviations,
 		attributeValues: attributeValues,
@@ -207,8 +209,9 @@ async function promptForConfiguration(actor, type, initialConfig = {}) {
 		bonus: actor.system.bonuses.accuracy.openCheck,
 	};
 
+	const title = initialConfig.title ?? FU.checkTypes[type];
 	const result = await foundry.applications.api.DialogV2.input({
-		window: { title: game.i18n.localize('FU.DialogCheckTitle') },
+		window: { title: game.i18n.localize(title) },
 		classes: ['projectfu', 'unique-dialog', 'backgroundstyle'],
 		actions: {
 			setDifficulty: onSetDifficulty,
@@ -249,11 +252,22 @@ async function promptForConfigurationV2(document, type, initialConfig, actors = 
 		}
 	});
 
+	const attributeValues = Object.entries(document.system.attributes).reduce(
+		(previousValue, [attribute, { current }]) => ({
+			...previousValue,
+			[attribute]: current,
+		}),
+		{},
+	);
+
 	let context = {
+		actor: document,
 		type: type,
+		typeLabel: StringUtils.localize(FU.checkTypes[type]),
 		label: initialConfig.label,
 		increment: initialConfig.increment !== undefined,
 		attributes: FU.attributes,
+		attributeValues: attributeValues,
 		attributeAbbr: FU.attributeAbbreviations,
 		attributeOptions: FoundryUtils.generateConfigIconOptions(Object.keys(FU.attributes), FU.attributes, FU.attributeIcons),
 		attributeIcons: FU.attributeIcons,
@@ -263,7 +277,6 @@ async function promptForConfigurationV2(document, type, initialConfig, actors = 
 		difficulty: recentCheck.difficulty,
 		supportDifficulty: recentCheck.supportDifficulty,
 		bonus: 0,
-		actors: actors,
 	};
 
 	switch (type) {
@@ -282,7 +295,7 @@ async function promptForConfigurationV2(document, type, initialConfig, actors = 
 			break;
 	}
 
-	let title = initialConfig.title ?? FU.checkTypes[type];
+	const title = initialConfig.title ?? FU.checkTypes[type];
 	const result = await foundry.applications.api.DialogV2.input({
 		window: { title: game.i18n.localize(title) },
 		classes: ['projectfu', 'unique-dialog', 'backgroundstyle'],
@@ -451,7 +464,7 @@ async function groupCheck(actor, options = {}) {
  * @returns {Promise<void>}
  */
 async function ritualCheck(actor, item, options = {}) {
-	const promptResult = await promptForConfigurationV2(actor, 'ritual', options, [actor]);
+	const promptResult = await promptForConfigurationV2(actor, 'ritual', options);
 	if (promptResult) {
 		return Checks.ritualCheck(actor, item, (check, callbackActor, item) => {
 			const config = CheckConfiguration.configure(check);

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -252,7 +252,7 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 						damage: damageData,
 						translation: {
 							damageTypes: FU.damageTypes,
-							damageIcon: FU.affIcon,
+							damageIcon: FU.affinityIcons,
 						},
 					},
 				});

--- a/module/documents/effects/triggers/render-check-rule-trigger.mjs
+++ b/module/documents/effects/triggers/render-check-rule-trigger.mjs
@@ -62,8 +62,8 @@ export class RenderCheckRuleTrigger extends RuleTriggerDataModel {
 
 		// If this RE is on an item, and it doesn't match the item in the event.
 		if (this.local && context.item) {
-			if (context.event.sourceInfo.itemUuid === context.sourceInfo.itemUuid) {
-				return true;
+			if (context.event.sourceInfo.itemUuid !== context.sourceInfo.itemUuid) {
+				return false;
 			}
 		}
 

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -83,6 +83,7 @@ FU.damageTypes = {
 /**
  * @typedef {"physical","air","bolt","dark","earth","fire","ice","light","poison"} AffIcon
  */
+
 /**
  * @type {Object<DamageType, string>}
  */
@@ -99,6 +100,29 @@ FU.affIcon = {
 	untyped: 'fua fu-untyped',
 };
 
+/**
+ * @type {Object<DamageType, string>}
+ * @remarks Since the original `affIcon` includes a prestyle.
+ */
+FU.affinityIcons = {
+	physical: 'fu-physical',
+	air: 'fu-air',
+	bolt: 'fu-bolt',
+	dark: 'fu-dark',
+	earth: 'fu-earth',
+	fire: 'fu-fire',
+	ice: 'fu-ice',
+	light: 'fu-light',
+	poison: 'fu-poison',
+	untyped: 'fu-untyped',
+};
+
+FU.checkIcons = {
+	accuracy: 'ra ra-targeted',
+	magic: '',
+	damage: '',
+};
+
 FU.allIcon = {
 	offensive: 'is-offensive',
 	martial: 'is-martial',
@@ -112,17 +136,14 @@ FU.allIcon = {
 	club: 'is-club',
 	heart: 'is-heart',
 	spade: 'is-spade',
-	physical: 'fua fu-physical',
-	air: 'fua fu-wind',
-	bolt: 'fua fu-bolt',
-	dark: 'fua fu-dark',
-	earth: 'fua fu-earth',
-	fire: 'fua fu-fire',
-	ice: 'fua fu-ice',
-	light: 'fua fu-light',
-	poison: 'fua fu-poison',
 	weaponEnchant: 'fu-weapon-enchant',
 	roll: 'fas fa-dice',
+	mod: 'fas fa-plus-minus ',
+	hr: 'ra ra-dice-six',
+	difficulty: 'ra ra-dice-six',
+	...FU.checkIcons,
+	...FU.affinityIcons,
+	...FU.attributeIcons,
 };
 
 FU.affType = {

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -121,6 +121,9 @@ FU.checkIcons = {
 	accuracy: 'ra ra-targeted',
 	magic: '',
 	damage: '',
+	difficulty: 'ra ra-perspective-dice-random',
+	mod: 'fas fa-plus-minus',
+	hr: 'ra  ra-perspective-dice-six',
 };
 
 FU.allIcon = {
@@ -138,9 +141,6 @@ FU.allIcon = {
 	spade: 'is-spade',
 	weaponEnchant: 'fu-weapon-enchant',
 	roll: 'fas fa-dice',
-	mod: 'fas fa-plus-minus ',
-	hr: 'ra ra-dice-six',
-	difficulty: 'ra ra-dice-six',
 	...FU.checkIcons,
 	...FU.affinityIcons,
 	...FU.attributeIcons,

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -161,6 +161,7 @@ export const FUHandlebars = Object.freeze({
 		Handlebars.registerHelper('pfuAutoComplete', autoComplete);
 		Handlebars.registerHelper('pfuTraits', traits);
 		Handlebars.registerHelper('pfuIconAttribute', attributeIcon);
+		Handlebars.registerHelper('pfuBadge', badge);
 	},
 });
 
@@ -281,33 +282,42 @@ function traits(model, path, options) {
 }
 
 /**
- * @typedef {"compact"} AttributeIconVariant
- */
-
-/**
- * @typedef AttributeIconOptions
- * @property {Number} die
+ * @typedef BadgeOptions
+ * @property {String} label
+ * @property {Number} value
  * @property {Boolean} compact
+ * @property {'xs'|'s'|'m'|'l'|'xl'} size
  */
 
 /**
  * @param {Attribute} attribute
- * @param {AttributeIconOptions} options
+ * @param {BadgeOptions} options
  * @returns {Handlebars.SafeString}
  */
 function attributeIcon(attribute, options) {
+	options.hash.label = FU.attributeAbbreviations[attribute];
+	return badge(attribute, options);
+}
+
+/**
+ * @param {String} key
+ * @param {BadgeOptions} options
+ * @returns {Handlebars.SafeString}
+ */
+function badge(key, options) {
 	if (options) {
 		options = options.hash;
 	}
-	const label = FU.attributeAbbreviations[attribute];
-	const icon = FU.attributeIcons[attribute];
-	const template = Handlebars.partials[systemTemplatePath('common/icons/icon-attribute')];
+	const icon = FU.allIcon[key];
+	const size = options.size ?? 's';
+	const template = Handlebars.partials[systemTemplatePath('common/icons/badge')];
 	const html =
 		typeof template === 'function'
 			? template({
-					label: label,
 					icon: icon,
-					die: options.die,
+					label: options.label,
+					size: size,
+					value: options.value,
 					compact: options.compact,
 				})
 			: '';

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -52,7 +52,7 @@ export const preloadHandlebarsTemplates = async function () {
 			'systems/projectfu/templates/common/fieldset-toggle.hbs',
 			'systems/projectfu/templates/common/auto-complete.hbs',
 			'systems/projectfu/templates/common/traits.hbs',
-			'systems/projectfu/templates/common/icons/icon-attribute.hbs',
+			'systems/projectfu/templates/common/icons/badge.hbs',
 
 			// Effects
 			'systems/projectfu/templates/effects/active-effect-details.hbs',

--- a/styles/css/components/checks.css
+++ b/styles/css/components/checks.css
@@ -1,7 +1,3 @@
-.fu-check__result-container {
-	height: 64px;
-}
-
 .fu-check__difficulty {
 	background: #dd9f9f;
 }

--- a/styles/css/components/checks.css
+++ b/styles/css/components/checks.css
@@ -1,5 +1,5 @@
 .fu-check__difficulty {
-	background: #dd9f9f;
+	background: #edd0aa;
 }
 
 .fu-check__difficulty div label {

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -148,6 +148,11 @@
 	--icon-size: 16px;
 }
 
+/* Used for background image icons since they won't reserve advance width */
+.fu-icon--bg {
+	padding-inline: var(--icon-size);
+}
+
 .fu-icon__radio-group input {
 	margin: 0;
 	content: none;

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -55,12 +55,10 @@
 
 .fu-dialog__icon-option {
 	display: inline-flex;
-	--icon-size: 100%;
-	width: var(--icon-size);
-	height: var(--icon-size);
+	height: 100%;
 	align-items: center;
 	justify-content: center;
-	padding: 0;
+	padding: 4px;
 	border-radius: 6px;
 	cursor: pointer;
 	transition:

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -121,8 +121,9 @@
 .fu-icon,
 .fu-icon--m,
 .fu-icon--s,
+.fu-icon--xs,
 .fu-icon--l {
-	display: inline-flex;
+	/*display: inline-flex;*/
 	--icon-size: 100%;
 	line-height: 1;
 	font-size: var(--icon-size);
@@ -142,6 +143,9 @@
 }
 .fu-icon--l {
 	--icon-size: 64px;
+}
+.fu-icon--xs {
+	--icon-size: 16px;
 }
 
 .fu-icon__radio-group input {

--- a/templates/actor/partials/actor-attributes.hbs
+++ b/templates/actor/partials/actor-attributes.hbs
@@ -2,6 +2,7 @@
 <div class="flexrow grid grid-2col">
     {{#each system.attributes as |attribute key|}}
         <div class="attribute resource-content flexrow flex-group-center" style="padding: 1px;">
+			<i class="fu-icon--s fu-{{key}}"></i>
             <label class="flexlarge align-left" data-label="{{ attribute.label }}">
                 <span class="resource-label-sm">{{ attribute.abbr }}</span>
             </label>

--- a/templates/chat/partials/chat-accuracy-check.hbs
+++ b/templates/chat/partials/chat-accuracy-check.hbs
@@ -1,40 +1,30 @@
-<header class="title-desc chat-header flexrow">
-    <h2 style="flex-grow: 4;">{{localize 'FU.Accuracy'}}</h2>
-    <section class="targets" style="align-items: end;">
-        <div class="fu-tags flexrow gap-5">
-            <a data-action="selectCheckCustomizer">
-                <span class='fu-tag button flex-group-center gap-5' style="filter: grayscale(100%);" data-tooltip="{{localize 'FU.CheckCustomizer'}}"><i class="icon fas fa-gear"></i></span>
-            </a>
-        </div>
-    </section>
-</header>
-
-<div class='detail-desc flexrow flex-group-center desc'>
+<header class='detail-desc flexrow flex-group-center desc' data-tooltip="{{localize 'FU.Accuracy'}}">
     <label
         class="total {{#if critical}}critical{{else}}{{#if fumble}}fumble{{else}}default{{/if}}{{/if}} flexrow"
         {{#if critical}}data-tooltip="{{localize 'FU.Critical'}}"{{/if}}
         {{#if fumble}}data-tooltip="{{localize 'FU.Fumble'}}"{{/if}}
     >
+		<i class="fu-icon--s ra ra-archery-target"></i>
         <div class="startcap"></div>
         <div class="" style="flex: 0 1 auto;">{{result}} <label>vs</label> {{pfuUppercase additionalData.targetedDefense}}{{pfuUppercase details.defense}}</div>
         <div class="endcap"></div>
     </label>
-</div>
+</header>
 
 <!-- Roll Details Section -->
 <div class="toggle-section accuracy-check-results {{#if (pfuGetSetting 'optionChatMessageHideRollDetails')}}hidden{{/if}}">
     <div class="flexrow gap-5">
         <div class='detail-desc flex-group-center grid grid-3col flex3'>
             <div data-tooltip="(Die Size: {{primary.dice}})">
-                <label class="title">{{localize (pfuConcat 'FU.Attribute' (pfuCapitalize primary.attribute) 'Abbr')}}</label>
+				{{pfuIconAttribute primary.attribute}}
                 <label class="detail">{{primary.result}}</label>
             </div>
             <div data-tooltip="(Die Size: {{secondary.dice}})">
-                <label class="title">{{localize (pfuConcat 'FU.Attribute' (pfuCapitalize secondary.attribute) 'Abbr')}}</label>
+				{{pfuIconAttribute secondary.attribute}}
                 <label class="detail">{{secondary.result}}</label>
             </div>
             <div {{#if modifiers}}data-tooltip="{{#each modifiers}}{{localize label}}: {{value}}{{#unless @last}}<br>{{/unless}}{{/each}}" {{/if}}>
-                <label class="title">{{localize 'FU.ModAbbr'}}</label>
+				{{pfuBadge 'mod' label='FU.ModAbbr' }}
                 <label class="detail">{{modifierTotal}}</label>
             </div>
         </div>

--- a/templates/chat/partials/chat-damage.hbs
+++ b/templates/chat/partials/chat-damage.hbs
@@ -1,31 +1,24 @@
-<header class="title-desc chat-header flexrow desc">
-    <h2 style="flex-grow: 4;">{{localize 'FU.Damage'}}</h2>
-    <section class="targets" style="align-items: end;">
-        <div class="fu-tags flexrow gap-5">
-            <a data-action="selectDamageCustomizer">
-                <span class='fu-tag button flex-group-center gap-5' data-tooltip="{{localize 'FU.DamageCustomizer'}}"><i class="icon fas fa-gear"></i></span>
-            </a>
-        </div>
-    </section>
-</header>
-
-<div class='detail-desc flex-group-center flexrow desc'>
-    <a>
-        <label class="damageType {{damage.type}} grid grid-3col">
-            <div class="startcap"></div>
-            <div>{{damage.total}}</div>
-            <div class="endcap" data-tooltip="{{localize (lookup translation.damageTypes damage.type)}}">
-                <i class="{{localize (lookup translation.damageIcon damage.type)}}"></i>
+<header class='detail-desc flexrow flex-group-center desc'>
+	<label class="total damageType {{damage.type}} flexrow" data-tooltip="{{localize 'FU.Damage'}}">
+		<i class="fu-icon--s {{lookup translation.damageIcon damage.type}}" data-tooltip="{{localize (lookup translation.damageTypes damage.type)}}"></i>
+		<div class="startcap"></div>
+		<div style="flex: 0 1 auto;">{{damage.total}}</div>
+		<div class="endcap"></div>
+		<section class="targets" style="align-items: end;">
+			<div class="fu-tags flexrow gap-5">
+				<a data-action="selectDamageCustomizer">
+					<span class='fu-tag button flex-group-center gap-5' data-tooltip="{{localize 'FU.DamageCustomizer'}}"><i class="icon fas fa-gear"></i></span>
+				</a>
 			</div>
-        </label>
-    </a>
-</div>
+		</section>
+	</label>
+</header>
 
 <div class="toggle-section accuracy-check-results {{#if (pfuGetSetting 'optionChatMessageHideRollDetails')}}hidden{{/if}}">
     <div class="flexrow gap-5">
         <div class='detail-desc flex-group-center grid grid-2col desc flex2'>
             <div>
-                <label class="title">{{localize 'FU.HighRollAbbr'}}</label>
+				{{pfuBadge 'hr' label='FU.HighRollAbbr' }}
                 <label class="detail">
                     {{#if (not damage.hrZero)}}
                         {{#if (gte check.primary.result check.secondary.result)}}
@@ -37,7 +30,7 @@
                 </label>
             </div>
             <div {{#if damage.modifiers}}data-tooltip="{{#each damage.modifiers}}{{localize label}}: {{value}}{{#unless @last}}<br>{{/unless}}{{/each}}"{{/if}}>
-                <label class="title">{{localize 'FU.ModAbbr'}}</label>
+				{{pfuBadge 'mod' label='FU.ModAbbr' }}
                 <label class="detail">{{damage.modifierTotal}}</label>
             </div>
         </div>

--- a/templates/chat/partials/chat-damage.hbs
+++ b/templates/chat/partials/chat-damage.hbs
@@ -1,6 +1,6 @@
 <header class='detail-desc flexrow flex-group-center desc'>
 	<label class="total damageType {{damage.type}} flexrow" data-tooltip="{{localize 'FU.Damage'}}">
-		<i class="fu-icon--s {{lookup translation.damageIcon damage.type}}" data-tooltip="{{localize (lookup translation.damageTypes damage.type)}}"></i>
+		<i class="fu-icon--s fu-icon--bg {{lookup translation.damageIcon damage.type}}" data-tooltip="{{localize (lookup translation.damageTypes damage.type)}}"></i>
 		<div class="startcap"></div>
 		<div style="flex: 0 1 auto;">{{damage.total}}</div>
 		<div class="endcap"></div>

--- a/templates/chat/partials/chat-default-check.hbs
+++ b/templates/chat/partials/chat-default-check.hbs
@@ -1,23 +1,23 @@
 <div class="flexrow gap-5">
     <div id='results' class='detail-desc flex-group-center grid grid-3col flex3'>
         <div>
-			{{pfuIconAttribute check.attr1.attribute die=result.die1 compact=true}}
+			{{pfuIconAttribute check.attr1.attribute die=result.die1}}
             <label class="detail">{{result.attr1}}</label>
         </div>
         <div>
-			{{pfuIconAttribute check.attr2.attribute die=result.die2 compact=true}}
+			{{pfuIconAttribute check.attr2.attribute die=result.die2}}
             <label class="detail">{{result.attr2}}</label>
         </div>
         <div {{#if modifiers}}data-tooltip="{{#each modifiers}}{{localize label}}: {{value}}{{#unless @last}}<br>{{/unless}}{{/each}}"{{/if}}>
-            <label class="title">{{localize 'FU.ModAbbr'}}</label>
+			{{pfuBadge 'mod' label='FU.ModAbbr' }}
             <label class="detail">{{#unless (lt result.modifier 0)}}+{{/unless}}{{result.modifier}}</label>
         </div>
 
     </div>
     {{#if (gt difficulty 0)}}
-    <div class="detail-desc fu-check__difficulty fu-check__result-container flex-group-center">
-		<div class="value">
-			<label class="title" data-tooltip="{{localize 'FU.ChatDifficulty'}}">{{localize 'FU.ChatDifficulty'}}</label>
+    <div class="detail-desc fu-check__difficulty flex-group-center">
+		<div>
+			{{pfuBadge 'difficulty' label='FU.ChatDifficulty' }}
 			<label class="detail">{{difficulty}}</label>
 		</div>
     </div>

--- a/templates/chat/partials/chat-default-check.hbs
+++ b/templates/chat/partials/chat-default-check.hbs
@@ -1,11 +1,11 @@
 <div class="flexrow gap-5">
     <div id='results' class='detail-desc flex-group-center grid grid-3col flex3'>
         <div>
-			{{pfuIconAttribute check.attr1.attribute die=result.die1}}
+			{{pfuIconAttribute check.attr1.attribute value=result.die1}}
             <label class="detail">{{result.attr1}}</label>
         </div>
         <div>
-			{{pfuIconAttribute check.attr2.attribute die=result.die2}}
+			{{pfuIconAttribute check.attr2.attribute value=result.die2}}
             <label class="detail">{{result.attr2}}</label>
         </div>
         <div {{#if modifiers}}data-tooltip="{{#each modifiers}}{{localize label}}: {{value}}{{#unless @last}}<br>{{/unless}}{{/each}}"{{/if}}>
@@ -17,7 +17,7 @@
     {{#if (gt difficulty 0)}}
     <div class="detail-desc fu-check__difficulty flex-group-center">
 		<div>
-			{{pfuBadge 'difficulty' label='FU.ChatDifficulty' }}
+			{{pfuBadge 'difficulty' label='FU.DifficultyLevelAbbr' tooltip='FU.ChatDifficulty' }}
 			<label class="detail">{{difficulty}}</label>
 		</div>
     </div>

--- a/templates/chat/partials/inline-damage-icon.hbs
+++ b/templates/chat/partials/inline-damage-icon.hbs
@@ -1,1 +1,1 @@
-<a class="inline inline-damage"> {{damageType}}<i class="{{affinityIcon}}"></i></a>
+<a class="inline inline-damage"> {{damageType}}<i class="{{affinityIcons}}"></i></a>

--- a/templates/common/icons/badge.hbs
+++ b/templates/common/icons/badge.hbs
@@ -1,8 +1,8 @@
 <div class='fu-icon__container flex-group-center' data-tooltip="{{localize label}}">
 	<div class='fu-icon__badge'>
-		<i class='fu-icon--s {{icon}}'></i>
-		{{#if die}}
-			<span class="fu-icon__badge-overlay">{{die}}</span>
+		<i class='fu-icon--{{size}} {{icon}}'></i>
+		{{#if value}}
+			<span class="fu-icon__badge-overlay">{{value}}</span>
 		{{/if}}
 	</div>
 	{{#unless compact}}

--- a/templates/dialog/dialog-check-prompt-unified.hbs
+++ b/templates/dialog/dialog-check-prompt-unified.hbs
@@ -1,18 +1,12 @@
 {{#if attributeValues}}
 	<section>
 		<fieldset class="title-fieldset resource-content flex-group-center flexrow desc">
-			<legend class="resource-text-m">{{localize 'FU.Attributes'}}</legend>
+			<legend class="resource-text-m">{{localize 'FU.Actor'}}</legend>
+			<img class="profile-img flexcol" src="{{actor.img}}"
+				 data-edit="img" title="{{actor.name}}"
+				 style="height: 96px; width: auto; object-fit: contain;" />
 			{{#each attributes}}
-				<fieldset>
-					<label class="resource-label-sm">
-						<span class='fu-tag'><i class="icon {{lookup @root.attributeIcons @key}}"></i></span>
-						<abbr title="{{localize this}}">
-							{{localize (lookup @root/attributeAbbr @key)}}
-						</abbr>
-						<span>:</span>
-						<span class="resource-label-m">D{{lookup @root/attributeValues @key}}</span>
-					</label>
-				</fieldset>
+				{{pfuIconAttribute @key value=(lookup @root/attributeValues @key)}}
 			{{/each}}
 		</fieldset>
 	</section>
@@ -163,7 +157,8 @@
 				<legend class="resource-text-m">{{localize 'FU.DialogCheckModifier'}}</legend>
 				{{#if (eq type 'open')}}
 					<label class="resource-text-m">
-						<span>{{localize 'FU.DialogCheckOpenCheck'}} {{localize 'FU.Bonus'}}: {{bonus}}</span>
+						{{localize 'FU.DialogCheckOpenCheck'}} {{localize 'FU.Bonus'}}
+						<input type="number" value="{{bonus}}" readonly>
 					</label>
 				{{/if}}
 				<label class="resource-text-m">
@@ -177,7 +172,7 @@
 
 					{{#if (eq type 'group')}}
 						<label class="resource-text-m">
-							{{localize 'FU.DialogGroupCheckDifficulty'}}
+							{{localize 'FU.DialogGroupCheckDifficulty' type=typeLabel}}
 							<input name="difficulty" type="number" value="{{difficulty}}" min="0">
 						</label>
 						<label class="resource-text-m">

--- a/templates/dialog/dialog-damage-customizer-v2.hbs
+++ b/templates/dialog/dialog-damage-customizer-v2.hbs
@@ -55,14 +55,14 @@
 		<legend class="resource-label-full">
 			<label class="resource-label-m">{{localize 'FU.Type'}}</label>
 		</legend>
-		<div class="grid flex-group-center grid-5col">
+		<div class="grid flex-group-center grid-5col gap-5">
 			<input type="hidden" name="damageType" value="{{selected}}">
 			{{#each context.types as |type| }}
 				<button type="button"
-						class="fu-dialog__icon-option fu-icon--m"
+						class="fu-dialog__icon-option"
 						data-tooltip="{{label}}"
-						 data-action="selectType" data-value="{{value}}">
-					<i class="fu-icon {{icon}}"></i>
+						data-action="selectType" data-value="{{value}}">
+					<i class="fu-icon--m {{icon}}"></i>
 				</button>
 			{{/each}}
 		</div>


### PR DESCRIPTION
This pull request introduces a comprehensive redesign and unification of icon and badge rendering for checks, attributes, and damage types throughout the UI. The changes standardize how icons and badges are displayed, making use of new helpers and configuration objects to ensure consistency and flexibility. Additionally, some UI/UX improvements and bug fixes are included.

**Icon & Badge System Overhaul:**

- Introduced a new `badge` Handlebars helper and refactored the existing `attributeIcon` helper to use it, allowing for more flexible badge/icon rendering with support for labels, values, sizes, and tooltips. (`module/helpers/handlebars.mjs`, `templates/common/icons/badge.hbs`) [[1]](diffhunk://#diff-2858726f1f56a71994d97fd2136ecbd6a4d936273d1dbc421a18b37fe37cabdfR164) [[2]](diffhunk://#diff-2858726f1f56a71994d97fd2136ecbd6a4d936273d1dbc421a18b37fe37cabdfL284-R320) [[3]](diffhunk://#diff-d9f46ac7309bdcdf92f63a6e1147ec7dbcdce55563ff88fd21cf854a83e76e10L3-R5)
- Added new configuration objects: `FU.affinityIcons` and `FU.checkIcons`, and merged them into `FU.allIcon` for centralized icon class management. (`module/helpers/config.mjs`) [[1]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5R103-R128) [[2]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5L115-R146)
- Updated all relevant templates to use the new `pfuBadge` and `pfuIconAttribute` helpers, replacing hardcoded icons and labels for checks, attributes, and modifiers. (`templates/chat/partials/chat-accuracy-check.hbs`, `templates/chat/partials/chat-damage.hbs`, `templates/chat/partials/chat-default-check.hbs`, `templates/actor/partials/actor-attributes.hbs`, `templates/chat/partials/inline-damage-icon.hbs`) [[1]](diffhunk://#diff-4f50785cf250a595d50870772d2d39f80f245545777c24f787651463cb65b613L1-R27) [[2]](diffhunk://#diff-4b54db73fec4f818f94b5e5ec628f1681a753bcdf9c8962cdfb15c2ad582aa5cL1-R21) [[3]](diffhunk://#diff-4b54db73fec4f818f94b5e5ec628f1681a753bcdf9c8962cdfb15c2ad582aa5cL40-R33) [[4]](diffhunk://#diff-d2991b5e41f67eb053b6c31f97a91f96f32430336f26fdecf4ca70c314ad5890L4-R20) [[5]](diffhunk://#diff-896c1614b34b32b7c58f411da423d7572a27c35abf2d8f39b6c6a49fd1eead1bR5) [[6]](diffhunk://#diff-bb6c1ad9d1aa2c4d60a7841695da893f8138f25b7c5eb2625ca13981021d5bafL1-R1)

**Styling and UI Improvements:**

- Added new CSS classes for icon sizing (`.fu-icon--xs`, `.fu-icon--bg`) and adjusted form and badge styles for improved appearance and alignment. (`styles/css/global/form.css`, `styles/css/components/checks.css`) [[1]](diffhunk://#diff-fdf288c144a2bdfdcd0cfbd33516327acf11ee433ed977b390e1f5ac74393226L58-R61) [[2]](diffhunk://#diff-fdf288c144a2bdfdcd0cfbd33516327acf11ee433ed977b390e1f5ac74393226R122-R124) [[3]](diffhunk://#diff-fdf288c144a2bdfdcd0cfbd33516327acf11ee433ed977b390e1f5ac74393226R145-R152) [[4]](diffhunk://#diff-78cc3de2af1eb66c8e85a1d03188542144e50914156a313fad8155b6f5631978L1-R2)
- Changed the background color of the check difficulty section for better visual distinction. (`styles/css/components/checks.css`)

**Dialog and Prompt Enhancements:**

- Improved the configuration dialogs for checks to support localized type labels and titles, and passed additional context such as attribute values. (`module/checks/check-prompt.mjs`) [[1]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aR194-R196) [[2]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aR212-R214) [[3]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aR255-R270) [[4]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aL266) [[5]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aL285-R298) [[6]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aL454-R467)

**Miscellaneous Fixes and Updates:**

- Fixed a logic bug in `RenderCheckRuleTrigger` where the item matching condition was reversed. (`module/documents/effects/triggers/render-check-rule-trigger.mjs`)
- Added a new localization string for the difficulty level abbreviation. (`lang/en.json`)
- Updated template preloading to use the new badge template. (`module/helpers/templates.mjs`)

These changes collectively modernize and unify the visual language of the system, making it easier to maintain and extend iconography and badge usage going forward.