### PR TITLE
Refactor skill/misc ability data models

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -953,7 +953,7 @@
 		"ChatOpportunitySettingMissing": "Automation for opportunities must be set on the system's homebrew settings",
 		"ChatPromptCheck": "A check has been prompted to <strong>{verb}</strong> the following clock:",
 		"ChatApplyEffect": "<strong>{effect}</strong> has been applied by <strong>{source}</source>",
-		"ChatApplyEffectLabel": "Apply Effect",
+		"ChatApplyEffectLabel": "Apply {effect}",
 		"ChatApplyEffectHint": "Apply <strong>{effect}</strong> to the target.",
 		"ChatApplyEffectPrompt": "One of the following effects can be applied due to <strong>{source}</strong>.",
 		"ChatRemoveEffect": "Remove effect",

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -79,6 +79,7 @@ function attack(inspector, actor, item) {
  * @property {FUItemGroup} damageSource
  * @property {Number} amount
  * @property {CharacterInfo} target
+ * @property {FUItem} item
  * @property {FUActor} actor
  * @property {Token} token
  * @property {Set<String>} traits
@@ -103,6 +104,7 @@ function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, orig
 	/** @type DamageEvent  **/
 	const damageEvent = {
 		amount: amount,
+		item: item,
 		type: type,
 		source: source,
 		sourceActor: sourceInfo,

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -358,7 +358,10 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 			const effectData = inspector.getEffects();
 			if (effectData) {
 				for (const entry of effectData.entries) {
-					actions.push(Effects.getTargetedAction(entry, sourceInfo));
+					const ea = await Effects.getTargetedAction(entry, sourceInfo);
+					if (ea) {
+						actions.push(ea);
+					}
 				}
 			}
 

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -491,6 +491,7 @@ const spendResource = (sections, actor, item, cost, targets, flags) => {
 				actor: actor.uuid,
 				item: item.uuid,
 				expense: expense,
+				resourceLabel: FU.resourcesAbbr[expense.resource],
 				icon: FU.resourceIcons[expense.resource],
 			},
 		};

--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -46,18 +46,20 @@ export class MessageRuleAction extends RuleActionDataModel {
 	}
 
 	async execute(context, selected) {
-		let flags = Pipeline.initializedFlags(Flags.ChatMessage.Item, context.item.uuid);
-		flags = Pipeline.setFlag(flags, Flags.ChatMessage.Source, context.sourceInfo);
-		let _message = this.message || StringUtils.localize('FU.RuleElementTriggered');
+		// Flag information
+		let flags = Pipeline.initializedFlags(Flags.ChatMessage.Source, context.sourceInfo);
+		flags = Pipeline.setFlag(flags, Flags.ChatMessage.Item, context.item.uuid);
 		if (context.check) {
 			flags = Pipeline.setFlag(flags, Flags.ChatMessage.CheckV2, context.check);
 		}
+		// Message
+		const _message = this.message || StringUtils.localize('FU.RuleElementTriggered');
 
 		switch (context.eventType) {
 			case FUHooks.RENDER_CHECK_EVENT: {
 				/** @type RenderCheckEvent **/
 				const rce = context.event;
-				const actor = rce.source.actor !== context.character.actor ? context.item.parent : null;
+				const actor = rce.source.actor !== context.character.actor ? context.item?.parent : null;
 				CommonSections.itemText(rce.renderData, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
 				break;
 			}
@@ -65,7 +67,7 @@ export class MessageRuleAction extends RuleActionDataModel {
 			case FUHooks.FEATURE_EVENT: {
 				/** @type FeatureEvent **/
 				const fe = context.event;
-				const actor = fe.source.actor !== context.character.actor ? context.item.parent : null;
+				const actor = fe.source.actor !== context.character.actor ? context.item?.parent : null;
 				CommonSections.itemText(fe.builder.sections, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
 				break;
 			}

--- a/module/documents/effects/predicates/targeting-rule-predicate.mjs
+++ b/module/documents/effects/predicates/targeting-rule-predicate.mjs
@@ -5,7 +5,7 @@ import { FU } from '../../../helpers/config.mjs';
 const fields = foundry.data.fields;
 
 /**
- * @property {TargetingRule} rule
+ * @property {FUTargetingPredicate} rule
  */
 export class TargetingRulePredicate extends RulePredicateDataModel {
 	static {
@@ -39,6 +39,8 @@ export class TargetingRulePredicate extends RulePredicateDataModel {
 	 */
 	validateContext(context) {
 		switch (this.rule) {
+			case 'none':
+				return context.targets.length === 0;
 			case 'single':
 				return context.targets.length === 1;
 			case 'multiple':

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -8,7 +8,7 @@ import { ActionCostDataModel } from '../common/action-cost-data-model.mjs';
 import { EffectApplicationDataModel } from '../common/effect-application-data-model.mjs';
 import { ResourceDataModel } from '../common/resource-data-model.mjs';
 import { ProgressDataModel } from '../common/progress-data-model.mjs';
-import { Traits } from '../../../pipelines/traits.mjs';
+import { Traits, TraitUtils } from '../../../pipelines/traits.mjs';
 import { ExpressionContext, Expressions } from '../../../expressions/expressions.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
 import { ChooseWeaponDialog } from './choose-weapon-dialog.mjs';
@@ -68,6 +68,13 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	}
 
 	/**
+	 * @return Tag[]
+	 */
+	getCommonTags() {
+		return TraitUtils.toTags(this.traits);
+	}
+
+	/**
 	 * @desc Common configuration for display checks.
 	 * @param {CheckConfigurer} config
 	 * @param {FUActor} actor
@@ -97,9 +104,10 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	 * @param {CheckConfigurer} config
 	 * @param {FUActor} actor
 	 * @param {FUItem} item
-	 * @param {ExpressionContext} context
 	 */
-	async configureDisplayCheck(config, actor, item, context) {
+	async configureDisplayCheck(config, actor, item) {
+		const targets = config.getTargets();
+		const context = ExpressionContext.fromTargetData(actor, item, targets);
 		this.configureCheck(config);
 		if (this.damage.hasDamage) {
 			if (this.useWeapon.damage) {
@@ -167,6 +175,10 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 		}
 	}
 
+	/**
+	 * @param {FUActor} actor
+	 * @returns {Promise<game.projectfu.FUItem>}
+	 */
 	async getWeapon(actor) {
 		const weapon = await ChooseWeaponDialog.prompt(actor, true);
 		if (weapon === false) {
@@ -180,6 +192,9 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 		return weapon;
 	}
 
+	/**
+	 * @returns {String[]} Common partials used by all skills.
+	 */
 	get commonPartials() {
 		return [
 			ItemPartialTemplates.standard,

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -1,0 +1,196 @@
+import { FUStandardItemDataModel } from '../item-data-model.mjs';
+import { UseWeaponDataModelV2 } from '../common/use-weapon-data-model-v2.mjs';
+import { FU } from '../../../helpers/config.mjs';
+import { DamageDataModelV2 } from '../common/damage-data-model-v2.mjs';
+import { ItemAttributesDataModelV2 } from '../common/item-attributes-data-model-v2.mjs';
+import { TargetingDataModel } from '../common/targeting-data-model.mjs';
+import { ActionCostDataModel } from '../common/action-cost-data-model.mjs';
+import { EffectApplicationDataModel } from '../common/effect-application-data-model.mjs';
+import { ResourceDataModel } from '../common/resource-data-model.mjs';
+import { ProgressDataModel } from '../common/progress-data-model.mjs';
+import { Traits } from '../../../pipelines/traits.mjs';
+import { ExpressionContext, Expressions } from '../../../expressions/expressions.mjs';
+import { ItemPartialTemplates } from '../item-partial-templates.mjs';
+import { ChooseWeaponDialog } from './choose-weapon-dialog.mjs';
+
+/**
+ * @property {string} description
+ * @property {string} opportunity
+ * @property {UseWeaponDataModelV2} useWeapon
+ * @property {ItemAttributesDataModelV2} attributes
+ * @property {number} accuracy
+ * @property {Defense} defense
+ * @property {DamageDataModelV2} damage
+ * @property {EffectApplicationDataModel} effects
+ * @property {ActionCostDataModel} cost
+ * @property {TargetingDataModel} targeting
+ * @property {Set<String>} traits
+ */
+
+export class BaseSkillDataModel extends FUStandardItemDataModel {
+	static defineSchema() {
+		const { SchemaField, StringField, BooleanField, NumberField, EmbeddedDataField, SetField } = foundry.data.fields;
+		return Object.assign(super.defineSchema(), {
+			attributes: new EmbeddedDataField(ItemAttributesDataModelV2, {
+				initial: {
+					primary: 'dex',
+					secondary: 'ins',
+				},
+			}),
+			useWeapon: new EmbeddedDataField(UseWeaponDataModelV2, {}),
+			accuracy: new NumberField({ initial: 0, integer: true, nullable: false }),
+			defense: new StringField({ initial: 'def', choices: Object.keys(FU.defenses), blank: true }),
+			damage: new EmbeddedDataField(DamageDataModelV2, {}),
+			targeting: new EmbeddedDataField(TargetingDataModel, {}),
+			traits: new SetField(new StringField()),
+			effects: new EmbeddedDataField(EffectApplicationDataModel, {}),
+			cost: new EmbeddedDataField(ActionCostDataModel, {}),
+			resource: new EmbeddedDataField(ResourceDataModel, {}),
+			// TODO: Deprecate due to progress tracks in effects
+			hasRoll: new SchemaField({ value: new BooleanField() }),
+			rp: new EmbeddedDataField(ProgressDataModel, {}),
+			hasResource: new SchemaField({ value: new BooleanField() }),
+		});
+	}
+
+	/**
+	 * @desc Common configuration for attribute checks.
+	 * @param {CheckConfigurer} config
+	 */
+	configureCheck(config) {
+		config.addTraits('skill');
+		config.addTraitsFromItemModel(this.traits);
+		config.addEffects(this.effects.entries);
+		config.addTraitsFromItemModel(this.traits);
+		if (this.resource.enabled) {
+			config.setResource(this.resource.type, this.resource.amount);
+		}
+	}
+
+	/**
+	 * @desc Common configuration for display checks.
+	 * @param {CheckConfigurer} config
+	 * @param {FUActor} actor
+	 * @param {FUItem} item
+	 */
+	async configureAttributeCheck(config, actor, item) {
+		const targets = config.getTargets();
+		const context = ExpressionContext.fromTargetData(actor, item, targets);
+		await this.addSkillAccuracy(config, actor, item, context);
+		if (this.defense && targets.length === 1) {
+			let dl;
+			switch (this.defense) {
+				case 'def':
+					dl = targets[0].def;
+					break;
+
+				case 'mdef':
+					dl = targets[0].mdef;
+					break;
+			}
+			config.setDifficulty(dl);
+		}
+	}
+
+	/**
+	 * @desc Common configuration for display checks.
+	 * @param {CheckConfigurer} config
+	 * @param {FUActor} actor
+	 * @param {FUItem} item
+	 * @param {ExpressionContext} context
+	 */
+	async configureDisplayCheck(config, actor, item, context) {
+		this.configureCheck(config);
+		if (this.damage.hasDamage) {
+			if (this.useWeapon.damage) {
+				const weapon = await this.getWeapon(actor);
+				config.setWeapon(weapon);
+				/** @type WeaponDataModel **/
+				const weaponData = weapon.system;
+				config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);
+			}
+			await this.addSkillDamage(config, item, context);
+		}
+	}
+
+	/**
+	 * @desc Common configuration for display checks.
+	 * @param {CheckConfigurer} config
+	 * @param {FUActor} actor
+	 * @param {FUItem} item
+	 * @param {ExpressionContext} context
+	 */
+	async addSkillAccuracy(config, actor, item, context) {
+		if (this.accuracy) {
+			const calculatedAccuracyBonus = await Expressions.evaluateAsync(this.accuracy, context);
+			if (calculatedAccuracyBonus > 0) {
+				config.check.modifiers.push({
+					label: 'FU.CheckBonus',
+					value: calculatedAccuracyBonus,
+				});
+			}
+		}
+	}
+
+	/**
+	 * @param {CheckConfigurer} config
+	 * @param {FUItem} item
+	 * @param {ExpressionContext} context
+	 * @returns {Promise<void>}
+	 */
+	async addSkillDamage(config, item, context) {
+		if (this.damage.hasDamage) {
+			config.addTraits(Traits.Damage);
+			config.setTargetedDefense(this.defense || config.getTargetedDefense());
+			if (config.hasDamage) {
+				config.modifyDamage((damage) => {
+					damage.type = this.damage.type || damage.type;
+					damage.addModifier('FU.DamageBonus', item.system.damage.value);
+					return damage;
+				});
+			} else {
+				config.setDamage(this.damage.type, item.system.damage.value);
+			}
+
+			const onRoll = this.damage.onRoll;
+			if (onRoll) {
+				const extraDamage = await Expressions.evaluateAsync(onRoll, context);
+				if (extraDamage > 0) {
+					config.addDamageBonus('FU.DamageOnRoll', extraDamage);
+				}
+			}
+
+			const onApply = this.damage.onApply;
+			if (onApply) {
+				config.setExtraDamage(onApply);
+			}
+		}
+	}
+
+	async getWeapon(actor) {
+		const weapon = await ChooseWeaponDialog.prompt(actor, true);
+		if (weapon === false) {
+			let message = game.i18n.localize('FU.AbilityNoWeaponEquipped');
+			ui.notifications.error(message);
+			throw new Error(message);
+		}
+		if (weapon == null) {
+			throw new Error('no selection');
+		}
+		return weapon;
+	}
+
+	get commonPartials() {
+		return [
+			ItemPartialTemplates.standard,
+			ItemPartialTemplates.traitsLegacy,
+			ItemPartialTemplates.actionCost,
+			ItemPartialTemplates.accuracy,
+			ItemPartialTemplates.damage,
+			ItemPartialTemplates.effects,
+			ItemPartialTemplates.resource,
+			ItemPartialTemplates.resourcePoints,
+			ItemPartialTemplates.targeting,
+		];
+	}
+}

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -1,15 +1,14 @@
 import { CheckHooks } from '../../../checks/check-hooks.mjs';
-import { ChooseWeaponDialog } from './choose-weapon-dialog.mjs';
 import { Checks } from '../../../checks/checks.mjs';
 import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
 import { CommonSections } from '../../../checks/common-sections.mjs';
 import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
 import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
 import { SkillMigrations } from './skill-migrations.mjs';
-import { ExpressionContext, Expressions } from '../../../expressions/expressions.mjs';
+import { ExpressionContext } from '../../../expressions/expressions.mjs';
 import { CommonEvents } from '../../../checks/common-events.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
-import { Traits, TraitUtils } from '../../../pipelines/traits.mjs';
+import { TraitUtils } from '../../../pipelines/traits.mjs';
 import { BaseSkillDataModel } from './base-skill-data-model.mjs';
 
 const skillForAttributeCheck = 'skillForAttributeCheck';
@@ -45,7 +44,7 @@ Hooks.on(CheckHooks.renderCheck, onRenderAccuracyCheck);
  * @type RenderCheckHook
  */
 let onRenderAttributeCheck = (sections, check, actor, item, flags) => {
-	if (check.type === 'attribute' && check.additionalData[skillForAttributeCheck]) {
+	if (check.type === 'attribute' && item?.system instanceof SkillDataModel && check.additionalData[skillForAttributeCheck]) {
 		const skill = fromUuidSync(check.additionalData[skillForAttributeCheck]);
 		const inspector = CheckConfiguration.inspect(check);
 		CommonSections.itemFlavor(sections, skill);
@@ -191,10 +190,7 @@ export class SkillDataModel extends BaseSkillDataModel {
 	#initializeSkillDisplay(modifiers) {
 		return async (check, actor, item) => {
 			const config = CheckConfiguration.configure(check);
-			const targets = config.getTargets();
-			const context = ExpressionContext.fromTargetData(actor, item, targets);
-			this.configureCheck(config);
-			await this.configureDisplayCheck(config, actor, item, context);
+			await this.configureDisplayCheck(config, actor, item);
 		};
 	}
 

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -1,25 +1,16 @@
-import { ProgressDataModel } from '../common/progress-data-model.mjs';
-import { FU } from '../../../helpers/config.mjs';
 import { CheckHooks } from '../../../checks/check-hooks.mjs';
 import { ChooseWeaponDialog } from './choose-weapon-dialog.mjs';
 import { Checks } from '../../../checks/checks.mjs';
 import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
 import { CommonSections } from '../../../checks/common-sections.mjs';
 import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
-import { ActionCostDataModel } from '../common/action-cost-data-model.mjs';
-import { TargetingDataModel } from '../common/targeting-data-model.mjs';
 import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
-import { UseWeaponDataModelV2 } from '../common/use-weapon-data-model-v2.mjs';
-import { ItemAttributesDataModelV2 } from '../common/item-attributes-data-model-v2.mjs';
-import { DamageDataModelV2 } from '../common/damage-data-model-v2.mjs';
 import { SkillMigrations } from './skill-migrations.mjs';
 import { ExpressionContext, Expressions } from '../../../expressions/expressions.mjs';
 import { CommonEvents } from '../../../checks/common-events.mjs';
-import { FUStandardItemDataModel } from '../item-data-model.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
 import { Traits, TraitUtils } from '../../../pipelines/traits.mjs';
-import { EffectApplicationDataModel } from '../common/effect-application-data-model.mjs';
-import { ResourceDataModel } from '../common/resource-data-model.mjs';
+import { BaseSkillDataModel } from './base-skill-data-model.mjs';
 
 const skillForAttributeCheck = 'skillForAttributeCheck';
 
@@ -121,7 +112,7 @@ function getTags(skill) {
  * @property {TargetingDataModel} targeting
  * @property {Set<String>} traits
  */
-export class SkillDataModel extends FUStandardItemDataModel {
+export class SkillDataModel extends BaseSkillDataModel {
 	static {
 		deprecationNotice(this, 'rollInfo.useWeapon.accuracy.value', 'useWeapon.accuracy');
 		deprecationNotice(this, 'rollInfo.useWeapon.damage.value', 'useWeapon.damage');
@@ -139,7 +130,7 @@ export class SkillDataModel extends FUStandardItemDataModel {
 	}
 
 	static defineSchema() {
-		const { SchemaField, StringField, BooleanField, NumberField, EmbeddedDataField, SetField } = foundry.data.fields;
+		const { SchemaField, StringField, NumberField } = foundry.data.fields;
 		return Object.assign(super.defineSchema(), {
 			level: new SchemaField({
 				value: new NumberField({ initial: 1, min: 0, integer: true, nullable: false }),
@@ -147,26 +138,6 @@ export class SkillDataModel extends FUStandardItemDataModel {
 				min: new NumberField({ initial: 0, min: 0, integer: true, nullable: false }),
 			}),
 			class: new SchemaField({ value: new StringField() }),
-			useWeapon: new EmbeddedDataField(UseWeaponDataModelV2, {}),
-			attributes: new EmbeddedDataField(ItemAttributesDataModelV2, {
-				initial: {
-					primary: 'dex',
-					secondary: 'ins',
-				},
-			}),
-			accuracy: new StringField({ initial: '', blank: true, nullable: false }),
-			defense: new StringField({ initial: 'def', choices: Object.keys(FU.defenses), blank: true }),
-			damage: new EmbeddedDataField(DamageDataModelV2, {
-				type: '',
-			}),
-			resource: new EmbeddedDataField(ResourceDataModel, {}),
-			effects: new EmbeddedDataField(EffectApplicationDataModel, {}),
-			hasResource: new SchemaField({ value: new BooleanField() }),
-			rp: new EmbeddedDataField(ProgressDataModel, {}),
-			hasRoll: new SchemaField({ value: new BooleanField() }),
-			cost: new EmbeddedDataField(ActionCostDataModel, {}),
-			targeting: new EmbeddedDataField(TargetingDataModel, {}),
-			traits: new SetField(new StringField()),
 		});
 	}
 
@@ -219,25 +190,11 @@ export class SkillDataModel extends FUStandardItemDataModel {
 	 */
 	#initializeSkillDisplay(modifiers) {
 		return async (check, actor, item) => {
-			/** @type SkillDataModel **/
-			const skill = item.system;
 			const config = CheckConfiguration.configure(check);
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
-			config.addEffects(skill.effects.entries);
-			if (skill.resource.enabled) {
-				config.setResource(skill.resource.type, skill.resource.amount);
-			}
-			if (this.damage.hasDamage) {
-				if (skill.useWeapon.damage) {
-					const weapon = await this.getWeapon(actor);
-					config.setWeapon(weapon);
-					/** @type WeaponDataModel **/
-					const weaponData = weapon.system;
-					config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);
-				}
-				await this.#addSkillDamage(config, actor, item, context, modifiers);
-			}
+			this.configureCheck(config);
+			await this.configureDisplayCheck(config, actor, item, context);
 		};
 	}
 
@@ -246,35 +203,8 @@ export class SkillDataModel extends FUStandardItemDataModel {
 	 */
 	#initializeAttributeCheck(modifiers) {
 		return async (check, actor, item) => {
-			/** @type SkillDataModel **/
-			const skill = item.system;
 			const config = CheckConfiguration.configure(check);
-			const targets = config.getTargets();
-			const context = ExpressionContext.fromTargetData(actor, item, targets);
-
-			if (skill.defense && targets.length === 1) {
-				let dl;
-				switch (skill.defense) {
-					case 'def':
-						dl = targets[0].def;
-						break;
-
-					case 'mdef':
-						dl = targets[0].mdef;
-						break;
-				}
-				config.setDifficulty(dl);
-			}
-
-			if (this.accuracy) {
-				const calculatedAccuracyBonus = await Expressions.evaluateAsync(this.accuracy, context);
-				if (calculatedAccuracyBonus > 0) {
-					check.modifiers.push({
-						label: 'FU.CheckBonus',
-						value: calculatedAccuracyBonus,
-					});
-				}
-			}
+			await this.configureAttributeCheck(config, actor, item);
 			check.additionalData[skillForAttributeCheck] = this.parent.uuid;
 		};
 	}
@@ -304,8 +234,9 @@ export class SkillDataModel extends FUStandardItemDataModel {
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
 
 			config.setWeapon(weapon);
-			config.addTraits('skill');
-			config.addTraitsFromItemModel(this.traits);
+			config.setHrZero(this.damage.hrZero || modifiers.shift);
+			this.configureCheck(config);
+			await this.addSkillDamage(config, item, context);
 
 			// Weapon support
 			if (skill.useWeapon.traits && weaponData.traits) {
@@ -321,70 +252,8 @@ export class SkillDataModel extends FUStandardItemDataModel {
 				});
 			}
 			config.setWeaponTraits(config.getWeaponTraits());
-
-			if (this.accuracy) {
-				const calculatedAccuracyBonus = await Expressions.evaluateAsync(this.accuracy, context);
-				if (calculatedAccuracyBonus > 0) {
-					check.modifiers.push({
-						label: 'FU.CheckBonus',
-						value: calculatedAccuracyBonus,
-					});
-				}
-			}
-
-			if (skill.resource.enabled) {
-				config.setResource(skill.resource.type, skill.resource.amount);
-			}
-
-			if (this.damage.hasDamage) {
-				config.setHrZero(this.damage.hrZero || modifiers.shift);
-				await this.#addSkillDamage(config, actor, item, context, modifiers);
-			}
-
-			config.addEffects(skill.effects.entries);
+			await this.addSkillAccuracy(config, actor, item, context);
 		};
-	}
-
-	async getWeapon(actor) {
-		const weapon = await ChooseWeaponDialog.prompt(actor, true);
-		if (weapon === false) {
-			let message = game.i18n.localize('FU.AbilityNoWeaponEquipped');
-			ui.notifications.error(message);
-			throw new Error(message);
-		}
-		if (weapon == null) {
-			throw new Error('no selection');
-		}
-		return weapon;
-	}
-
-	async #addSkillDamage(config, actor, item, context) {
-		if (this.damage.hasDamage) {
-			config.addTraits(Traits.Damage);
-			config.setTargetedDefense(this.defense || config.getTargetedDefense());
-			if (config.hasDamage) {
-				config.modifyDamage((damage) => {
-					damage.type = this.damage.type || damage.type;
-					damage.addModifier('FU.DamageBonus', item.system.damage.value);
-					return damage;
-				});
-			} else {
-				config.setDamage(this.damage.type, item.system.damage.value);
-			}
-
-			const onRoll = this.damage.onRoll;
-			if (onRoll) {
-				const extraDamage = await Expressions.evaluateAsync(onRoll, context);
-				if (extraDamage > 0) {
-					config.addDamageBonus('FU.DamageOnRoll', extraDamage);
-				}
-			}
-
-			const onApply = this.damage.onApply;
-			if (onApply) {
-				config.setExtraDamage(onApply);
-			}
-		}
 	}
 
 	shouldApplyEffect(effect) {
@@ -392,19 +261,7 @@ export class SkillDataModel extends FUStandardItemDataModel {
 	}
 
 	get attributePartials() {
-		return [
-			ItemPartialTemplates.standard,
-			ItemPartialTemplates.traitsLegacy,
-			ItemPartialTemplates.classField,
-			ItemPartialTemplates.actionCost,
-			ItemPartialTemplates.skillAttributes,
-			ItemPartialTemplates.accuracy,
-			ItemPartialTemplates.damage,
-			ItemPartialTemplates.effects,
-			ItemPartialTemplates.targeting,
-			ItemPartialTemplates.resource,
-			ItemPartialTemplates.resourcePoints,
-		];
+		return [...this.commonPartials, ItemPartialTemplates.classField, ItemPartialTemplates.skillAttributes];
 	}
 
 	/**

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -979,7 +979,11 @@ FU.predicateQuantifier = {
 	none: 'FU.None',
 };
 
+/**
+ * @typedef {"none", "single", "multiple"} FUTargetingPredicate
+ */
 FU.targetingPredicate = {
+	none: 'FU.None',
 	single: 'FU.Single',
 	multiple: 'FU.Multiple',
 };

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -354,10 +354,9 @@ export default class FoundryUtils {
 	 * @return {Boolean}
 	 */
 	static isUUID(str) {
-		if (typeof str === 'string') {
-			return /^[A-Za-z]+\.[A-Za-z0-9]+(\.[A-Za-z]+\.[A-Za-z0-9]+)*$/.test(str);
-		}
-		return false;
+		if (typeof str !== 'string') return false;
+
+		return /^(?:Compendium\.[a-z0-9-]+\.[a-z0-9-]+\.)?[A-Za-z]+\.[A-Za-z0-9]+(?:\.[A-Za-z]+\.[A-Za-z0-9]+)*$/.test(str);
 	}
 
 	/**

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -98,10 +98,16 @@ async function getEffectData(id) {
 	if (id in Effects.STATUS_EFFECTS || id in Effects.BOONS_AND_BANES) {
 		effect = statusEffects.find((value) => value.id === id);
 	} else {
+		// Resolve by uuid
+		if (FoundryUtils.isUUID(id)) {
+			effect = await fromUuid(id);
+		}
 		// Resolve by fuid
-		const entry = await CompendiumIndex.instance.getItemByFuid(id);
-		if (entry) {
-			effect = await fromUuid(entry.uuid);
+		else {
+			const entry = await CompendiumIndex.instance.getItemByFuid(id);
+			if (entry) {
+				effect = await fromUuid(entry.uuid);
+			}
 		}
 		// Get the first AE attached to the item
 		if (effect && effect instanceof FUItem) {
@@ -109,7 +115,7 @@ async function getEffectData(id) {
 		}
 	}
 	if (!effect) {
-		console.error(`No effect with id ${this.effect} could be resolved.`);
+		console.error(`No effect with id '${id}' could be resolved.`);
 	}
 	return effect;
 }

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -728,7 +728,7 @@ async function promptRemoveEffect(actor, source) {
  * @returns {ChatAction}
  */
 async function getTargetedAction(id, sourceInfo) {
-	let label;
+	let name;
 	let icon;
 	let img;
 	const effectData = await getEffectData(id);
@@ -742,13 +742,16 @@ async function getTargetedAction(id, sourceInfo) {
 				icon = 'ra ra-biohazard';
 			}
 		}
-		label = StringUtils.localize(effectData.name);
+		name = StringUtils.localize(effectData.name);
 	} else {
 		return null;
 	}
 
 	const tooltip = StringUtils.localize('FU.ChatApplyEffectHint', {
-		effect: label,
+		effect: name,
+	});
+	const label = StringUtils.localize('FU.ChatApplyEffectLabel', {
+		effect: name,
 	});
 
 	return new ChatAction('applyEffect', icon, tooltip, {
@@ -757,6 +760,7 @@ async function getTargetedAction(id, sourceInfo) {
 		.requiresOwner()
 		.setFlag(Flags.ChatMessage.Effects)
 		.withSelected()
+		.withLabel(label)
 		.withImage(img)
 		.withDataset({
 			['effect-id']: id,

--- a/module/ui/compendium/compendium-index.mjs
+++ b/module/ui/compendium/compendium-index.mjs
@@ -63,6 +63,7 @@ export class CompendiumIndex {
 	 * @desc Forces the index to be reinitialized.
 	 */
 	static reinitialize() {
+		console.debug(`Refreshing PFU compendium index.`);
 		CompendiumIndex.#instance = undefined;
 	}
 
@@ -419,5 +420,15 @@ export class CompendiumIndex {
 			stash: await this.getActorsOfType('stash'),
 		};
 		return entries;
+	}
+
+	/**
+	 * @desc Subscribes to various callbacks for indexing.
+	 */
+	static initialize() {
+		Hooks.on('updateCompendium', async (pack, changes) => {
+			// TODO: More granular update?
+			CompendiumIndex.reinitialize();
+		});
 	}
 }

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -88,6 +88,13 @@
 	cursor: not-allowed;
 }
 
+.fu-form__property-groups {
+	display: grid;
+	grid-column: span 2 / span 2;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 5px;
+}
+
 /*		DIALOGS		*/
 .fu-application .background,
 .fu-dialog .background,

--- a/templates/chat/partials/chat-item-spend-resource.hbs
+++ b/templates/chat/partials/chat-item-spend-resource.hbs
@@ -1,6 +1,7 @@
 <div class="fu-tags flexrow gap-5">
     <a data-action="applyResourceLoss" data-name="{{name}}" data-actor="{{actor}}" data-item="{{item}}" data-resource="{{expense.resource}}" data-tooltip="{{localize "FU.ChatApplyResourceLossTooltip"}}" data-amount="{{expense.amount}}">
-        <span class='fu-tag button flex-group-center gap-5 fu-target-action__icon__container' style="width: 100%;white-space: nowrap;">{{localize "FU.ChatApplyResourceLoss"}} {{expense.amount}}
+        <span class='fu-tag button flex-group-center gap-5 fu-target-action__icon__container' style="width: 100%;white-space: nowrap;">
+			{{localize "FU.ChatApplyResourceLoss"}} {{expense.amount}} {{localize resourceLabel}}
 			<i class="fu-icon {{icon}} fu-target-action__icon"></i>
 		</span>
     </a>

--- a/templates/item/partials/item-effect-application-section.hbs
+++ b/templates/item/partials/item-effect-application-section.hbs
@@ -15,7 +15,7 @@
 				 type="text"
 				 name="system.effects.entries.{{index}}"
 				 value="{{entry}}"
-				 placeholder="e.g. dazed|Item.XYZ123.ActiveEffect.ABC123"
+				 placeholder="e.g. status|fuid|uuid"
 				/>
 			</label>
 			<a data-path="system.effects.entries" data-index="{{ index }}" data-action="removeArrayElement">

--- a/templates/item/parts/item-attributes.hbs
+++ b/templates/item/parts/item-attributes.hbs
@@ -22,7 +22,7 @@
 
 	<!-- Grid -->
 	{{#if attributePartials.grid}}
-		<section class="grid grid-2col gap-5">
+		<section class="fu-form__property-groups">
 			{{#each attributePartials.grid as |part|}}
 				{{> (part) @root}}
 			{{/each}}


### PR DESCRIPTION
This pull request refactors and enhances the handling of skill and ability data models, especially for miscellaneous abilities, to improve code reuse, maintainability, and feature consistency. The main changes include extracting common logic into a new `BaseSkillDataModel`, updating how ability checks are configured and displayed, and making several related improvements and bug fixes.

**Skill and Ability Data Model Refactoring:**

* Introduced a new `BaseSkillDataModel` class to encapsulate shared schema definitions and logic for skills and abilities, including fields like `accuracy`, `damage`, `traits`, `effects`, `cost`, `resource`, and methods for configuring checks and display logic. (`module/documents/items/skill/base-skill-data-model.mjs`)
* Updated `MiscAbilityDataModel` to extend from `BaseSkillDataModel` instead of `FUSubTypedItemDataModel`, removing redundant or now-inherited schema fields and logic. The schema and logic for handling checks, tags, and display are now streamlined and more consistent with other skills. (`module/documents/items/misc/misc-ability-data-model.mjs`) [[1]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L3-L78) [[2]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93R108-R113) [[3]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L115-R137)

**Check and Display Logic Improvements:**

* Refactored the hooks and logic for rendering accuracy, attribute, and display checks for miscellaneous abilities to use the new shared methods from `BaseSkillDataModel`, improving code clarity and reducing duplication. (`module/documents/items/misc/misc-ability-data-model.mjs`)
* Improved tag handling and display for skills and abilities, ensuring that tags from both the item and its weapon (if applicable) are combined and shown in check summaries. (`module/documents/items/misc/misc-ability-data-model.mjs`)

**Bug Fixes and Minor Enhancements:**

* Fixed the order of flag initialization in `MessageRuleAction.execute` and improved null safety when accessing item parents. (`module/documents/effects/actions/message-rule-action.mjs`)
* Improved handling of effect actions to avoid pushing undefined actions. (`module/checks/common-sections.mjs`)
* Added the `item` property to `DamageEvent` and ensured it is passed through correctly. (`module/checks/common-events.mjs`) [[1]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R82) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R107)

**Predicate and Validation Consistency:**

* Clarified documentation and logic for the `TargetingRulePredicate` to use the correct type and added explicit handling for the `'none'` rule. (`module/documents/effects/predicates/targeting-rule-predicate.mjs`) [[1]](diffhunk://#diff-9365815fbff5ce5b5e6b5f85dbc634a8cebb50f3c3d063562a23fe2acc0c7f90L8-R8) [[2]](diffhunk://#diff-9365815fbff5ce5b5e6b5f85dbc634a8cebb50f3c3d063562a23fe2acc0c7f90R42-R43)

These changes collectively modernize the skill and ability infrastructure, making it easier to maintain and extend in the future.