### PR TITLE
Make sure to use uuids when passing references to items during flags

### DIFF
--- a/module/checks/accuracy-check.mjs
+++ b/module/checks/accuracy-check.mjs
@@ -149,7 +149,7 @@ function onRenderCheck(data, checkResult, actor, item, flags) {
 		const targets = inspector.getTargets();
 		CommonSections.actions(data, actor, item, targets, flags, inspector);
 		CommonEvents.attack(inspector, actor, item);
-		(flags[SYSTEM] ??= {})[Flags.ChatMessage.Item] ??= item.toObject();
+		(flags[SYSTEM] ??= {})[Flags.ChatMessage.Item] ??= item.uuid;
 	}
 }
 

--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -520,7 +520,7 @@ async function renderCheck(result, actor, item, flags = {}) {
 			{
 				[SYSTEM]: {
 					[Flags.ChatMessage.CheckV2]: result,
-					[Flags.ChatMessage.Item]: item?.toObject(),
+					[Flags.ChatMessage.Item]: item?.uuid,
 				},
 			},
 			foundry.utils.mergeObject(additionalFlags, flags, { overwrite: false }),

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -418,6 +418,7 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 
 			// Set any flags
 			Pipeline.toggleFlag(flags, Flags.ChatMessage.Targets);
+			flags = Pipeline.setFlag(flags, Flags.ChatMessage.Source, sourceInfo);
 			for (const action of actions) {
 				if (action.flag) {
 					Pipeline.toggleFlag(flags, action.flag);

--- a/module/checks/magic-check.mjs
+++ b/module/checks/magic-check.mjs
@@ -127,7 +127,7 @@ function onRenderCheck(data, checkResult, actor, item, flags) {
 			renderCombatMagicCheck(checkResult, inspector, data, actor, item, flags);
 		}
 
-		(flags[SYSTEM] ??= {})[Flags.ChatMessage.Item] ??= item.toObject();
+		(flags[SYSTEM] ??= {})[Flags.ChatMessage.Item] ??= item.uuid;
 	}
 }
 

--- a/module/documents/effects/active-effect-behaviour-mixin.mjs
+++ b/module/documents/effects/active-effect-behaviour-mixin.mjs
@@ -92,7 +92,7 @@ export function ActiveEffectBehaviourMixin(BaseDocument) {
 		/**
 		 * @returns {InlineSourceInfo} If present, information about the actor/item that was the source of this effect
 		 */
-		get source() {
+		get sourceInfo() {
 			return this.getFlag(Flags.Scope, Flags.ActiveEffect.Source);
 		}
 
@@ -108,8 +108,8 @@ export function ActiveEffectBehaviourMixin(BaseDocument) {
 		 * @remarks Used by the templates
 		 */
 		get sourceName() {
-			if (this.source) {
-				return this.source.name;
+			if (this.sourceInfo) {
+				return this.sourceInfo.name;
 			}
 			return this.parent.name;
 		}
@@ -224,8 +224,8 @@ export function ActiveEffectBehaviourMixin(BaseDocument) {
 
 			const context = new ExpressionContext(actor, item, [target]);
 			context.effect = this;
-			if (this.source) {
-				context.setSourceUuid(this.source.itemUuid);
+			if (this.sourceInfo) {
+				context.setSourceItem(this.sourceInfo.itemUuid);
 			}
 			return context;
 		}
@@ -261,7 +261,7 @@ export function ActiveEffectBehaviourMixin(BaseDocument) {
 		 * @remarks Unlike `_onCreate`, is managed by the GM.
 		 */
 		async _preCreate(data, options, user) {
-			console.debug(`Created active effect ${this.name} on ${this.parent.name ?? 'unknown'} with origin: ${this.origin}, source: ${this.source ? this.source.name : ''}`);
+			console.debug(`Created active effect ${this.name} on ${this.parent.name ?? 'unknown'} with origin: ${this.origin}, source: ${this.sourceInfo ? this.sourceInfo.name : ''}`);
 			const changes = {
 				name: game.i18n.localize(data.name),
 				[`system.duration.remaining`]: this.system.duration.interval,

--- a/module/documents/items/classFeature/arcanist/arcanum-data-model.mjs
+++ b/module/documents/items/classFeature/arcanist/arcanum-data-model.mjs
@@ -70,7 +70,7 @@ export class ArcanumDataModel extends RollableClassFeatureDataModel {
 				item: model.parent.parent,
 			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/arcanist/feature-arcanum-chat-message.hbs', data),
-			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
+			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid } },
 		};
 
 		CommonEvents.skill(item.actor, item);

--- a/module/documents/items/classFeature/chanter/key-data-model.mjs
+++ b/module/documents/items/classFeature/chanter/key-data-model.mjs
@@ -110,7 +110,7 @@ export class KeyDataModel extends RollableClassFeatureDataModel {
 				item: model.parent.parent,
 			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/chanter/feature-key-chat-message.hbs', data),
-			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
+			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid } },
 		};
 
 		ChatMessage.create(chatMessage);

--- a/module/documents/items/classFeature/dancer/dance-data-model.mjs
+++ b/module/documents/items/classFeature/dancer/dance-data-model.mjs
@@ -54,7 +54,7 @@ export class DanceDataModel extends RollableClassFeatureDataModel {
 			flavor: await FoundryUtils.renderTemplate('chat/chat-check-flavor-item-v2', { item: item }),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/dancer/feature-dance-chat-message.hbs', data),
 			flags: {
-				[SYSTEM]: { [Flags.ChatMessage.Item]: item },
+				[SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid },
 			},
 		};
 

--- a/module/documents/items/classFeature/esper/psychic-gift-data-model.mjs
+++ b/module/documents/items/classFeature/esper/psychic-gift-data-model.mjs
@@ -53,7 +53,7 @@ export class PsychicGiftDataModel extends RollableClassFeatureDataModel {
 				item: model.parent.parent,
 			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/esper/feature-psychic-chat-message.hbs', data),
-			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
+			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid } },
 		};
 
 		ChatMessage.create(chatMessage);

--- a/module/documents/items/classFeature/pilot/armor-module-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/armor-module-data-model.mjs
@@ -94,7 +94,7 @@ export class ArmorModuleDataModel extends RollableClassFeatureDataModel {
 				item: model.parent.parent,
 			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/pilot/feature-armor-module-chat-message.hbs', data),
-			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
+			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid } },
 		};
 
 		ChatMessage.create(chatMessage);

--- a/module/documents/items/classFeature/pilot/vehicle-data-model.mjs
+++ b/module/documents/items/classFeature/pilot/vehicle-data-model.mjs
@@ -85,7 +85,7 @@ export class VehicleDataModel extends RollableClassFeatureDataModel {
 				item: model.parent.parent,
 			}),
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/feature/pilot/feature-vehicle-frame-chat-message.hbs', data),
-			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item } },
+			flags: { [SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid } },
 		};
 
 		ChatMessage.create(chatMessage);

