### PR TITLE
Set ChatLog ContextMenu To Fixed Position

### DIFF
--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -112,6 +112,7 @@ import { CompendiumIndex } from './ui/compendium/compendium-index.mjs';
 import { PressureSystem } from './systems/pressure-system.mjs';
 import { FUToken } from './ui/token.mjs';
 import { FUPressureGauge, FUModernPressureGauge, FUPixelPressureGauge } from './ui/pressureGauges/index.mjs';
+import { FUChatLog } from './ui/chat-log.mjs';
 
 globalThis.projectfu = {
 	ClassFeatureDataModel,
@@ -281,6 +282,7 @@ Hooks.once('init', async () => {
 	//CONFIG.ui.combat = FUCombatTracker;
 	Object.assign(CONFIG.ui, {
 		combat: FUCombatTracker,
+		chat: FUChatLog,
 	});
 
 	// Register status effects

--- a/module/ui/chat-log.mjs
+++ b/module/ui/chat-log.mjs
@@ -1,0 +1,21 @@
+/**
+ * The sidebar chat tab.
+ *
+ * @remarks This is overridden here to ensure its ContextMenu is given a fixed position, rather than being constrained within the bounds of the ChatLog
+ * @extends {foundry.applications.sidebar.tabs.ChatLog}
+ * @mixes HandlebarsApplication
+ */
+export class FUChatLog extends foundry.applications.sidebar.tabs.ChatLog {
+	_createContextMenu(handler, selector, { container, hookName, parentClassHooks, ...options } = {}) {
+		container ??= this.element;
+		hookName ??= 'get{}ContextOptions';
+		const menuItems = this._doEvent(handler, { hookName, parentClassHooks, hookResponse: true });
+		if (!menuItems.length) return null;
+
+		return new foundry.applications.ux.ContextMenu.implementation(container, selector, menuItems, {
+			jQuery: false,
+			fixed: true,
+			...options,
+		});
+	}
+}


### PR DESCRIPTION
This PR overrides the built-in `ChatLog` class in order to pass `fixed: true` to its ContextMenu constructor

Default Foundry behavior ends up positioning the ContextMenu for a chat message either wholly above or wholly below the message within the bounds of the `ChatLog` application.  For particularly long chat messages, this can make accessing the context menu difficult

<table>
  <tr>
    <td colspan="2" align="center">Default Behavior</td>
  </tr>
  <tr>
    <td align="center">
      <img
        height="350"
        alt="image"
        src="https://github.com/user-attachments/assets/466a0353-0fac-42d4-b965-1d2fa8076dfd"
      />
    </td>
    <td align="center">
      <img
        height="350"
        alt="image"
        src="https://github.com/user-attachments/assets/e0dbf278-bd9c-43fd-a30f-bac6f1cce718"
      />
    </td>
  </tr>
  <tr>
    <td colspan="2">ContextMenu extends outside of currently visible area and requires scrolling the chat log to view</td>
  </tr>
  <tr>
    <td align="center" colspan="2">Updated Behavior</td>
  </tr>
  <tr>
    <td align="center">
      <img
        height="350"
        alt="image"
        src="https://github.com/user-attachments/assets/32773a35-f739-44ec-a6de-43813ff30e21"
      />
    </td>
    <td align="center">
      <img
        height="350"
        alt="image"
        src="https://github.com/user-attachments/assets/74aa9915-8da9-4366-8010-97e96bc68bad"
      />
    </td>
  </tr>
  <tr>
    <td colspan="2">Context menu is placed relative to the cursor's current position with respect to the browser window's boundaries</td>
  </tr>
</table>
