### PR TITLE
Add compendium filters

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1740,6 +1740,8 @@
 		},
 		"CompendiumBrowser": "Compendium Browser",
 		"CompendiumBrowserOpen": "Open Compendium Browser",
-		"Actors": "Actors"
+		"Actors": "Actors",
+		"Ability": "Ability",
+		"Abilities": "Abilities"
 	}
 }

--- a/module/documents/items/spell/spell-data-model.mjs
+++ b/module/documents/items/spell/spell-data-model.mjs
@@ -59,7 +59,7 @@ Hooks.on(CheckHooks.renderCheck, onRenderCheck);
  * @property {UseWeaponDataModel} useWeapon
  * @property {ItemAttributesDataModel} attributes
  * @property {number} accuracy.value
- * @property {DamageDataModel} damage
+ //* @property {DamageDataModel} damage
  * @property {EffectApplicationDataModel} effects
  * @property {ResourceDataModel} resource
  * @property {ImprovisedDamageDataModel} impdamage
@@ -89,7 +89,7 @@ export class SpellDataModel extends FUStandardItemDataModel {
 			useWeapon: new EmbeddedDataField(UseWeaponDataModel, {}),
 			attributes: new EmbeddedDataField(ItemAttributesDataModel, { initial: { primary: { value: 'ins' }, secondary: { value: 'mig' } } }),
 			accuracy: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
-			damage: new EmbeddedDataField(DamageDataModel, {}),
+			// damage: new EmbeddedDataField(DamageDataModel, {}),
 			resource: new EmbeddedDataField(ResourceDataModel, {}),
 			effects: new EmbeddedDataField(EffectApplicationDataModel, {}),
 			impdamage: new EmbeddedDataField(ImprovisedDamageDataModel, {}),

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -401,7 +401,7 @@ function itemAnchor(item, options) {
 
 /**
  * @param {String} tab
- * @param {CompendiumFilterOptions} options
+ * @param {CompendiumFilterInputOptions} options
  * @returns {Handlebars.SafeString}
  */
 function compendium(tab, options) {

--- a/module/helpers/html-utils.mjs
+++ b/module/helpers/html-utils.mjs
@@ -79,4 +79,17 @@ export const HTMLUtils = Object.freeze({
 			dataset[key] = value ?? '';
 		}
 	},
+
+	/**
+	 * @param fn A function
+	 * @param ms The time in milliseconds.
+	 * @returns {(function(...[*]): void)|*}
+	 */
+	debounce: (fn, ms) => {
+		let timer;
+		return (...args) => {
+			clearTimeout(timer);
+			timer = setTimeout(() => fn(...args), ms);
+		};
+	},
 });

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -93,6 +93,19 @@ class WeaponCompendiumTableRenderer extends CompendiumTableRenderer {
 	};
 }
 
