### PR TITLE
Add attributes to targeted defenses

### DIFF
--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -508,7 +508,7 @@ export class CheckConfigurer extends CheckInspector {
 			const targetedDefense = this.getTargetedDefense();
 			for (let t = 0; t < targets.length; t++) {
 				const target = targets[t];
-				const difficulty = target[targetedDefense];
+				const difficulty = target.defenses[targetedDefense];
 				let targetResult;
 				if (this.check.critical) {
 					targetResult = 'hit';

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -436,9 +436,10 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 
 			return {
 				order: CHECK_RESULT,
-				partial: 'systems/projectfu/templates/chat/partials/chat-targets.hbs',
+				partial: 'systems/projectfu/templates/chat/partials/chat-actions.hbs',
 				data: {
 					retarget: true,
+					defense: inspector.getTargetedDefense(),
 					rule: rule,
 					targets: targetData,
 					actions: actions,

--- a/module/helpers/chat-action.mjs
+++ b/module/helpers/chat-action.mjs
@@ -134,7 +134,7 @@ export class ChatAction {
 	 * @return {Promise<String>}
 	 */
 	static async renderToChat(actions, targetData = [], retarget = true) {
-		const html = await FoundryUtils.renderTemplate('chat/partials/chat-targets', {
+		const html = await FoundryUtils.renderTemplate('chat/partials/chat-actions', {
 			retarget: retarget,
 			targets: targetData,
 			actions: actions,

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -447,7 +447,7 @@ FU.weaponTypes = {
 };
 
 /**
- * @typedef {"def", "mdef"} Defense
+ * @typedef {"def", "mdef", "dex", "ins", "mig", "wlp"} Defense
  */
 /**
  * @type {Object.<Defense, Object.<"name"|"abbr", string>>}
@@ -460,6 +460,22 @@ FU.defenses = {
 	mdef: {
 		name: 'FU.MagicDefense',
 		abbr: 'FU.MagicDefenseAbbr',
+	},
+	dex: {
+		name: 'FU.AttributeDex',
+		abbr: 'FU.AttributeDexAbbr',
+	},
+	ins: {
+		name: 'FU.AttributeIns',
+		abbr: 'FU.AttributeInsAbbr',
+	},
+	mig: {
+		name: 'FU.AttributeMig',
+		abbr: 'FU.AttributeMigAbbr',
+	},
+	wlp: {
+		name: 'FU.AttributeWlp',
+		abbr: 'FU.AttributeWlpAbbr',
 	},
 };
 

--- a/module/helpers/targeting.mjs
+++ b/module/helpers/targeting.mjs
@@ -8,12 +8,23 @@ import { ChatAction } from './chat-action.mjs';
  */
 
 /**
+ * @typedef DefenseData
+ * @property {Number} def
+ * @property {Number} mdef
+ * @property {Number} dex
+ * @property {Number} ins
+ * @property {Number} mig
+ * @property {Number} wlp
+ */
+
+/**
  * @typedef TargetData
  * @property {string} name The name of the actor
  * @property {string} uuid The uuid of the actor
  * @property {string} link An html link to the actor
  * @property {Number} def
  * @property {Number} mdef
+ * @property {DefenseData} defenses
  * @property {number} difficulty
  * @property {"none", "hit", "miss"} result
  * @property {Boolean} isOwner
@@ -103,9 +114,18 @@ function constructData(actor) {
 		name: actor.name,
 		uuid: actor.uuid,
 		link: actor.link,
-		result: 'none',
+		result: 'none', // Updated during evaluation
+		// LEGACY
 		def: actor.system.derived.def.value,
 		mdef: actor.system.derived.mdef.value,
+		defenses: {
+			def: actor.system.derived.def.value,
+			mdef: actor.system.derived.mdef.value,
+			dex: actor.system.attributes.dex.current,
+			ins: actor.system.attributes.ins.current,
+			mig: actor.system.attributes.mig.current,
+			wlp: actor.system.attributes.wlp.current,
+		},
 		isOwner: actor.isOwner,
 	};
 }

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -105,7 +105,7 @@ export const preloadHandlebarsTemplates = async function () {
 			'systems/projectfu/templates/chat/partials/chat-opposed-check-details.hbs',
 			'systems/projectfu/templates/chat/partials/chat-clock-details.hbs',
 			'systems/projectfu/templates/chat/partials/chat-resource-details.hbs',
-			'systems/projectfu/templates/chat/partials/chat-targets.hbs',
+			'systems/projectfu/templates/chat/partials/chat-actions.hbs',
 			'systems/projectfu/templates/chat/partials/chat-common-sections.hbs',
 			'systems/projectfu/templates/chat/partials/chat-collapsible-description.hbs',
 			'systems/projectfu/templates/chat/partials/chat-generic-text.hbs',

--- a/templates/chat/chat-apply-damage-prompt.hbs
+++ b/templates/chat/chat-apply-damage-prompt.hbs
@@ -2,4 +2,4 @@
 	{{{localize 'FU.ChatApplyDamagePrompt' type=type amount=amount source=source }}}
 </section>
 
-{{> 'systems/projectfu/templates/chat/partials/chat-targets.hbs' targets=targets actions=actions}}
+{{> 'systems/projectfu/templates/chat/partials/chat-actions.hbs' targets=targets actions=actions}}

--- a/templates/chat/chat-apply-effect-prompt.hbs
+++ b/templates/chat/chat-apply-effect-prompt.hbs
@@ -2,4 +2,4 @@
 	{{{localize 'FU.ChatApplyEffectPrompt' source=source }}}
 </section>
 
-{{> 'systems/projectfu/templates/chat/partials/chat-targets.hbs' targets=targets actions=actions}}
+{{> 'systems/projectfu/templates/chat/partials/chat-actions.hbs' targets=targets actions=actions}}

--- a/templates/chat/chat-update-resource-prompt.hbs
+++ b/templates/chat/chat-update-resource-prompt.hbs
@@ -2,4 +2,4 @@
 	{{{localize message type=type amount=amount source=source }}}
 </section>
 
-{{> 'systems/projectfu/templates/chat/partials/chat-targets.hbs' targets=targets actions=actions}}
+{{> 'systems/projectfu/templates/chat/partials/chat-actions.hbs' targets=targets actions=actions}}

--- a/templates/chat/partials/chat-actions.hbs
+++ b/templates/chat/partials/chat-actions.hbs
@@ -5,7 +5,9 @@
             <span class="flexrow">
                 <span class="target total {{#if (eq target.result "hit")}}hit{{else if (eq target.result "miss")}}miss{{else}}default{{/if}} flexrow">
                     <!-- Label -->
-                    <div style="padding: 2px;">{{target.name}}</div>
+                    <div style="padding: 2px;">
+						{{target.name}}
+					</div>
                     <!-- Accuracy Information -->
 					{{#if (or (eq target.result "hit") (eq target.result "miss"))}}
 						<div class="endcap gap-5" style="flex: 0 1 auto;">

--- a/templates/item/partials/item-attack-accuracy.hbs
+++ b/templates/item/partials/item-attack-accuracy.hbs
@@ -1,7 +1,8 @@
 <fieldset class="title-fieldset desc resource-content">
 	<legend class="resource-label-full">
-		<label class="resource-label-m"><i class="fas fa-dice icon"></i>{{localize
-		 'FU.Accuracy'}}</label>
+		<label class="resource-label-m"><i class="fas fa-dice icon"></i>
+			{{localize 'FU.Accuracy'}}
+		</label>
 	</legend>
 	<div class="grid grid-3col flexrow">
 		<label class="resource-label-m resource-content flexcol flex-group-center">
@@ -31,8 +32,7 @@
 			{{localize 'FU.Defense'}}
 			<div class="resource-content flexrow flex-group-center">
 				<select name="system.defense" class="resource-inputs resource-text-sm">
-					{{selectOptions defenses selected=system.defense sort=true localize=true
-									labelAttr="abbr"}}
+					{{selectOptions defenses selected=system.defense localize=true labelAttr="abbr"}}
 				</select>
 			</div>
 		</label>


### PR DESCRIPTION
This pull request expands the defense system in the project by introducing new defense types, updates the way target defense values are accessed and displayed, and consolidates several chat partial templates for consistency. The changes enhance flexibility for future mechanics and streamline template usage.

**Defense System Enhancements:**

* Added new defense types (`dex`, `ins`, `mig`, `wlp`) to the `Defense` typedef and `FU.defenses` configuration, allowing actors to have a broader range of defense attributes. [[1]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5L450-R450) [[2]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5R464-R479)
* Updated the `TargetData` structure and its construction to include a new `defenses` object containing all defense values, improving data organization and future extensibility. [[1]](diffhunk://#diff-10ba8f10b1e56301f1dc109edf02f268b67d253759d628a84db1fda4a5102cdfR10-R27) [[2]](diffhunk://#diff-10ba8f10b1e56301f1dc109edf02f268b67d253759d628a84db1fda4a5102cdfL106-R128)

**Template and UI Updates:**

* Renamed and consolidated the chat partial template from `chat-targets.hbs` to `chat-actions.hbs`, updating all relevant references across the codebase and templates for consistency. [[1]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL439-R442) [[2]](diffhunk://#diff-efd7d445d98d0eb05af7e82ab7f0a9ce67a96b1943d2e5fa080921b0eb374c88L137-R137) [[3]](diffhunk://#diff-c55f5a7794a56f98b8ce58d411e65f9c641fd4ad659751611cbb7787250557d9L108-R108) [[4]](diffhunk://#diff-a6d4b7a4c1219223df24425a1dbb621d523ab870a63c0334b18829aff59243ccL5-R5) [[5]](diffhunk://#diff-0a2b3f09a3b7436705d1f8a6472f831b1116e8ae662d01fa884ad18f37801253L5-R5) [[6]](diffhunk://#diff-8c1ee0f80912a81e0c17d58addda2898f128a4af97299804ef8877fb8551d78dL5-R5) [[7]](diffhunk://#diff-912a05d02174c707acfd4b6d01b7998584d502ced8fc701e91ab570ff45e19a2L8-R10)
* Improved the accuracy and defense selection UI in `item-attack-accuracy.hbs` by cleaning up the label markup and removing unnecessary sorting from the defense dropdown. [[1]](diffhunk://#diff-60f6235ab47a93205060ba36970347e15d353f1008c8f5ec6248d4ecb8844c43L3-R5) [[2]](diffhunk://#diff-60f6235ab47a93205060ba36970347e15d353f1008c8f5ec6248d4ecb8844c43L34-R35)

**Logic Adjustments:**

* Updated targeting logic to access defense values from the new `defenses` object, ensuring compatibility with the expanded defense system.