### PR TITLE
Update inline icon, skill chat message rendering

### DIFF
--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -22,6 +22,7 @@ const TRAITS = 'traits';
 const WEAPON_TRAITS = 'weaponTraits';
 const LABEL_KEY = 'label';
 const TARGETED_ACTIONS = 'targetedActions';
+const WEAPON_USED = 'weaponUsedBySkill';
 
 /**
  *
@@ -185,6 +186,13 @@ class CheckInspector {
 	 */
 	hasTrait(trait) {
 		return this.getTraits().includes(trait);
+	}
+
+	/**
+	 * @returns {String} The uuid of the weapon used.
+	 */
+	getWeaponReference() {
+		return this.#check.additionalData[WEAPON_USED];
 	}
 
 	/**
@@ -406,7 +414,7 @@ export class CheckConfigurer extends CheckInspector {
 
 	/**
 	 * @param {string} label
-	 * @param {number} path
+	 * @param {number} value
 	 * @return CheckConfigurer
 	 */
 	addDamageBonusIfDefined(label, value) {
@@ -414,6 +422,13 @@ export class CheckConfigurer extends CheckInspector {
 			return this.addDamageBonus(label, value);
 		}
 		return this;
+	}
+
+	/**
+	 * @param {FUItem} weapon An item that is of the weapon type.
+	 */
+	setWeapon(weapon) {
+		this.check.additionalData[WEAPON_USED] = weapon.uuid;
 	}
 
 	/**

--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -15,6 +15,7 @@ import { CheckRetarget } from './check-retarget.mjs';
 import { GroupCheck } from './group-check.mjs';
 import { SupportCheck } from './support-check.mjs';
 import { CommonEvents } from './common-events.mjs';
+import FoundryUtils from '../helpers/foundry-utils.mjs';
 
 const { DiceTerm, NumericTerm } = foundry.dice.terms;
 
@@ -479,14 +480,18 @@ async function renderCheck(result, actor, item, flags = {}) {
 		}
 	}
 	if (!flavor?.trim()) {
+		let linked = [];
+		const weaponReference = config.getWeaponReference();
+		if (weaponReference) {
+			linked.push(await fromUuid(weaponReference));
+		}
+
 		flavor = item
-			? await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', {
-					name: item.name,
-					img: item.img,
-					id: item.id,
-					uuid: item.uuid,
+			? await FoundryUtils.renderTemplate('chat/chat-check-flavor-item', {
+					item: item,
+					linked: linked,
 				})
-			: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-check.hbs', {
+			: await FoundryUtils.renderTemplate('chat/chat-check-flavor-check', {
 					title: FU.checkTypes[result.type] || 'FU.RollCheck',
 					type: result.type,
 					label: config.getLabel(),

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -195,10 +195,7 @@ const itemFlavor = (sections, item, order = CHECK_FLAVOR) => {
 		order: order,
 		partial: 'systems/projectfu/templates/chat/chat-check-flavor-item.hbs',
 		data: {
-			name: item.name,
-			img: item.img,
-			id: item.id,
-			uuid: item.uuid,
+			item: item,
 		},
 	});
 };

--- a/module/documents/items/classFeature/arcanist/arcanum-data-model.mjs
+++ b/module/documents/items/classFeature/arcanist/arcanum-data-model.mjs
@@ -3,6 +3,7 @@ import { SYSTEM } from '../../../../helpers/config.mjs';
 import { Flags } from '../../../../helpers/flags.mjs';
 import { CommonEvents } from '../../../../checks/common-events.mjs';
 import { TextEditor } from '../../../../helpers/text-editor.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 /**
  * @extends ClassFeatureDataModel
@@ -65,7 +66,9 @@ export class ArcanumDataModel extends RollableClassFeatureDataModel {
 		const speaker = ChatMessage.implementation.getSpeaker({ actor: actor });
 		const chatMessage = {
 			speaker,
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', model.parent.parent),
+			flavor: await FoundryUtils.renderTemplate('chat/chat-check-flavor-item', {
+				item: model.parent.parent,
+			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/arcanist/feature-arcanum-chat-message.hbs', data),
 			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
 		};

--- a/module/documents/items/classFeature/chanter/key-data-model.mjs
+++ b/module/documents/items/classFeature/chanter/key-data-model.mjs
@@ -2,6 +2,7 @@ import { RollableClassFeatureDataModel } from '../class-feature-data-model.mjs';
 import { FU, SYSTEM } from '../../../../helpers/config.mjs';
 import { Flags } from '../../../../helpers/flags.mjs';
 import { KeyMigrations } from './key-migrations.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 const resourceOptions = {
 	hp: 'FU.HealthPoints',
@@ -105,7 +106,9 @@ export class KeyDataModel extends RollableClassFeatureDataModel {
 		const speaker = ChatMessage.implementation.getSpeaker({ actor: actor });
 		const chatMessage = {
 			speaker,
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', model.parent.parent),
+			flavor: await FoundryUtils.renderTemplate('chat-check-flavor-item', {
+				item: model.parent.parent,
+			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/chanter/feature-key-chat-message.hbs', data),
 			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
 		};

--- a/module/documents/items/classFeature/chanter/verses-application.mjs
+++ b/module/documents/items/classFeature/chanter/verses-application.mjs
@@ -9,6 +9,7 @@ import { TextEditor } from '../../../../helpers/text-editor.mjs';
 import FUApplication from '../../../../ui/application.mjs';
 import { ActionCostDataModel } from '../../common/action-cost-data-model.mjs';
 import { ClassFeatureTypeDataModel } from '../class-feature-type-data-model.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 /**
  * @param {VerseDataModel} model
@@ -308,7 +309,9 @@ export class VersesApplication extends FUApplication {
 		// Prepare the chat message data
 		const chatMessage = {
 			speaker: ChatMessage.implementation.getSpeaker({ actor }),
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', this.#verse.parent.parent),
+			flavor: await FoundryUtils.renderTemplate('chat-check-flavor-item', {
+				item: this.#verse.parent.parent,
+			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/chanter/feature-verse-chat-message.hbs', data),
 			flags: flags,
 		};

--- a/module/documents/items/classFeature/dancer/dance-data-model.mjs
+++ b/module/documents/items/classFeature/dancer/dance-data-model.mjs
@@ -3,6 +3,7 @@ import { Flags } from '../../../../helpers/flags.mjs';
 import { SYSTEM } from '../../../../helpers/config.mjs';
 import { CommonEvents } from '../../../../checks/common-events.mjs';
 import { TextEditor } from '../../../../helpers/text-editor.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 const durations = {
 	instant: 'FU.ClassFeatureDanceDurationInstant',
@@ -50,7 +51,7 @@ export class DanceDataModel extends RollableClassFeatureDataModel {
 		const speaker = ChatMessage.implementation.getSpeaker({ actor: item.actor });
 		const chatMessage = {
 			speaker,
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', item),
+			flavor: await FoundryUtils.renderTemplate.renderTemplate('chat/chat-check-flavor-item', { item: item }),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/dancer/feature-dance-chat-message.hbs', data),
 			flags: {
 				[SYSTEM]: { [Flags.ChatMessage.Item]: item },

--- a/module/documents/items/classFeature/esper/psychic-gift-data-model.mjs
+++ b/module/documents/items/classFeature/esper/psychic-gift-data-model.mjs
@@ -2,6 +2,7 @@ import { RollableClassFeatureDataModel } from '../class-feature-data-model.mjs';
 import { SYSTEM } from '../../../../helpers/config.mjs';
 import { Flags } from '../../../../helpers/flags.mjs';
 import { TextEditor } from '../../../../helpers/text-editor.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 /**
  * @extends RollableClassFeatureDataModel
@@ -48,7 +49,9 @@ export class PsychicGiftDataModel extends RollableClassFeatureDataModel {
 		const speaker = ChatMessage.implementation.getSpeaker({ actor: actor });
 		const chatMessage = {
 			speaker,
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', model.parent.parent),
+			flavor: await FoundryUtils.renderTemplate('chat/chat-check-flavor-item', {
+				item: model.parent.parent,
+			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/esper/feature-psychic-chat-message.hbs', data),
 			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
 		};

--- a/module/documents/items/classFeature/pilot/armor-module-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/armor-module-data-model.mjs
@@ -2,6 +2,7 @@ import { RollableClassFeatureDataModel } from '../class-feature-data-model.mjs';
 import { FU, SYSTEM } from '../../../../helpers/config.mjs';
 import { Flags } from '../../../../helpers/flags.mjs';
 import { TextEditor } from '../../../../helpers/text-editor.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 /**
  * @extends RollableClassFeatureDataModel
@@ -89,7 +90,9 @@ export class ArmorModuleDataModel extends RollableClassFeatureDataModel {
 		const speaker = ChatMessage.implementation.getSpeaker({ actor: actor });
 		const chatMessage = {
 			speaker,
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', model.parent.parent),
+			flavor: await FoundryUtils.renderTemplate('chat/chat-check-flavor-item', {
+				item: model.parent.parent,
+			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/pilot/feature-armor-module-chat-message.hbs', data),
 			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
 		};

--- a/module/documents/items/classFeature/pilot/vehicle-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/vehicle-data-model.mjs
@@ -2,6 +2,7 @@ import { RollableClassFeatureDataModel } from '../class-feature-data-model.mjs';
 import { SYSTEM } from '../../../../helpers/config.mjs';
 import { Flags } from '../../../../helpers/flags.mjs';
 import { TextEditor } from '../../../../helpers/text-editor.mjs';
+import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
 
 /**
  * Available frame types and their translation keys
@@ -80,7 +81,9 @@ export class VehicleDataModel extends RollableClassFeatureDataModel {
 		const speaker = ChatMessage.implementation.getSpeaker({ actor: actor });
 		const chatMessage = {
 			speaker,
-			flavor: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', model.parent.parent),
+			flavor: await FoundryUtils.renderTemplate('chat/chat-check-flavor-item', {
+				item: model.parent.parent,
+			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/pilot/feature-vehicle-frame-chat-message.hbs', data),
 			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
 		};

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -32,13 +32,6 @@ Hooks.on(CheckHooks.renderCheck, (sections, check, actor, item, flags) => {
 			CommonSections.clock(sections, item.system.progress, CHECK_DETAILS);
 		}
 		if (weapon) {
-			sections.push(() => ({
-				partial: 'systems/projectfu/templates/chat/partials/chat-ability-weapon.hbs',
-				data: {
-					weapon,
-				},
-				order: CHECK_DETAILS,
-			}));
 			CommonSections.tags(
 				sections,
 				[

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -35,13 +35,14 @@ let onRenderAccuracyCheck = (sections, check, actor, item, flags) => {
 			CommonSections.opportunity(sections, item.system.opportunity, CHECK_DETAILS);
 		}
 
-		CommonSections.tags(sections, getTags(item), CHECK_DETAILS);
-		CommonSections.description(sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
+		let tags = getTags(item);
 		if (weapon) {
 			if (weapon.system.getTags instanceof Function) {
-				CommonSections.tags(sections, weapon.system.getTags(item.system.useWeapon.traits), CHECK_DETAILS);
+				tags.push(...weapon.system.getTags(item.system.useWeapon.traits));
 			}
 		}
+		CommonSections.tags(sections, tags, CHECK_DETAILS);
+		CommonSections.description(sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
 
 		const targets = inspector.getTargets();
 		CommonSections.spendResource(sections, actor, item, item.system.cost, targets, flags);

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -21,7 +21,6 @@ import { Traits, TraitUtils } from '../../../pipelines/traits.mjs';
 import { EffectApplicationDataModel } from '../common/effect-application-data-model.mjs';
 import { ResourceDataModel } from '../common/resource-data-model.mjs';
 
-const weaponUsedBySkill = 'weaponUsedBySkill';
 const skillForAttributeCheck = 'skillForAttributeCheck';
 
 /**
@@ -29,7 +28,8 @@ const skillForAttributeCheck = 'skillForAttributeCheck';
  */
 let onRenderAccuracyCheck = (sections, check, actor, item, flags) => {
 	if (check.type === 'accuracy' && item?.system instanceof SkillDataModel) {
-		const weapon = fromUuidSync(check.additionalData[weaponUsedBySkill]);
+		const inspector = CheckConfiguration.inspect(check);
+		const weapon = fromUuidSync(inspector.getWeaponReference());
 
 		if (check.critical) {
 			CommonSections.opportunity(sections, item.system.opportunity, CHECK_DETAILS);
@@ -38,20 +38,11 @@ let onRenderAccuracyCheck = (sections, check, actor, item, flags) => {
 		CommonSections.tags(sections, getTags(item), CHECK_DETAILS);
 		CommonSections.description(sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
 		if (weapon) {
-			sections.push(() => ({
-				partial: 'systems/projectfu/templates/chat/partials/chat-ability-weapon.hbs',
-				data: {
-					weapon,
-				},
-				order: CHECK_DETAILS,
-			}));
-
 			if (weapon.system.getTags instanceof Function) {
 				CommonSections.tags(sections, weapon.system.getTags(item.system.useWeapon.traits), CHECK_DETAILS);
 			}
 		}
 
-		const inspector = CheckConfiguration.inspect(check);
 		const targets = inspector.getTargets();
 		CommonSections.spendResource(sections, actor, item, item.system.cost, targets, flags);
 	}
@@ -239,9 +230,9 @@ export class SkillDataModel extends FUStandardItemDataModel {
 			if (this.damage.hasDamage) {
 				if (skill.useWeapon.damage) {
 					const weapon = await this.getWeapon(actor);
+					config.setWeapon(weapon);
 					/** @type WeaponDataModel **/
 					const weaponData = weapon.system;
-					check.additionalData[weaponUsedBySkill] = weapon.uuid;
 					config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);
 				}
 				await this.#addSkillDamage(config, actor, item, context, modifiers);
@@ -304,7 +295,6 @@ export class SkillDataModel extends FUStandardItemDataModel {
 
 			check.primary = weaponCheck.primary;
 			check.secondary = weaponCheck.secondary;
-			check.additionalData[weaponUsedBySkill] = weapon.uuid;
 
 			/** @type SkillDataModel **/
 			const skill = item.system;
@@ -312,6 +302,7 @@ export class SkillDataModel extends FUStandardItemDataModel {
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
 
+			config.setWeapon(weapon);
 			config.addTraits('skill');
 			config.addTraitsFromItemModel(this.traits);
 

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -1002,6 +1002,8 @@ FU.allIcon = {
 	weaponEnchant: 'fu-weapon-enchant',
 	damage: 'fu-damage',
 	type: 'fu-type',
+	info: 'fas fa-circle-info',
+	warning: 'fas fa-triangle-exclamation',
 	roll: FU.checkIcons.open,
 	...FU.checkIcons,
 	...FU.affinityIcons,

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -201,6 +201,7 @@ export const FUHandlebars = Object.freeze({
 		Handlebars.registerHelper('pfuTraits', traits);
 		Handlebars.registerHelper('pfuIconAttribute', attributeIcon);
 		Handlebars.registerHelper('pfuBadge', badge);
+		Handlebars.registerHelper('pfuItemAnchor', itemAnchor);
 	},
 });
 
@@ -358,6 +359,30 @@ function badge(key, options) {
 					size: size,
 					value: options.value,
 					compact: options.compact,
+				})
+			: '';
+	return new Handlebars.SafeString(html);
+}
+
+/**
+ * @param {FUItem} item
+ * @param {BadgeOptions} options
+ * @returns {Handlebars.SafeString}
+ */
+function itemAnchor(item, options) {
+	if (options.hash) {
+		options = options.hash;
+	}
+
+	const template = Handlebars.partials[systemTemplatePath('common/icons/item')];
+	const html =
+		typeof template === 'function'
+			? template({
+					name: item.name,
+					uuid: item.uuid,
+					id: item.id,
+					img: item.img,
+					classes: options?.classes,
 				})
 			: '';
 	return new Handlebars.SafeString(html);

--- a/module/helpers/inline-action.mjs
+++ b/module/helpers/inline-action.mjs
@@ -35,7 +35,7 @@ const editorEnricher = {
 
 			// ICON
 			const icon = FU.actionIcons[type];
-			InlineHelper.appendVectorIcon(anchor, 'fu-icon-s', icon);
+			InlineHelper.appendIcon(anchor, 'fu-icon-s', icon);
 			/** @type FUActionType **/
 			switch (type) {
 				case 'study':

--- a/module/helpers/inline-check.mjs
+++ b/module/helpers/inline-check.mjs
@@ -55,7 +55,7 @@ function checkEnricher(match, options) {
 		let tooltip = game.i18n.localize('FU.InlineRollCheck');
 
 		// ICON
-		InlineHelper.appendIcon(anchor, 'open');
+		InlineHelper.appendSystemIcon(anchor, 'open');
 
 		if (label) {
 			anchor.append(label);
@@ -91,8 +91,8 @@ function checkEnricher(match, options) {
 		// Show attributes
 		const span = document.createElement('span');
 		span.classList.add(`inline`, 'inline-group');
-		InlineHelper.appendIcon(span, first);
-		InlineHelper.appendIcon(span, second);
+		InlineHelper.appendSystemIcon(span, first);
+		InlineHelper.appendSystemIcon(span, second);
 		anchor.append(span);
 		return anchor;
 	}

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -40,7 +40,7 @@ function damageEnricher(text, options) {
 		}
 		anchor.draggable = true;
 
-		InlineHelper.appendIcon(anchor, 'damage');
+		InlineHelper.appendSystemIcon(anchor, 'damage');
 
 		// TOOLTIP
 		anchor.setAttribute(
@@ -61,7 +61,7 @@ function damageEnricher(text, options) {
 		}
 
 		// ICON
-		InlineHelper.appendIcon(anchor, type);
+		InlineHelper.appendSystemIcon(anchor, type);
 		return anchor;
 	}
 

--- a/module/helpers/inline-helper.mjs
+++ b/module/helpers/inline-helper.mjs
@@ -383,12 +383,18 @@ function appendImage(anchor, path, size = 16, margin = true) {
 }
 
 /**
+ * @typedef InlineIconConfig
+ * @property {String[]|String} classes
+ * @property {String} size
+ */
+
+/**
  * @param {HTMLAnchorElement} anchor
  * @param {...string} classes
  */
-function appendVectorIcon(anchor, ...classes) {
+function appendIcon(anchor, ...classes) {
 	const icon = document.createElement(`i`);
-	icon.classList.add(`icon`, ...classes.flatMap((c) => c.split(/\s+/)));
+	icon.classList.add(`fu-icon--xs`, ...classes.flatMap((c) => c.split(/\s+/)));
 	icon.style.marginLeft = '2px';
 	anchor.append(icon);
 	return icon;
@@ -397,14 +403,11 @@ function appendVectorIcon(anchor, ...classes) {
 /**
  * @param {HTMLAnchorElement} anchor
  * @param {String} name
+ *
  */
-function appendIcon(anchor, name) {
-	const icon = document.createElement(`i`);
+function appendSystemIcon(anchor, name) {
 	const className = FU.allIcon[name];
-	icon.classList.add(`fu-icon--xs`, className);
-	icon.style.marginLeft = '2px';
-	anchor.append(icon);
-	return icon;
+	return appendIcon(anchor, className);
 }
 
 /**
@@ -478,8 +481,8 @@ export const InlineHelper = {
 	determineSource,
 	appendAmountToAnchor,
 	appendImage,
-	appendVectorIcon,
 	appendIcon,
+	appendSystemIcon,
 	appendVariableToAnchor,
 	registerCommand,
 	compose,

--- a/module/helpers/inline-icons.mjs
+++ b/module/helpers/inline-icons.mjs
@@ -1,41 +1,31 @@
 import { FU } from './config.mjs';
-import { systemAssetPath } from './system-utils.mjs';
 import { InlineHelper } from './inline-helper.mjs';
+import { StringUtils } from './string-utils.mjs';
 
 const inlineIconEnricher = {
 	id: 'inlineIconEnricher',
-	pattern: /@ICON\[(\w+?)]/g,
+	pattern: InlineHelper.compose('(?:ICON|TOOLTIP)', '(?<icon>\\w+)(?:\\s+"(?<tooltip>[^"]*)")?'),
 	enricher: enricher,
 };
 
 function enricher(text, options) {
-	const iconName = text[1];
+	//const iconName = text[1];
+	const iconName = text.groups.icon;
 
 	if (iconName in FU.allIcon) {
-		const iconClass = FU.allIcon[iconName];
-		const span = document.createElement('span');
-		const classNames = iconClass.split(' ').filter((className) => className !== '');
-		span.classList.add('inline', 'inline-icon', ...classNames);
-		span.textContent = '';
-		return span;
-	} else if (iconName in attributeIconPaths) {
-		const span = document.createElement('span');
-		span.classList.add('inline', 'inline-icon');
-		span.dataset.tooltip = game.i18n.localize(FU.attributes[iconName]);
-		InlineHelper.appendImage(span, attributeIconPaths[iconName], 16, false);
+		const anchor = document.createElement('a');
+		anchor.classList.add('inline', 'inline-icon');
+		InlineHelper.appendSystemIcon(anchor, iconName);
 
-		return span;
+		const tooltip = text.groups.tooltip;
+		if (tooltip) {
+			anchor.setAttribute('data-tooltip', StringUtils.localize(tooltip));
+		}
+		return anchor;
 	}
 
 	return null;
 }
-
-const attributeIconPaths = {
-	dex: systemAssetPath('icons/attributes/dex-glyph.png'),
-	mig: systemAssetPath('icons/attributes/mig-glyph.png'),
-	ins: systemAssetPath('icons/attributes/ins-glyph.png'),
-	wlp: systemAssetPath('icons/attributes/wlp-glyph.png'),
-};
 
 function getIconClass(icon) {
 	return FU.allIcon[icon];
@@ -46,6 +36,5 @@ function getIconClass(icon) {
  */
 export const InlineIcon = Object.freeze({
 	enrichers: [inlineIconEnricher],
-	attributeIconPaths,
 	getIconClass,
 });

--- a/module/helpers/inline-resources.mjs
+++ b/module/helpers/inline-resources.mjs
@@ -71,7 +71,7 @@ function createReplacementElement(amount, type, elementClass, uncapped, tooltip,
 			anchor.append(` ${typeName}`);
 		}
 		// ICON
-		InlineHelper.appendIcon(anchor, type);
+		InlineHelper.appendSystemIcon(anchor, type);
 
 		return anchor;
 	} else {

--- a/module/helpers/inline-type.mjs
+++ b/module/helpers/inline-type.mjs
@@ -41,7 +41,7 @@ const editorEnricher = {
 			const label = match.groups.label;
 
 			// ICON
-			InlineHelper.appendIcon(anchor, 'type');
+			InlineHelper.appendSystemIcon(anchor, 'type');
 
 			if (type === 'damage') {
 				// TOOLTIP
@@ -84,7 +84,7 @@ const editorEnricher = {
 					anchor.append(`${localizedAffinity} (${localizedTypes})`);
 				}
 				// ICON
-				InlineHelper.appendVectorIcon(anchor, 'fu-icon--xs', damageTypes.length > 1 ? FU.allIcon.diamond : FU.affIcon[damageTypes[0]]);
+				InlineHelper.appendIcon(anchor, damageTypes.length > 1 ? FU.allIcon.diamond : FU.affIcon[damageTypes[0]]);
 				return anchor;
 			}
 		}

--- a/module/helpers/section-chat-builder.mjs
+++ b/module/helpers/section-chat-builder.mjs
@@ -97,11 +97,8 @@ export class SectionChatBuilder {
 		}
 		if (!flavor?.trim()) {
 			flavor = item
-				? await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-check-flavor-item.hbs', {
-						name: item.name,
-						img: item.img,
-						id: item.id,
-						uuid: item.uuid,
+				? await FoundryUtils.renderTemplate('chat/chat-check-flavor-item', {
+						item: item,
 					})
 				: '';
 		}

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -53,6 +53,7 @@ export const preloadHandlebarsTemplates = async function () {
 			'systems/projectfu/templates/common/auto-complete.hbs',
 			'systems/projectfu/templates/common/traits.hbs',
 			'systems/projectfu/templates/common/icons/badge.hbs',
+			'systems/projectfu/templates/common/icons/item.hbs',
 
 			// Effects
 			'systems/projectfu/templates/effects/active-effect-details.hbs',

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -312,3 +312,8 @@
 	-webkit-filter: unset;
 	filter: unset;
 }
+
+.fu-image__link {
+	border-radius: 10px;
+	background-color: rgba(9, 66, 34, 0.14);
+}

--- a/templates/chat/chat-check-flavor-item.hbs
+++ b/templates/chat/chat-check-flavor-item.hbs
@@ -1,11 +1,13 @@
 <header class="title-desc chat-header flexrow">
-    <a data-link draggable="true" data-uuid="{{uuid}}" data-type="Item" data-tooltip="{{name}}"><img src="{{img}}"
-            alt="Image" data-item-id="{{id}}" class="item-img"></a>
-    <h2 style="flex-grow: 8; margin-left: 4px;">{{name}}</h2>
-    <a class="universal-toggle fu-tags flexrow gap-5" style="align-items:end;"
-        data-tooltip="{{localize 'FU.ChatMessageShow'}}">
-        <span class="fu-tag button" style="padding: 5px;">
-            <i class="fas fa-chevron-up toggle-icon"></i>
-        </span>
-    </a>
+	{{pfuItemAnchor item}}
+	<h2 style="flex-grow: 8; margin-left: 4px;">{{item.name}}</h2>
+	{{#each linked as |li|}}
+		{{pfuItemAnchor li classes="fu-image__link"}}
+	{{/each}}
+	<a class="universal-toggle fu-tags flexrow gap-5" style="align-items:end;"
+	   data-tooltip="{{localize 'FU.ChatMessageShow'}}">
+			<span class="fu-tag button" style="padding: 5px;">
+				<i class="fas fa-chevron-up toggle-icon"></i>
+			</span>
+	</a>
 </header>

--- a/templates/common/icons/item.hbs
+++ b/templates/common/icons/item.hbs
@@ -1,0 +1,5 @@
+<a data-link draggable="true" data-uuid="{{uuid}}"
+   class="{{classes}}"
+   data-type="Item" data-tooltip="{{name}}">
+	<img src="{{img}}" alt="{{name}}" data-item-id="{{id}}" class="item-img">
+</a>


### PR DESCRIPTION
This pull request introduces a more robust and consistent approach for handling weapon references in skill checks and chat message rendering, while also refactoring the way chat flavor templates are rendered across various item data models. Additionally, it introduces a new Handlebars helper for item anchors and improves icon support. The changes are grouped into three main themes: weapon reference handling, chat flavor rendering refactor, and UI/Handlebars enhancements.

**Weapon Reference Handling and Skill Checks**
- Introduced a new constant `WEAPON_USED` and corresponding getter/setter methods (`getWeaponReference`, `setWeapon`) in `CheckInspector` and `CheckConfigurer` to standardize how weapon references are stored and accessed in skill checks. This replaces previous direct manipulation of `additionalData` and string constants. [[1]](diffhunk://#diff-a9e8cf5c6eb9e1df14abbbef3f093c1c7fc0df669748dcf3694767a635d9b14bR25) [[2]](diffhunk://#diff-a9e8cf5c6eb9e1df14abbbef3f093c1c7fc0df669748dcf3694767a635d9b14bR191-R197) [[3]](diffhunk://#diff-a9e8cf5c6eb9e1df14abbbef3f093c1c7fc0df669748dcf3694767a635d9b14bR427-R433)
- Updated skill check logic to use the new `setWeapon` and `getWeaponReference` methods, improving encapsulation and consistency when associating weapons with skill checks. [[1]](diffhunk://#diff-8a73c984614377bd6825d61edd71b98b036d399ec8c3b99fb329c497e3678436R234-L244) [[2]](diffhunk://#diff-8a73c984614377bd6825d61edd71b98b036d399ec8c3b99fb329c497e3678436L307-R306)
- Modified the rendering logic for skill check results to retrieve the weapon via the new inspector method, and improved tag aggregation when a weapon is present.

**Chat Flavor Rendering Refactor**
- Refactored chat flavor rendering across multiple class feature data models (`arcanum`, `key`, `verses`, `dance`, `psychic gift`, `armor module`, `vehicle`) to use a new centralized `FoundryUtils.renderTemplate` helper, passing an `item` object instead of individual fields. This reduces template code duplication and standardizes the rendering process. [[1]](diffhunk://#diff-91891d2bd08c94bef124d39657d314fb81873534286a05563c9a9f11f0b15a62L68-R71) [[2]](diffhunk://#diff-e435263eff36853464ad6d11556a282804c9be083224d4610d18e2755f77162cL108-R111) [[3]](diffhunk://#diff-74c272722d45c74bafee2dc11cb25a91f14782150f5162130dd502ebc1259428L311-R314) [[4]](diffhunk://#diff-0a36d40bc611e17fe9157d84a8438ea0d13159f71994b2b4179be18baa20bd87L53-R54) [[5]](diffhunk://#diff-e4b0bf5662a7ab060eb5cf85aef0f5780c0adb9063a49ccff8717749e87119bfL51-R54) [[6]](diffhunk://#diff-519208cb06a606eeee9149d14dfaee3c3450a48510bea186cfafcc68308c767dL92-R95) [[7]](diffhunk://#diff-f3793803652647ffe1ab1cd1d6b7d54980ede8ee4ed899850f229972aa97f582L83-R86) [[8]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL198-R198)
- Updated `itemFlavor` and check rendering code to use the new template rendering approach and data structure, improving maintainability and extensibility. [[1]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1R483-R494) [[2]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL198-R198)

**UI and Handlebars Enhancements**
- Added new icons (`info`, `warning`) to the icon configuration for broader UI support.
- Introduced a new Handlebars helper `pfuItemAnchor` for rendering item links in templates, along with its implementation and registration. [[1]](diffhunk://#diff-2858726f1f56a71994d97fd2136ecbd6a4d936273d1dbc421a18b37fe37cabdfR204) [[2]](diffhunk://#diff-2858726f1f56a71994d97fd2136ecbd6a4d936273d1dbc421a18b37fe37cabdfR366-R389)
- Improved inline action icon rendering by switching from `appendVectorIcon` to a more general `appendIcon` function, enhancing flexibility for future icon updates.

These changes collectively improve code maintainability, consistency, and the user experience when interacting with skill checks and item-related chat messages.