--- a/module/documents/items/classFeature/tinkerer/alchemy-data-model.mjs
+++ b/module/documents/items/classFeature/tinkerer/alchemy-data-model.mjs
@@ -176,7 +176,7 @@ export class AlchemyDataModel extends RollableClassFeatureDataModel {
 			superior: await TextEditor.enrichHTML(model.superior || ''),
 		};
 		if (dice && rank) {
-			const flags = { [SYSTEM]: { [Flags.ChatMessage.Item]: item } };
+			const flags = { [SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid } };
 			const actor = model.parent.parent.actor;
 			const roll = await new Roll(`{${Array(dice).fill('d20').join(', ')}}`).roll();
 			const description = descriptions[rank];

--- a/module/expressions/expressions.mjs
+++ b/module/expressions/expressions.mjs
@@ -17,7 +17,6 @@ import { ObjectUtils } from '../helpers/object-utils.mjs';
  * @property {FUItem} item  The item the expression is evaluated on
  * @property {FUActiveEffect} effect  The effect the expression is evaluated on
  * @property {FUActor[]} targets The targets the expression is evaluated on
- * @property {FUActor} source Optionally, can be used to execute evaluations on
  * @property {CheckResultV2|null} check The result of a check.
  * @property {InlineSourceInfo} sourceInfo
  * @remarks Do not serialize this class, as it references full objects. Instead, store their uuids
@@ -79,10 +78,6 @@ export class ExpressionContext {
 		return this;
 	}
 
-	setSourceUuid(sourceId) {
-		this.#sourceUuid = sourceId;
-	}
-
 	/**
 	 * @param {String} match
 	 */
@@ -97,7 +92,7 @@ export class ExpressionContext {
 	 * @param {String} match
 	 */
 	assertSource(match) {
-		if (this.source == null) {
+		if (this.sourceItem == null) {
 			// Can be evaluated very early
 			if (ui.notifications) {
 				ui.notifications.warn('FU.ChatEvaluateAmountNoSource', { localize: true });
@@ -175,8 +170,7 @@ export class ExpressionContext {
 	resolveActorOrSource(match, redirect) {
 		if (redirect) {
 			this.assertSource(match);
-			const sourceItem = this.source;
-			const sourceActor = sourceItem.actor;
+			const sourceActor = this.sourceItem.actor;
 			if (!sourceActor) {
 				ui.notifications.warn('FU.ChatEvaluateNoSourceActor', { localize: true });
 				throw new Error(`The source item needs to be owned by an actor in order to evaluate the expression"`);
@@ -195,9 +189,16 @@ export class ExpressionContext {
 	}
 
 	/**
+	 * @param {String} sourceId
+	 */
+	setSourceItem(sourceId) {
+		this.#sourceUuid = sourceId;
+	}
+
+	/**
 	 * @returns {FUItem}
 	 */
-	get source() {
+	get sourceItem() {
 		if (!this._source && this.#sourceUuid) {
 			this._source = fromUuidSync(this.#sourceUuid);
 		}

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -27,10 +27,10 @@ export const Flags = Object.freeze({
 		SupportCheck: 'Supporter',
 		PromptCheck: 'PromptCheck',
 		GroupCheckSupporters: 'GroupCheckSupporters',
-		Item: 'Item',
+		Item: 'Item', // UUID
 		Effect: 'Effect',
 		Damage: 'Damage',
-		Source: 'Source',
+		Source: 'Source', // InlineSourceInfo
 		ResourceGain: 'ResourceGain',
 		ResourceLoss: 'ResourceLoss',
 		Progress: 'Progress',

--- a/module/helpers/inline-helper.mjs
+++ b/module/helpers/inline-helper.mjs
@@ -60,6 +60,18 @@ export class InlineSourceInfo {
 	}
 
 	/**
+	 * @param message
+	 * @returns {InlineSourceInfo}
+	 */
+	static fromChatMessage(message) {
+		const info = message.getFlag(SYSTEM, Flags.ChatMessage.Source);
+		if (info) {
+			return new InlineSourceInfo(info.name, info.actorUuid, info.itemUuid);
+		}
+		return null;
+	}
+
+	/**
 	 * @returns {FUActor|null}
 	 */
 	resolveActor() {

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -565,13 +565,6 @@ async function process(request) {
 	return Promise.all(updates);
 }
 
-function getSourceInfoFromChatMessage(message) {
-	const sourceActorUuid = message.getFlag(SYSTEM, Flags.ChatMessage.CheckV2)?.actorUuid;
-	const sourceItemUuid = message.getFlag(SYSTEM, Flags.ChatMessage.CheckV2)?.itemUuid;
-	const sourceName = message.getFlag(SYSTEM, Flags.ChatMessage.Item)?.name;
-	return new InlineSourceInfo(sourceName, sourceActorUuid, sourceItemUuid);
-}
-
 /**
  * @param {ChatMessage} message
  * @param {HTMLElement} html
@@ -589,7 +582,7 @@ function onRenderChatMessage(message, html) {
 		const inspector = CheckConfiguration.inspect(message);
 		const damageData = inspector.getDamage();
 		const traits = inspector.getTraits();
-		const sourceInfo = getSourceInfoFromChatMessage(message);
+		const sourceInfo = InlineSourceInfo.fromChatMessage(message);
 
 		const customizeDamage = async (event, targets) => {
 			return DamageCustomizer(

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -417,7 +417,7 @@ function removeEffect(document, source, effect) {
 	const existingEffect = document.effects.find(
 		(e) =>
 			e.getFlag(SYSTEM, Flags.ActiveEffect.Temporary) &&
-			e.source === source &&
+			e.sourceItem === source &&
 			e.changes.length === effect.changes.length &&
 			e.changes.every((change, index) => change.key === effect.changes[index].key && change.mode === effect.changes[index].mode && change.value === effect.changes[index].value),
 	);


### PR DESCRIPTION
This pull request standardizes how item references are stored in chat message flags, updates naming conventions for source information accessors, and improves handling of source information throughout the codebase. The changes primarily focus on using item UUIDs instead of full item objects in chat message flags, renaming and refactoring methods and properties related to source information, and enhancing consistency when retrieving source info from chat messages.

**Standardization of item references in chat message flags:**
- Replaced storage of full item objects with item UUIDs for `Flags.ChatMessage.Item` in various modules and data models, improving serialization and reducing data size. [[1]](diffhunk://#diff-25e3557cd86f5e71fa2a4f78c11dc38d55d6c3fd2a18110ee43796e615c25e0dL152-R152) [[2]](diffhunk://#diff-a24a65b13ca3debb615e61d8e99aff910d272322ee740e2ce8027d093a7312b6L130-R130) [[3]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1L523-R523) [[4]](diffhunk://#diff-91891d2bd08c94bef124d39657d314fb81873534286a05563c9a9f11f0b15a62L73-R73) [[5]](diffhunk://#diff-e435263eff36853464ad6d11556a282804c9be083224d4610d18e2755f77162cL113-R113) [[6]](diffhunk://#diff-0a36d40bc611e17fe9157d84a8438ea0d13159f71994b2b4179be18baa20bd87L57-R57) [[7]](diffhunk://#diff-e4b0bf5662a7ab060eb5cf85aef0f5780c0adb9063a49ccff8717749e87119bfL56-R56) [[8]](diffhunk://#diff-519208cb06a606eeee9149d14dfaee3c3450a48510bea186cfafcc68308c767dL97-R97) [[9]](diffhunk://#diff-f3793803652647ffe1ab1cd1d6b7d54980ede8ee4ed899850f229972aa97f582L88-R88) [[10]](diffhunk://#diff-a2b09fc08b2a116ef4263f5190e5f859433bbcfcd0838e1512dc9b78f1706832L179-R179)

**Refactoring and renaming for source information:**
- Renamed the `source` property to `sourceInfo` in the `ActiveEffectBehaviourMixin` and updated all usages to reflect this change, clarifying the intent and improving code readability. [[1]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735L95-R95) [[2]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735L111-R112) [[3]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735L227-R228) [[4]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735L264-R264)
- Updated the `ExpressionContext` class: replaced `setSourceUuid`/`source` with `setSourceItem`/`sourceItem` methods and properties, and refactored related logic for clarity and consistency. [[1]](diffhunk://#diff-4775c47144b82c3f6f4dfaa582bbf9e4b215e8c1ecb9a88871e118950fa358faL82-L85) [[2]](diffhunk://#diff-4775c47144b82c3f6f4dfaa582bbf9e4b215e8c1ecb9a88871e118950fa358faL100-R95) [[3]](diffhunk://#diff-4775c47144b82c3f6f4dfaa582bbf9e4b215e8c1ecb9a88871e118950fa358faL178-R173) [[4]](diffhunk://#diff-4775c47144b82c3f6f4dfaa582bbf9e4b215e8c1ecb9a88871e118950fa358faR191-R201)

**Improved handling and retrieval of source information:**
- Added a static `fromChatMessage` method to `InlineSourceInfo` for extracting source info from chat messages, and refactored pipelines to use this utility. [[1]](diffhunk://#diff-98053ef999f4ef1d1118c7eb322e4d7707c2e1bd78f1d7e8f6e089b8502a2299R62-R73) [[2]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL568-L574) [[3]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL592-R585)
- Updated flag documentation and usages to clarify that `Flags.ChatMessage.Item` now stores UUIDs and `Flags.ChatMessage.Source` stores `InlineSourceInfo`.

**Other improvements:**
- Updated references in effect removal logic and documentation to use the new `sourceItem` property for consistency. [[1]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL420-R420) [[2]](diffhunk://#diff-4775c47144b82c3f6f4dfaa582bbf9e4b215e8c1ecb9a88871e118950fa358faL20)