### PR TITLE
Update display retargeting

### DIFF
--- a/module/checks/check-retarget.mjs
+++ b/module/checks/check-retarget.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM } from '../helpers/config.mjs';
+import { FU, SYSTEM } from '../helpers/config.mjs';
 import { CheckConfiguration } from './check-configuration.mjs';
 import { Checks } from './checks.mjs';
 import { getTargeted } from '../helpers/target-handler.mjs';
@@ -28,10 +28,16 @@ function addRetargetEntry(application, menuItems) {
 	});
 }
 
+function isValid(message) {
+	// Updated to handle display "checks"
+	const types = Object.keys(FU.checkTypes);
+	return Checks.isCheck(message, types);
+}
+
 async function retarget(messageId) {
 	/** @type ChatMessage | undefined */
 	const message = game.messages.get(messageId);
-	const isCheck = Checks.isCheck(message);
+	const isCheck = isValid(message);
 	if (isCheck) {
 		const checkId = CheckConfiguration.inspect(message).getCheck().id;
 		let shouldDelete = false;
@@ -53,7 +59,7 @@ async function retarget(messageId) {
 }
 
 function onRenderChatMessage(message, html) {
-	if (!Checks.isCheck(message)) {
+	if (!isValid(message)) {
 		return;
 	}
 

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -262,7 +262,23 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 					order: CHECK_ROLL,
 					partial: 'systems/projectfu/templates/chat/chat-check-container.hbs',
 					data: {
+						type: checkData.type,
+						hasAccuracy: checkData.type === 'accuracy' || checkData.type === 'magic',
 						check: checkData,
+						damage: damageData,
+						translation: {
+							damageTypes: FU.damageTypes,
+							damageIcon: FU.affinityIcons,
+						},
+					},
+				});
+				break;
+
+			case 'display':
+				sections.push({
+					order: CHECK_ROLL,
+					partial: 'systems/projectfu/templates/chat/chat-display-container.hbs',
+					data: {
 						damage: damageData,
 						translation: {
 							damageTypes: FU.damageTypes,

--- a/module/helpers/target-handler.mjs
+++ b/module/helpers/target-handler.mjs
@@ -71,7 +71,7 @@ export async function getSelected(warn = true) {
 export function getTargeted(tokens = false, warn = true) {
 	const targets = Array.from(game.user.targets)
 		.map((target) => (tokens ? target : target.actor))
-		.filter((actor) => actor.isCharacterType);
+		.filter((actor) => actor);
 
 	if (targets.length === 0 && warn) {
 		ui.notifications.warn('FU.ChatApplyEffectNoActorsTargeted', { localize: true });

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -70,6 +70,7 @@ export const preloadHandlebarsTemplates = async function () {
 
 			// Chat Messages
 			'systems/projectfu/templates/chat/chat-check-container.hbs',
+			'systems/projectfu/templates/chat/chat-display-container.hbs',
 			'systems/projectfu/templates/chat/chat-check-flavor-check.hbs',
 			'systems/projectfu/templates/chat/chat-check-flavor-item.hbs',
 			'systems/projectfu/templates/chat/chat-group-check-initiated.hbs',
@@ -82,7 +83,7 @@ export const preloadHandlebarsTemplates = async function () {
 
 			// Chat Message Partials
 			'systems/projectfu/templates/chat/partials/chat-accuracy-check.hbs',
-			'systems/projectfu/templates/chat/partials/chat-damage.hbs',
+			'systems/projectfu/templates/chat/partials/chat-check-damage.hbs',
 			'systems/projectfu/templates/chat/partials/chat-default-check.hbs',
 			'systems/projectfu/templates/chat/partials/chat-item-description.hbs',
 			'systems/projectfu/templates/chat/partials/chat-item-quality.hbs',

--- a/styles/css/utils/typography.css
+++ b/styles/css/utils/typography.css
@@ -417,7 +417,7 @@
 
 		div {
 			font-size: var(--font-size-small);
-			padding: 5px 0;
+			padding: 2px 0;
 		}
 	}
 

--- a/templates/chat/chat-check-container.hbs
+++ b/templates/chat/chat-check-container.hbs
@@ -1,15 +1,13 @@
 <div class="combineAccDmg">
-    {{#if check}}
-        <div class="accuracy-check">
-            {{#with check}}
-                {{> 'systems/projectfu/templates/chat/partials/chat-accuracy-check.hbs' hideSettings=../hideSettings}}
-            {{/with}}
-        </div>
-    {{/if}}
+	<div class="accuracy-check">
+		{{#with check}}
+			{{> 'systems/projectfu/templates/chat/partials/chat-accuracy-check.hbs' hideSettings=../hideSettings}}
+		{{/with}}
+	</div>
 
     {{#if damage}}
         <div class="damage-check">
-			{{> 'systems/projectfu/templates/chat/partials/chat-damage.hbs' damage=damage check=check translation=translation hideSettings=../hideSettings}}
+			{{> 'systems/projectfu/templates/chat/partials/chat-check-damage.hbs' damage=damage check=check translation=translation hideSettings=../hideSettings}}
         </div>
     {{/if}}
 </div>

--- a/templates/chat/chat-check-flavor-item.hbs
+++ b/templates/chat/chat-check-flavor-item.hbs
@@ -1,8 +1,7 @@
 <header class="title-desc chat-header flexrow">
     <a data-link draggable="true" data-uuid="{{uuid}}" data-type="Item" data-tooltip="{{name}}"><img src="{{img}}"
             alt="Image" data-item-id="{{id}}" class="item-img"></a>
-    <h2 style="flex-grow: 8;">{{name}}</h2>
-
+    <h2 style="flex-grow: 8; margin-left: 4px;">{{name}}</h2>
     <a class="universal-toggle fu-tags flexrow gap-5" style="align-items:end;"
         data-tooltip="{{localize 'FU.ChatMessageShow'}}">
         <span class="fu-tag button" style="padding: 5px;">

--- a/templates/chat/chat-display-container.hbs
+++ b/templates/chat/chat-display-container.hbs
@@ -1,0 +1,21 @@
+{{#if damage}}
+	<header class='detail-desc flexrow flex-group-center desc'>
+		<label class="total damageType {{damage.type}} flexrow"
+			   data-tooltip="{{localize 'FU.Damage'}}">
+			<i class="fu-icon--s fu-icon--bg {{lookup translation.damageIcon damage.type}}" data-tooltip="{{localize (lookup translation.damageTypes damage.type)}}"></i>
+			<div class="startcap"></div>
+			<div style="flex: 0 1 auto;">{{damage.total}}</div>
+			<div class="endcap"></div>
+			<div {{#if damage.modifiers}}data-tooltip="{{#each damage.modifiers}}{{localize label}}: {{value}}{{#unless @last}}<br>{{/unless}}{{/each}}"{{/if}}>
+				{{pfuBadge 'mod' compact=true }}
+			</div>
+			<section class="targets">
+				<a data-action="retarget" data-tooltip="{{localize 'FU.ChatContextRetarget'}}">
+				<span class="fu-tag button flex-group-center" style="font-size:1rem">
+					<i class="icon fa fa-refresh"></i>
+				</span>
+				</a>
+			</section>
+		</label>
+	</header>
+{{/if}}

--- a/templates/chat/partials/chat-accuracy-check.hbs
+++ b/templates/chat/partials/chat-accuracy-check.hbs
@@ -8,6 +8,11 @@
         <div class="startcap"></div>
         <div class="" style="flex: 0 1 auto;">{{result}} <label>vs</label> {{pfuUppercase additionalData.targetedDefense}}{{pfuUppercase details.defense}}</div>
         <div class="endcap"></div>
+		<a data-action="retarget" data-tooltip="{{localize 'FU.ChatContextRetarget'}}">
+			<span class="fu-tag button flex-group-center" style="font-size:1rem">
+				<i class="icon fa fa-refresh"></i>
+			</span>
+		</a>
     </label>
 </header>
 

--- a/templates/chat/partials/chat-check-damage.hbs
+++ b/templates/chat/partials/chat-check-damage.hbs
@@ -4,7 +4,7 @@
 		<div class="startcap"></div>
 		<div style="flex: 0 1 auto;">{{damage.total}}</div>
 		<div class="endcap"></div>
-		<section class="targets" style="align-items: end;">
+		<section class="targets">
 			<div class="fu-tags flexrow gap-5" style="padding: 4px;">
 				<a data-action="selectDamageCustomizer">
 					<span class='button flex-group-center gap-5'

--- a/templates/chat/partials/chat-targets.hbs
+++ b/templates/chat/partials/chat-targets.hbs
@@ -1,21 +1,12 @@
-
 {{#if targets}}
     <div style="clear: both"></div>
-	{{#if retarget}}
-		<header class="title-desc chat-header flexrow">
-			<h2>
-				<a data-action="retarget" data-tooltip="{{localize 'FU.ChatContextRetarget'}}">
-				<span class="fu-tag button flex-group-center" style="font-size:1rem">
-					<i class="icon fa fa-refresh"></i>
-				</span>
-				</a>
-				{{localize "FU.Target"}}
-				{{#if (gt targets.length 1)}}
-					<span>: {{localize rule}}({{targets.length}})</span>
-				{{/if}}
-			</h2>
-		</header>
-	{{/if}}
+<!--	{{#if (gt targets.length 1)}}-->
+<!--		<header class="title-desc chat-header flexrow">-->
+<!--			<h2>-->
+<!--				<span>{{localize "FU.Target"}}: {{localize rule}}({{targets.length}})</span>-->
+<!--			</h2>-->
+<!--		</header>-->
+<!--	{{/if}}-->
     <section class="targets">
         {{#each targets as |target|}}
             <span class="flexrow">

--- a/templates/dialog/dialog-damage-customizer.hbs
+++ b/templates/dialog/dialog-damage-customizer.hbs
@@ -1,4 +1,4 @@
-<main>
+<main class="">
 	<div class="desc mb-3 gap-5">
 		<div class="inline-desc form-group resource-content gap-5" style="padding: 5px 10px;">
 			<label for="total-damage" class="resource-label" style="flex-grow: 8;">


### PR DESCRIPTION
This pull request introduces support for a new "display" check type in the Project FU system, refactors how checks are validated and rendered, and improves the modularity and clarity of the chat message templates. It also includes minor UI and template improvements. The most important changes are grouped below.

**Support for "display" check type:**

* Added logic throughout `checks.mjs` and `common-sections.mjs` to handle a new "display" check type, including appropriate data passing and template rendering for display-only checks. [[1]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1L156-R171) [[2]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1L183-R211) [[3]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bR276-R289)
* Added a new `chat-display-container.hbs` template and integrated it into the template preloading and rendering logic. [[1]](diffhunk://#diff-c55f5a7794a56f98b8ce58d411e65f9c641fd4ad659751611cbb7787250557d9R73) [[2]](diffhunk://#diff-ce07afc3add8b33eee382cb4cc42d17aba1e49454bb2936a45ec5609489bb332R1-R21)

**Check validation and retargeting improvements:**

* Refactored check validation to use a new `isValid` function that supports "display" checks, updating all usages in `check-retarget.mjs`. [[1]](diffhunk://#diff-06fac45304295be90bfc1dd492a08a88d13bf1df4455b8952e081a1da7e1720dL1-R1) [[2]](diffhunk://#diff-06fac45304295be90bfc1dd492a08a88d13bf1df4455b8952e081a1da7e1720dR31-R40) [[3]](diffhunk://#diff-06fac45304295be90bfc1dd492a08a88d13bf1df4455b8952e081a1da7e1720dL56-R62)
* Improved retargeting logic and ensured that checks of type "display" are handled correctly during modification and rendering.

**Template and rendering updates:**

* Renamed `chat-damage.hbs` to `chat-check-damage.hbs` and updated all references to improve naming consistency. [[1]](diffhunk://#diff-c55f5a7794a56f98b8ce58d411e65f9c641fd4ad659751611cbb7787250557d9L85-R86) [[2]](diffhunk://#diff-10fa4c2b5884ca41643219b9f0c41c59c26265432813ea0db386899eefdf5c06L2-R10) [[3]](diffhunk://#diff-d31440734e84d9963d43a222db5b770fee8b886e45a2bf14287a6ade6a93abcfL7-R7)
* Updated chat templates to streamline the display of retargeting actions and damage sections, including moving the retarget button into the appropriate partials and cleaning up the targets header. [[1]](diffhunk://#diff-4f50785cf250a595d50870772d2d39f80f245545777c24f787651463cb65b613R11-R15) [[2]](diffhunk://#diff-7ebc7209f34e1c1cfaccdd80472291c7797b414b8b19f2ce2f237632ce2b7847L1-R9)

**Minor improvements and fixes:**

* Improved filtering in `getTargeted` to avoid errors when an actor is missing.
* Made small UI adjustments for better spacing and visual consistency in chat headers and typography. [[1]](diffhunk://#diff-4a346b5e655307e6a14529bbee55f19a0aaef425cfe5aff58ad2d1d8ee2d4d83L420-R420) [[2]](diffhunk://#diff-678bbffc1c0b1f80789ceb3df3e9627df15343a029cb244ab75d80983f74bf22L4-R4) [[3]](diffhunk://#diff-68b92138f90006b72cf44dc06ac9c6b22b6dd26b107d5aefb362c7fc65f22442L1-R1)

These changes collectively enhance the flexibility and maintainability of the check system, especially regarding display-only checks and chat message rendering.