### PR TITLE
Add support for NPC damage overrides

### DIFF
--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -1,7 +1,6 @@
 import { SYSTEM } from '../helpers/config.mjs';
 import { SETTINGS } from '../settings.js';
 import { Flags } from '../helpers/flags.mjs';
-import { CharacterDataModel } from '../documents/actors/character/character-data-model.mjs';
 import { StringUtils } from '../helpers/string-utils.mjs';
 import { Traits } from '../pipelines/traits.mjs';
 import { CheckHooks } from './check-hooks.mjs';
@@ -556,7 +555,7 @@ export class CheckConfigurer extends CheckInspector {
 	 */
 	setDamageOverride(actor, scope) {
 		// Potential override to damage type
-		if (actor.system instanceof CharacterDataModel) {
+		if (actor.isCharacterType) {
 			/** @type DamageTypeOverrideDataModel **/
 			let scopeField;
 			switch (scope) {

--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -99,7 +99,7 @@ export class FUActor extends Actor {
 	}
 
 	/**
-	 * @returns {Boolean}
+	 * @returns {Boolean} True for PCs and NPCs.
 	 */
 	get isCharacterType() {
 		return this.type === 'character' || this.type === 'npc';

--- a/module/documents/actors/character/character-data-model.mjs
+++ b/module/documents/actors/character/character-data-model.mjs
@@ -1,24 +1,27 @@
 import { CharacterMigrations } from './character-migrations.mjs';
-import { AffinitiesDataModel } from '../common/affinities-data-model.mjs';
-import { AttributesDataModel } from '../common/attributes-data-model.mjs';
-import { BonusesDataModel, MultipliersDataModel } from '../common/bonuses-data-model.mjs';
-import { ImmunitiesDataModel } from '../common/immunities-data-model.mjs';
 import { BondDataModel } from '../common/bond-data-model.mjs';
 import { CharacterSkillTracker } from './character-skill-tracker.mjs';
 import { FU, SYSTEM } from '../../../helpers/config.mjs';
-import { DerivedValuesDataModel } from '../common/derived-values-data-model.mjs';
-import { EquipDataModel } from '../common/equip-data-model.mjs';
 import { PilotVehicleDataModel } from './pilot-vehicle-data-model.mjs';
 import { SETTINGS } from '../../../settings.js';
-import { OverridesDataModel } from '../common/overrides-data-model.mjs';
 import { FloralistDataModel } from './floralist-data-model.mjs';
 import { EquipmentHandler } from '../../../helpers/equipment-handler.mjs';
+import { BaseCharacterDataModel } from '../common/base-character-data-model.mjs';
 
 const CLASS_HP_BENEFITS = 5;
 const CLASS_MP_BENEFITS = 5;
 const CLASS_IP_BENEFITS = 2;
 
 /**
+ * @class
+ * @extends BaseCharacterDataModel
+ * @property {AffinitiesDataModel} affinities
+ * @property {AttributesDataModel} attributes
+ * @property {DerivedValuesDataModel} derived
+ * @property {BonusesDataModel} bonuses Flat amounts
+ * @property {BonusesDataModel} multipliers Multiplies the base amount
+ * @property {OverridesDataModel} overrides Overrides for default behaviour
+ * @property {string} description
  * @property {number} level.value
  * @property {number} resources.hp.max
  * @property {number} resources.hp.value
@@ -33,28 +36,21 @@ const CLASS_IP_BENEFITS = 2;
  * @property {number} resources.ip.bonus
  * @property {Object} resources.fp
  * @property {number} resources.fp.value
- * @property {BondDataModel[]} bonds
  * @property {number} resources.exp.value
  * @property {string} resources.identity.name
  * @property {string} resources.pronouns.name
  * @property {string} resources.theme.name
  * @property {string} resources.origin.name
- * @property {AffinitiesDataModel} affinities
- * @property {AttributesDataModel} attributes
- * @property {DerivedValuesDataModel} derived
- * @property {BonusesDataModel} bonuses Flat amounts
- * @property {BonusesDataModel} multipliers Multiplies the base amount
+ * @property {BondDataModel[]} bonds
  * @property {PilotVehicleDataModel} vehicle
- * @property {string} description
  * @property {CharacterSkillTracker} tlTracker
- * @property {OverridesDataModel} overrides Overrides for default behaviour
  * @property {FloralistDataModel} floralist
- *
+ * @inheritDoc
  */
-export class CharacterDataModel extends foundry.abstract.TypeDataModel {
+export class CharacterDataModel extends BaseCharacterDataModel {
 	static defineSchema() {
-		const { SchemaField, NumberField, StringField, ArrayField, EmbeddedDataField, HTMLField } = foundry.data.fields;
-		return {
+		const { SchemaField, NumberField, StringField, ArrayField, EmbeddedDataField } = foundry.data.fields;
+		return Object.assign(super.defineSchema(), {
 			level: new SchemaField({
 				value: new NumberField({
 					initial: 5,
@@ -93,32 +89,16 @@ export class CharacterDataModel extends foundry.abstract.TypeDataModel {
 					}
 				},
 			}),
-			affinities: new EmbeddedDataField(AffinitiesDataModel, {}),
-			attributes: new EmbeddedDataField(AttributesDataModel, {}),
-			derived: new EmbeddedDataField(DerivedValuesDataModel, {}),
-			equipped: new EmbeddedDataField(EquipDataModel, {}),
-			bonuses: new EmbeddedDataField(BonusesDataModel, {}),
-			multipliers: new EmbeddedDataField(MultipliersDataModel, {}),
-			immunities: new EmbeddedDataField(ImmunitiesDataModel, {}),
 			vehicle: new EmbeddedDataField(PilotVehicleDataModel, {}),
-			overrides: new EmbeddedDataField(OverridesDataModel, {}),
+			// TODO: Refactor
 			floralist: new EmbeddedDataField(FloralistDataModel, {}),
-			description: new HTMLField(),
-		};
+		});
 	}
 
 	static migrateData(source) {
 		source = super.migrateData(source);
 		CharacterMigrations.run(source);
-
 		return source;
-	}
-
-	/**
-	 * @return FUActor
-	 */
-	get actor() {
-		return this.parent;
 	}
 
 	/**

--- a/module/documents/actors/common/base-character-data-model.mjs
+++ b/module/documents/actors/common/base-character-data-model.mjs
@@ -1,0 +1,42 @@
+import { AffinitiesDataModel } from './affinities-data-model.mjs';
+import { AttributesDataModel } from './attributes-data-model.mjs';
+import { DerivedValuesDataModel } from './derived-values-data-model.mjs';
+import { EquipDataModel } from './equip-data-model.mjs';
+import { BonusesDataModel, MultipliersDataModel } from './bonuses-data-model.mjs';
+import { ImmunitiesDataModel } from './immunities-data-model.mjs';
+import { OverridesDataModel } from './overrides-data-model.mjs';
+
+const fields = foundry.data.fields;
+
+/**
+ * @class
+ * @property {AffinitiesDataModel} affinities
+ * @property {AttributesDataModel} attributes
+ * @property {DerivedValuesDataModel} derived
+ * @property {BonusesDataModel} bonuses Flat amounts
+ * @property {BonusesDataModel} multipliers Multiplies the base amount
+ * @property {OverridesDataModel} overrides Overrides for default behaviour
+ * @property {string} description
+ */
+export class BaseCharacterDataModel extends foundry.abstract.TypeDataModel {
+	static defineSchema() {
+		return {
+			affinities: new fields.EmbeddedDataField(AffinitiesDataModel, {}),
+			attributes: new fields.EmbeddedDataField(AttributesDataModel, {}),
+			derived: new fields.EmbeddedDataField(DerivedValuesDataModel, {}),
+			equipped: new fields.EmbeddedDataField(EquipDataModel, {}),
+			bonuses: new fields.EmbeddedDataField(BonusesDataModel, {}),
+			multipliers: new fields.EmbeddedDataField(MultipliersDataModel, {}),
+			overrides: new fields.EmbeddedDataField(OverridesDataModel, {}),
+			immunities: new fields.EmbeddedDataField(ImmunitiesDataModel, {}),
+			description: new fields.HTMLField(),
+		};
+	}
+
+	/**
+	 * @return FUActor
+	 */
+	get actor() {
+		return this.parent;
+	}
+}

--- a/module/documents/items/basic/basic-item-data-model.mjs
+++ b/module/documents/items/basic/basic-item-data-model.mjs
@@ -31,6 +31,7 @@ const prepareCheck = (check, actor, item, registerCallback) => {
 				weaponType: item.system.type.value,
 			})
 			.addTraitsFromItemModel(item.system.traits)
+			.setDamageOverride(actor, 'attack')
 			.modifyHrZero((hrZero) => hrZero || item.system.rollInfo.useWeapon.hrZero.value);
 	}
 };


### PR DESCRIPTION
This pull request introduces a significant refactor to the character and NPC data model codebase, focusing on reducing duplication and improving maintainability. The main change is the introduction of a new `BaseCharacterDataModel` class that consolidates common schema fields and logic shared between `CharacterDataModel` and `NpcDataModel`. Both character and NPC data models now extend this new base class, allowing for cleaner, more maintainable code. Additionally, some method calls and type checks have been updated to align with these changes.

### Data Model Refactoring

* Introduced `BaseCharacterDataModel` in `module/documents/actors/common/base-character-data-model.mjs`, consolidating shared schema fields and logic for character-like actors, including affinities, attributes, derived values, equipment, bonuses, multipliers, overrides, immunities, and description. (`[module/documents/actors/common/base-character-data-model.mjsR1-R42](diffhunk://#diff-cf243f13c29751f12daa49f123bd2ba89b39324cbadc106bfc6e96a728caf6d0R1-R42)`)
* Refactored `CharacterDataModel` and `NpcDataModel` to extend `BaseCharacterDataModel` instead of duplicating common fields, and updated their schema definitions to use `Object.assign(super.defineSchema(), ...)` for extending the base schema. 

### Code Simplification and Cleanup

* Removed redundant imports of shared data models from `character-data-model.mjs` and `npc-data-model.mjs` now that they are handled by the base class. 
* Removed duplicated `actor` getter from both `CharacterDataModel` and `NpcDataModel`, as it is now provided by the base class.

### Behavioral/Type Changes

* Updated type check for character actors in `CheckConfigurer.setDamageOverride` to use the new `actor.isCharacterType` property instead of checking for an instance of `CharacterDataModel`.
* Updated the JSDoc for `FUActor.isCharacterType` to clarify its return value. 

### Minor Functional Update

* Added a call to `setDamageOverride` when preparing checks for basic items, ensuring damage overrides are properly applied during check preparation.

These changes collectively modernize and streamline the actor data model structure, making it easier to maintain and extend in the future.