+class AttackCompendiumTableRenderer extends CompendiumTableRenderer {
+	/** @type TableConfig */
+	static TABLE_CONFIG = {
+		...super.TABLE_CONFIG,
+		cssClass: 'compendium-attack-table',
+		columns: {
+			name: CommonColumns.itemAnchorColumn({ columnName: 'FU.Name' }),
+			damage: CommonColumns.propertyColumn('FU.Damage', 'system.damage.value'),
+			type: CommonColumns.propertyColumn('FU.Type', 'system.damageType.value', FU.damageTypes),
+		},
+	};
+}
+
 class ArmorCompendiumTableRenderer extends CompendiumTableRenderer {
 	/** @type TableConfig */
 	static TABLE_CONFIG = {
@@ -158,6 +171,7 @@ export class CompendiumBrowser extends FUApplication {
 				{ id: 'equipment', label: 'FU.Equipment', icon: 'ra ra-anvil' },
 				{ id: 'spells', label: 'FU.Spells', icon: 'ra ra-fairy-wand' },
 				{ id: 'adversaries', label: 'FU.Adversaries', icon: 'ra ra-monster-skull' },
+				{ id: 'abilities', label: 'FU.Abilities', icon: 'ra ra-bird-claw' },
 				{ id: 'effects', label: 'FU.Effects', icon: 'ra ra-droplet-splash' },
 			],
 			initial: 'classes',
@@ -217,6 +231,9 @@ export class CompendiumBrowser extends FUApplication {
 		},
 		effects: {
 			template: systemTemplatePath('ui/compendium-browser/compendium-browser-effects'),
+		},
+		abilities: {
+			template: systemTemplatePath('ui/compendium-browser/compendium-browser-abilities'),
 		},
 	};
 
@@ -301,6 +318,7 @@ export class CompendiumBrowser extends FUApplication {
 			case 'equipment':
 			case 'skills':
 			case 'spells':
+			case 'abilities':
 			case 'effects':
 				{
 					context.tables = tabData.tables;
@@ -406,6 +424,7 @@ export class CompendiumBrowser extends FUApplication {
 	#armorRenderer = new ArmorCompendiumTableRenderer();
 	#consumableRenderer = new ConsumableCompendiumTableRenderer();
 	#skillRenderer = new SkillsCompendiumTableRenderer();
+	#attackRenderer = new AttackCompendiumTableRenderer();
 
 	getTypeFilter(entries) {
 		return {
@@ -490,20 +509,59 @@ export class CompendiumBrowser extends FUApplication {
 								entries: skills.heroic,
 								renderer: this.#basicRenderer,
 							},
-							{
-								entries: skills.miscAbility,
-								renderer: this.#basicRenderer,
-							},
-							{
-								entries: skills.rule,
-								renderer: this.#basicRenderer,
-							},
 						],
 						{
 							class: {
 								label: 'FU.Class',
 								propertyPath: 'system.class.value',
 								options: classOptions,
+							},
+						},
+					);
+				}
+				break;
+
+			case 'abilities':
+				{
+					const abilities = await this.index.getAbilities();
+					await this.setTables(
+						[
+							{
+								entries: abilities.basic,
+								renderer: this.#attackRenderer,
+							},
+							{
+								entries: abilities.miscAbility,
+								renderer: this.#basicRenderer,
+							},
+							{
+								entries: abilities.rule,
+								renderer: this.#basicRenderer,
+							},
+						],
+						{
+							type: {
+								label: 'FU.Type',
+								propertyPath: 'type',
+								options: [
+									{
+										value: 'basic',
+										label: 'FU.Attack',
+									},
+									{
+										value: 'miscAbility',
+										label: 'FU.Ability',
+									},
+									{
+										value: 'rule',
+										label: 'FU.Rule',
+									},
+								],
+							},
+							attackDamage: {
+								label: 'FU.DamageType',
+								propertyPath: CompendiumIndex.itemFields.weaponDamageType,
+								options: FoundryUtils.getFormOptions(FU.damageTypes),
 							},
 						},
 					);

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -7,6 +7,7 @@ import { CompendiumIndex } from './compendium-index.mjs';
 import { FU } from '../../helpers/config.mjs';
 import { CompendiumFilter } from './compendium-filter.mjs';
 import { HTMLUtils } from '../../helpers/html-utils.mjs';
+import FoundryUtils from '../../helpers/foundry-utils.mjs';
 
 /**
  * @typedef CompendiumIndexEntry
@@ -406,6 +407,23 @@ export class CompendiumBrowser extends FUApplication {
 	#consumableRenderer = new ConsumableCompendiumTableRenderer();
 	#skillRenderer = new SkillsCompendiumTableRenderer();
 
+	getTypeFilter(entries) {
+		return {
+			label: 'FU.Type',
+			propertyPath: 'type',
+			options: [
+				{
+					value: 'class',
+					label: 'FU.Class',
+				},
+				{
+					value: 'classFeature',
+					label: 'FU.ClassFeature',
+				},
+			],
+		};
+	}
+
 	/**
 	 *
 	 * @param {String} tabId
@@ -495,36 +513,91 @@ export class CompendiumBrowser extends FUApplication {
 			case 'equipment':
 				{
 					const equipment = await this.index.getEquipment();
-					await this.setTables([
+					await this.setTables(
+						[
+							{
+								entries: equipment.weapon,
+								renderer: this.#weaponRenderer,
+							},
+							{
+								entries: equipment.armor,
+								renderer: this.#armorRenderer,
+							},
+							{
+								entries: equipment.accessory,
+								renderer: this.#armorRenderer, // Same data paths as above.
+							},
+							{
+								entries: equipment.consumable,
+								renderer: this.#consumableRenderer,
+							},
+						],
 						{
-							entries: equipment.weapon,
-							renderer: this.#weaponRenderer,
+							type: {
+								label: 'FU.Type',
+								propertyPath: 'type',
+								options: [
+									{
+										value: 'weapon',
+										label: 'FU.Weapon',
+									},
+									{
+										value: 'armor',
+										label: 'FU.Armor',
+									},
+									{
+										value: 'accessory',
+										label: 'FU.Accessory',
+									},
+									{
+										value: 'consumable',
+										label: 'FU.Consumable',
+									},
+								],
+							},
+							weaponCategory: {
+								label: 'FU.Category',
+								propertyPath: CompendiumIndex.itemFields.weaponCategory,
+								options: FoundryUtils.getFormOptions(FU.weaponCategories),
+							},
+							weaponDamage: {
+								label: 'FU.DamageType',
+								propertyPath: CompendiumIndex.itemFields.weaponDamageType,
+								options: FoundryUtils.getFormOptions(FU.damageTypes),
+							},
 						},
-						{
-							entries: equipment.armor,
-							renderer: this.#armorRenderer,
-						},
-						{
-							entries: equipment.accessory,
-							renderer: this.#armorRenderer, // Same data paths as above.
-						},
-						{
-							entries: equipment.consumable,
-							renderer: this.#consumableRenderer,
-						},
-					]);
+					);
 				}
 				break;
 
 			case 'adversaries':
 				{
 					const characters = await this.index.getCharacters();
-					await this.setTables([
+					await this.setTables(
+						[
+							{
+								entries: characters.npc,
+								renderer: this.#adversaryRenderer,
+							},
+						],
 						{
-							entries: characters.npc,
-							renderer: this.#adversaryRenderer,
+							species: {
+								label: 'FU.Species',
+								propertyPath: 'system.species.value',
+								options: FoundryUtils.getFormOptions(FU.species),
+							},
+							rank: {
+								label: 'FU.Rank',
+								propertyPath: 'system.rank.value',
+								options: FoundryUtils.getFormOptions(FU.rank),
+							},
+							role: {
+								label: 'FU.Role',
+								propertyPath: 'system.role.value',
+								options: FoundryUtils.getFormOptions(FU.role),
+							},
 						},
-					]);
+					);
 				}
 				break;
 
@@ -550,6 +623,11 @@ export class CompendiumBrowser extends FUApplication {
 								label: 'FU.Class',
 								propertyPath: 'system.class.value',
 								options: classOptions,
+							},
+							damageType: {
+								label: 'FU.DamageType',
+								propertyPath: CompendiumIndex.itemFields.spellDamageType,
+								options: FoundryUtils.getFormOptions(FU.damageTypes),
 							},
 						},
 					);

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -332,6 +332,7 @@ export class CompendiumBrowser extends FUApplication {
 		switch (partId) {
 			case 'sidebar':
 				{
+					// Text filter
 					const searchInput = element.querySelector('#search');
 					if (!searchInput) {
 						return;
@@ -341,11 +342,11 @@ export class CompendiumBrowser extends FUApplication {
 						HTMLUtils.debounce(() => {
 							const text = searchInput.value.toLowerCase() || '';
 							this.filter.setText(text);
+							console.debug(`[COMPENDIUM] Text updated: ${text}`);
 							return this.renderTables(this.activeTabId, true, false);
 						}, 150),
 					);
-
-					// Checkbox filters (delegated)
+					// Checkbox filters
 					element.addEventListener('change', (event) => {
 						const input = event.target;
 						if (!(input instanceof HTMLInputElement)) return;
@@ -355,7 +356,7 @@ export class CompendiumBrowser extends FUApplication {
 						if (!category || !option) return;
 						this.filter.toggle(category, option, input.checked);
 						console.debug(`[COMPENDIUM] Filter toggled: ${category}=${option} (${input.checked})`);
-						//this.#applyFilters();
+						return this.renderTables(this.activeTabId, true, false);
 					});
 				}
 				break;

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -491,7 +491,7 @@ export class CompendiumBrowser extends FUApplication {
 								],
 							},
 							class: {
-								label: 'FU.Class',
+								label: 'FU.ClassFeature',
 								propertyPath: 'metadata.class',
 								options: classOptions,
 							},

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -455,24 +455,40 @@ export class CompendiumBrowser extends FUApplication {
 			case 'skills':
 				{
 					const skills = await this.index.getSkills();
-					await this.setTables([
+					const classes = await this.index.getItemsOfType('class');
+					const classOptions = classes.map((c) => {
+						return {
+							value: c.name,
+							label: c.name,
+						};
+					});
+					await this.setTables(
+						[
+							{
+								entries: skills.skill,
+								renderer: this.#skillRenderer,
+							},
+							{
+								entries: skills.heroic,
+								renderer: this.#basicRenderer,
+							},
+							{
+								entries: skills.miscAbility,
+								renderer: this.#basicRenderer,
+							},
+							{
+								entries: skills.rule,
+								renderer: this.#basicRenderer,
+							},
+						],
 						{
-							entries: skills.skill,
-							renderer: this.#skillRenderer,
+							class: {
+								label: 'FU.Class',
+								propertyPath: 'system.class.value',
+								options: classOptions,
+							},
 						},
-						{
-							entries: skills.heroic,
-							renderer: this.#basicRenderer,
-						},
-						{
-							entries: skills.miscAbility,
-							renderer: this.#basicRenderer,
-						},
-						{
-							entries: skills.rule,
-							renderer: this.#basicRenderer,
-						},
-					]);
+					);
 				}
 				break;
 
@@ -515,12 +531,28 @@ export class CompendiumBrowser extends FUApplication {
 			case 'spells':
 				{
 					const spells = await this.index.getItemsOfType('spell');
-					await this.setTables([
+					const classes = ['Spiritist', 'Entropist', 'Elementalist']; // hardcoded for now
+					const classOptions = classes.map((c) => {
+						return {
+							value: c,
+							label: c,
+						};
+					});
+					await this.setTables(
+						[
+							{
+								entries: spells,
+								renderer: this.#spellRenderer,
+							},
+						],
 						{
-							entries: spells,
-							renderer: this.#spellRenderer,
+							class: {
+								label: 'FU.Class',
+								propertyPath: 'system.class.value',
+								options: classOptions,
+							},
 						},
-					]);
+					);
 				}
 				break;
 
@@ -561,18 +593,15 @@ export class CompendiumBrowser extends FUApplication {
 	}
 
 	/**
-	 * @typedef CompendiumFilterOptions
-	 * @property {String} text
-	 *
-	 */
-
-	/**
 	 * @param {String} tab The initial tab to open.
-	 * @param {CompendiumFilterOptions} filter Initial filtering for the tab.
+	 * @param {CompendiumFilterInputOptions} inputFilter Initial filtering for the tab.
 	 */
-	static open(tab, filter) {
+	static open(tab, inputFilter) {
 		const instance = CompendiumBrowser.instance;
-		instance.filter.setText(filter.text);
+		instance.filter.setText(inputFilter.text);
+		if (inputFilter.filter) {
+			instance.filter.toggle(inputFilter.filter.key, inputFilter.filter.option, true);
+		}
 		instance.render(true, {
 			tab: tab,
 		});

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -458,6 +458,12 @@ export class CompendiumBrowser extends FUApplication {
 			case 'classes':
 				{
 					const classes = await this.index.getClasses();
+					const classOptions = classes.class
+						.sort((a, b) => a.name.localeCompare(b.name))
+						.map((c) => ({
+							value: c.name,
+							label: c.name,
+						}));
 					await this.setTables(
 						[
 							{
@@ -484,6 +490,11 @@ export class CompendiumBrowser extends FUApplication {
 									},
 								],
 							},
+							class: {
+								label: 'FU.Class',
+								propertyPath: 'metadata.class',
+								options: classOptions,
+							},
 						},
 					);
 				}
@@ -493,12 +504,12 @@ export class CompendiumBrowser extends FUApplication {
 				{
 					const skills = await this.index.getSkills();
 					const classes = await this.index.getItemsOfType('class');
-					const classOptions = classes.map((c) => {
-						return {
+					const classOptions = classes
+						.sort((a, b) => a.name.localeCompare(b.name))
+						.map((c) => ({
 							value: c.name,
 							label: c.name,
-						};
-					});
+						}));
 					await this.setTables(
 						[
 							{

--- a/module/ui/compendium/compendium-filter.mjs
+++ b/module/ui/compendium/compendium-filter.mjs
@@ -31,17 +31,25 @@ export class CompendiumFilter {
 	 * @return {Boolean}
 	 */
 	filter(entry) {
-		if (this.text) {
-			const needle = this.text.toLowerCase();
-			const textMatch = Object.values(entry).some((value) => {
-				if (typeof value !== 'string') return false;
-				return value.toLowerCase().includes(needle);
-			});
-			if (!textMatch) {
-				return false;
+		const textMatch = Object.values(entry).some((value) => {
+			if (typeof value !== 'string') return false;
+			if (this.text) {
+				const needle = this.text.toLowerCase();
+				if (!value.toLowerCase().includes(needle)) {
+					return false;
+				}
 			}
-		}
-		return true;
+			for (const category of Object.values(this.categories)) {
+				if (category.selected.size > 0) {
+					const propertyValue = foundry.utils.getProperty(entry, category.propertyPath);
+					if (!propertyValue || !category.selected.has(propertyValue)) {
+						return false;
+					}
+				}
+			}
+			return true;
+		});
+		return textMatch;
 	}
 
 	/**

--- a/module/ui/compendium/compendium-filter.mjs
+++ b/module/ui/compendium/compendium-filter.mjs
@@ -1,11 +1,28 @@
+/**
+ * @typedef CompendiumFilterCategory
+ * @property {String} label
+ * @property {String} propertyPath
+ * @property {FormSelectOption[]} options
+ * @property {Set<String>} selected
+ */
+
+/**
+ * @desc Used for filtering the compendiums.
+ */
 export class CompendiumFilter {
 	/**
 	 * @type String
 	 */
 	#text;
+	/**
+	 * @type {Record<string, CompendiumFilterCategory>}
+	 * @desc Matches against the document type;
+	 */
+	#categories;
 
 	constructor() {
 		this.#text = '';
+		this.#categories = [];
 		this.filter = this.filter.bind(this);
 	}
 
@@ -32,13 +49,46 @@ export class CompendiumFilter {
 	 */
 	clear() {
 		this.setText('');
+		this.filters = [];
 	}
 
 	get text() {
 		return this.#text;
 	}
 
+	/**
+	 * @param {Record<string, CompendiumFilterCategory>} categories Document types.
+	 */
+	setCategories(categories) {
+		this.#categories = categories;
+	}
+
+	/**
+	 * @returns {Record<string, CompendiumFilterCategory>}
+	 */
+	get categories() {
+		return this.#categories;
+	}
+
 	setText(text) {
 		this.#text = text;
+	}
+
+	/**
+	 * @desc Updates an existing filter based from input.
+	 * @param {String} key The id of the category.
+	 * @param {String} option The value of the option being checked.
+	 * @param {Boolean} checked
+	 */
+	toggle(key, option, checked) {
+		const category = this.#categories[key];
+		if (!category.selected) {
+			category.selected = new Set();
+		}
+		if (checked) {
+			category.selected.add(option);
+		} else {
+			category.selected.delete(option);
+		}
 	}
 }

--- a/module/ui/compendium/compendium-filter.mjs
+++ b/module/ui/compendium/compendium-filter.mjs
@@ -7,6 +7,12 @@
  */
 
 /**
+ * @typedef CompendiumFilterInputOptions
+ * @property {String} text
+ * @property {{key: string, option: string}} filter
+ */
+
+/**
  * @desc Used for filtering the compendiums.
  */
 export class CompendiumFilter {
@@ -39,11 +45,13 @@ export class CompendiumFilter {
 					return false;
 				}
 			}
-			for (const category of Object.values(this.categories)) {
-				if (category.selected.size > 0) {
-					const propertyValue = foundry.utils.getProperty(entry, category.propertyPath);
-					if (!propertyValue || !category.selected.has(propertyValue)) {
-						return false;
+			if (this.categories) {
+				for (const category of Object.values(this.categories)) {
+					if (category.selected?.size > 0) {
+						const propertyValue = foundry.utils.getProperty(entry, category.propertyPath);
+						if (!propertyValue || !category.selected.has(propertyValue)) {
+							return false;
+						}
 					}
 				}
 			}
@@ -57,7 +65,7 @@ export class CompendiumFilter {
 	 */
 	clear() {
 		this.setText('');
-		this.filters = [];
+		this.#categories = undefined;
 	}
 
 	get text() {
@@ -89,7 +97,10 @@ export class CompendiumFilter {
 	 * @param {Boolean} checked
 	 */
 	toggle(key, option, checked) {
-		const category = this.#categories[key];
+		if (!this.categories) {
+			return;
+		}
+		const category = this.categories[key];
 		if (!category.selected) {
 			category.selected = new Set();
 		}

--- a/module/ui/compendium/compendium-index.mjs
+++ b/module/ui/compendium/compendium-index.mjs
@@ -188,7 +188,6 @@ export class CompendiumIndex {
 			shield: await this.getItemsOfType('shield'),
 			accessory: await this.getItemsOfType('accessory'),
 		};
-		entries.all = Object.values(entries).flat();
 		return entries;
 	}
 
@@ -200,7 +199,6 @@ export class CompendiumIndex {
 			class: await this.getItemsOfType('class'),
 			classFeature: await this.getItemsOfType('classFeature'),
 		};
-		entries.all = Object.values(entries).flat();
 		return entries;
 	}
 
@@ -214,7 +212,6 @@ export class CompendiumIndex {
 			rule: await this.getItemsOfType('rule'),
 			miscAbility: await this.getItemsOfType('miscAbility'),
 		};
-		entries.all = Object.values(entries).flat();
 		return entries;
 	}
 
@@ -227,7 +224,6 @@ export class CompendiumIndex {
 			npc: await this.getActorsOfType('npc'),
 			stash: await this.getActorsOfType('stash'),
 		};
-		entries.all = Object.values(entries).flat();
 		return entries;
 	}
 }

--- a/module/ui/compendium/compendium-index.mjs
+++ b/module/ui/compendium/compendium-index.mjs
@@ -64,14 +64,42 @@ export class CompendiumIndex {
 	static npcFields = ['system.species.value', 'system.rank.value', 'system.role.value'];
 	static actorFields = [...this.npcFields];
 
-	// Items
-	static sharedItemFields = ['system.cost.value', `system.source`];
-	static classFields = ['system.class.value', 'system.level.max'];
-	static spellFields = [`system.duration.value`, `system.cost.amount`];
-	static weaponFields = [`system.damage.value`, `system.damageType.value`];
-	static armorFields = [`system.def.attribute`, `system.def.value`, `system.mdef.attribute`, `system.mdef.value`];
-	static consumableFields = [`system.ipCost.value`];
-	static itemFields = [...this.sharedItemFields, ...this.spellFields, ...this.classFields, ...this.weaponFields, ...this.armorFields, ...this.consumableFields];
+	// TODO: Encode label, options data
+	/**
+	 * @desc The fields that are being indexed.
+	 * @returns {Record<string, string>}
+	 */
+	static itemFields = Object.freeze({
+		// Shared
+		cost: 'system.cost.value',
+		source: 'system.source',
+
+		// Class
+		class: 'system.class.value',
+		levelMax: 'system.level.max',
+
+		// Spells
+		duration: 'system.duration.value',
+		costAmount: 'system.cost.amount',
+		spellDamageType: 'system.rollInfo.damage.type.value',
+
+		// Weapons
+		damage: 'system.damage.value',
+		weaponDamageType: 'system.damageType.value',
+		weaponCategory: 'system.category.value',
+		type: 'system.type.value',
+
+		// Armor
+		defAttribute: 'system.def.attribute',
+		defValue: 'system.def.value',
+		mdefAttribute: 'system.mdef.attribute',
+		mdefValue: 'system.mdef.value',
+
+		// Consumables
+		ipCost: 'system.ipCost.value',
+	});
+
+	static #itemFieldsArray = Object.values(CompendiumIndex.itemFields);
 
 	/**
 	 * @param {Boolean} force
@@ -79,7 +107,7 @@ export class CompendiumIndex {
 	 */
 	async getItems(force) {
 		if (!this.#items || force) {
-			this.#items = await this.getEntries('Item', null, CompendiumIndex.itemFields);
+			this.#items = await this.getEntries('Item', null, CompendiumIndex.#itemFieldsArray);
 		}
 		return this.#items;
 	}

--- a/module/ui/compendium/compendium-index.mjs
+++ b/module/ui/compendium/compendium-index.mjs
@@ -24,6 +24,13 @@ import { systemId } from '../../helpers/system-utils.mjs';
  */
 
 /**
+ * @typedef AbilityEntries
+ * @property {CompendiumIndexEntry[]} basic
+ * @property {CompendiumIndexEntry[]} miscAbility
+ * @property {CompendiumIndexEntry[]} rule
+ */
+
+/**
  * @typedef CharacterEntries
  * @property {CompendiumIndexEntry[]} character
  * @property {CompendiumIndexEntry[]} npc
@@ -237,8 +244,18 @@ export class CompendiumIndex {
 		const entries = {
 			skill: await this.getItemsOfType('skill'),
 			heroic: await this.getItemsOfType('heroic'),
-			rule: await this.getItemsOfType('rule'),
+		};
+		return entries;
+	}
+
+	/**
+	 * @returns {Promise<AbilityEntries>}
+	 */
+	async getAbilities() {
+		const entries = {
+			basic: await this.getItemsOfType('basic'),
 			miscAbility: await this.getItemsOfType('miscAbility'),
+			rule: await this.getItemsOfType('rule'),
 		};
 		return entries;
 	}

--- a/module/ui/compendium/compendium-index.mjs
+++ b/module/ui/compendium/compendium-index.mjs
@@ -81,6 +81,9 @@ export class CompendiumIndex {
 		cost: 'system.cost.value',
 		source: 'system.source',
 
+		// Feature
+		featureType: 'system.featureType',
+
 		// Class
 		class: 'system.class.value',
 		levelMax: 'system.level.max',
@@ -202,6 +205,8 @@ export class CompendiumIndex {
 				const key = entry.type ?? 'unknown';
 				if (type && key !== type) continue;
 
+				this.patchEntryData(entry);
+
 				(result[key] ??= []).push({
 					...entry,
 					pack: pack.collection,
@@ -210,6 +215,74 @@ export class CompendiumIndex {
 		}
 
 		return result;
+	}
+
+	/**
+	 * @desc Adds extra data to entries of specific data models to help with indexing.
+	 * @param {CompendiumIndexEntry} entry
+	 * @returns {*}
+	 */
+	patchEntryData(entry) {
+		let _class;
+		// TODO: Use lowercase?
+		switch (entry.system.featureType) {
+			case 'projectfu.dance':
+				_class = 'Dancer';
+				break;
+
+			case 'projectfu.key':
+			case 'projectfu.tone':
+			case 'projectfu.verse':
+				_class = 'Chanter';
+				break;
+
+			case 'projectfu.symbol':
+				_class = 'Symbolist';
+				break;
+
+			case 'projectfu.therioform':
+				_class = 'Mutant';
+				break;
+
+			case 'projectfu.magitech':
+			case 'projectfu.alchemy':
+			case 'projectfu.infusions':
+				_class = 'Tinkerer';
+				break;
+
+			case 'projectfu.magiseed':
+			case 'projectfu.garden':
+				_class = 'Floralist';
+				break;
+
+			case 'projectfu.ingredient':
+			case 'projectfu.cookbook':
+				_class = 'Gourmet';
+				break;
+
+			case 'projectfu.arcanum':
+				_class = 'Arcanist';
+				break;
+
+			case 'projectfu.vehicle':
+			case 'projectfu.armorModule':
+			case 'projectfu.weaponModule':
+			case 'projectfu.supportModule':
+				_class = 'Pilot';
+				break;
+
+			case 'projectfu.invocations':
+				_class = 'Invoker';
+				break;
+
+			case 'projectfu.psychicGift':
+				_class = 'Esper';
+				break;
+		}
+		entry.metadata = {
+			class: _class,
+		};
+		return entry;
 	}
 
 	/**

--- a/styles/css/components/table/_table-definitions.css
+++ b/styles/css/components/table/_table-definitions.css
@@ -154,3 +154,7 @@
 .compendium-effects-table {
 	grid-template-columns: [name] auto [source] 100px [duration] 100px;
 }
+
+.compendium-attack-table {
+	grid-template-columns: [name] auto [damage] 100px [type] 100px;
+}

--- a/styles/css/global/application.css
+++ b/styles/css/global/application.css
@@ -26,6 +26,9 @@
 	border-right: 1px solid var(--color-border-light-primary);
 	overflow-y: auto;
 	grid-area: sidebar;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
 }
 
 .fu-application__content {

--- a/styles/css/global/application.css
+++ b/styles/css/global/application.css
@@ -9,7 +9,7 @@
 		'tabs tabs'
 		'sidebar content';
 	grid-template-rows: auto 1fr;
-	grid-template-columns: 200px 1fr;
+	grid-template-columns: 240px 1fr;
 }
 
 .fu-application__tabs {
@@ -29,6 +29,12 @@
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
+}
+
+.fu-application__sidebar__filter {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	align-items: start;
 }
 
 .fu-application__content {

--- a/templates/actor/character/parts/actor-section-combat.hbs
+++ b/templates/actor/character/parts/actor-section-combat.hbs
@@ -1,5 +1,11 @@
 <div class="tab flexcol {{tab.cssClass}}" data-group="primary" data-tab="combat">
 	<section class="desc flexgrow-1">
+		<header class="items-main-header">
+		<span class="items-main">
+			<label class="items-label">{{localize "FU.Abilities"}}</label>
+			{{pfuCompendium "abilities"}}
+		</span>
+		</header>
 		{{{basicAttacksTable}}}
 
 		{{{skillsTable}}}

--- a/templates/ui/compendium-browser/compendium-browser-abilities.hbs
+++ b/templates/ui/compendium-browser/compendium-browser-abilities.hbs
@@ -1,0 +1,6 @@
+<section class="tab abilities {{tab.cssClass}} background fu-application__content"
+		 data-tab="abilities" data-group="primary">
+	{{#each tables as |table|}}
+		{{{table}}}
+	{{/each}}
+</section>

--- a/templates/ui/compendium-browser/compendium-browser-sidebar.hbs
+++ b/templates/ui/compendium-browser/compendium-browser-sidebar.hbs
@@ -10,7 +10,7 @@
 			 autocomplete="off"/>
 		</label>
 	</section>
-	{{#each filter.categories as |cat|}}
+	{{#each filter.categories as |cat id|}}
 		<fieldset class="title-fieldset desc resource-content"
 				  style="display: flex; flex-wrap: wrap;
 				  justify-content: space-around;">
@@ -24,7 +24,7 @@
 				{{#each cat.options as |opt|}}
 					<label class="fu-filter-option">
 						<input type="checkbox"
-							   data-category="{{@key}}"
+							   data-category="{{id}}"
 							   data-option="{{opt.value}}"
 							   {{#if opt.checked}}checked{{/if}}
 						/>

--- a/templates/ui/compendium-browser/compendium-browser-sidebar.hbs
+++ b/templates/ui/compendium-browser/compendium-browser-sidebar.hbs
@@ -20,7 +20,7 @@
 					{{localize cat.label}}
 				</label>
 			</legend>
-			<div>
+			<div class="fu-application__sidebar__filter">
 				{{#each cat.options as |opt|}}
 					<label class="fu-filter-option">
 						<input type="checkbox"

--- a/templates/ui/compendium-browser/compendium-browser-sidebar.hbs
+++ b/templates/ui/compendium-browser/compendium-browser-sidebar.hbs
@@ -1,13 +1,37 @@
 <aside class="fu-application__sidebar">
-	<section class="">
+	<section>
 		<label>
 			<input
 			 id="search"
 			 type="search"
 			 name="search"
-			 value="{{filterText}}"
+			 value="{{filter.text}}"
 			 placeholder="Search…"
 			 autocomplete="off"/>
 		</label>
 	</section>
+	{{#each filter.categories as |cat|}}
+		<fieldset class="title-fieldset desc resource-content"
+				  style="display: flex; flex-wrap: wrap;
+				  justify-content: space-around;">
+			<legend class="resource-label-full">
+				<label class="resource-label-m">
+					<i class="fa fa-filter"></i>
+					{{localize cat.label}}
+				</label>
+			</legend>
+			<div>
+				{{#each cat.options as |opt|}}
+					<label class="fu-filter-option">
+						<input type="checkbox"
+							   data-category="{{@key}}"
+							   data-option="{{opt.value}}"
+							   {{#if opt.checked}}checked{{/if}}
+						/>
+						{{localize opt.label}}
+					</label>
+				{{/each}}
+			</div>
+		</fieldset>
+	{{/each}}
 </aside>


### PR DESCRIPTION
This pull request introduces a significant upgrade to the Compendium Browser, adding support for dynamic, multi-category filtering and a new "Abilities" tab. The changes improve filtering flexibility, user experience, and code maintainability. The most important changes are grouped below by theme.

**Compendium Browser Filtering System:**

* Refactored the filtering logic in `CompendiumFilter` to support multiple filter categories, allowing users to filter compendium entries by various attributes (e.g., type, class, damage type). Added new types and methods for managing filter categories and selections. [[1]](diffhunk://#diff-e40f45c79934611f76992290987d06f680b21555e8bf9dda113763d85c5dd982R1-R31) [[2]](diffhunk://#diff-e40f45c79934611f76992290987d06f680b21555e8bf9dda113763d85c5dd982L17-R112)
* Updated the Compendium Browser UI and logic to dynamically render filter options per tab, synchronize filter state, and apply filters when users interact with checkboxes or text input. Sidebar now updates with relevant filters for each tab. [[1]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR301-R312) [[2]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR354-R382) [[3]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL335-R417) [[4]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR427-R468) [[5]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL398-R514) [[6]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR523-R586) [[7]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL446-R702) [[8]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL487-R723) [[9]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL506-R751)

**Abilities Tab and Table Rendering:**

* Added a new "Abilities" tab to the Compendium Browser, including a dedicated table renderer (`AttackCompendiumTableRenderer`) and template. Abilities are now listed and can be filtered by type and damage type. [[1]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR96-R108) [[2]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR174-R204) [[3]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR235-R237) [[4]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR321-R324) [[5]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eR523-R586)

**User Experience Improvements:**

* Implemented a reusable `debounce` utility in `HTMLUtils` for smoother filtering interactions, replacing inline debounce code and improving maintainability.
* Enhanced tab switching and table rendering logic to ensure filters and tables update correctly when navigating between tabs or changing filter options. [[1]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL487-R723) [[2]](diffhunk://#diff-48699bb4184ee31194d94e87d9d99dbf7694d7674255958282bee187ce01be7eL506-R751)

**Localization and Type Updates:**

* Added new localization strings for "Ability" and "Abilities" in `lang/en.json` to support the new tab and filtering options.
* Updated type definitions and references to support new filter input options and categories throughout the browser and helpers. [[1]](diffhunk://#diff-2858726f1f56a71994d97fd2136ecbd6a4d936273d1dbc421a18b37fe37cabdfL404-R404) [[2]](diffhunk://#diff-e40f45c79934611f76992290987d06f680b21555e8bf9dda113763d85c5dd982R1-R31)

**Spell Data Model Adjustments:**

* Commented out the unused `damage` field in the `SpellDataModel` to prepare for future refactoring and reduce confusion in item data models. [[1]](diffhunk://#diff-45f5f6438b97c6017910d48d2e984222d6582b29d35606f27f3ce2ee8b297654L62-R62) [[2]](diffhunk://#diff-45f5f6438b97c6017910d48d2e984222d6582b29d35606f27f3ce2ee8b297654L92-R92)

<img width="1165" height="922" alt="image" src="https://github.com/user-attachments/assets/c7039b30-18b5-4be4-ab2a-9dd53bc672cc" />
