### PR TITLE
Fix clear effect REA not working on all valid triggers

### DIFF
--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -71,12 +71,12 @@ const template = (sections, template, context, order) => {
 /**
  * @param {CheckRenderData} sections
  * @param {ChatAction[]} actions
+ * @param {Object} flags
  * @param {number} [order]
  */
-const chatActions = (sections, actions, order) => {
+const chatActions = (sections, actions, flags = {}, order) => {
 	sections.push(async () => {
 		const content = await ChatAction.renderToChat(actions);
-		let flags = {};
 		for (const action of actions) {
 			if (action.flag) {
 				Pipeline.toggleFlag(flags, action.flag);

--- a/module/checks/opposed-check.mjs
+++ b/module/checks/opposed-check.mjs
@@ -114,7 +114,7 @@ const onRenderCheck = (sections, check, actor, item, flags) => {
 				initialCheck: check,
 			};
 			const action = new ChatAction(actionName, FU.checkIcons.opposed, tooltip).withLabel(tooltip).withSelected().withFields(data);
-			CommonSections.chatActions(sections, [action], CHECK_ADDENDUM_ORDER);
+			CommonSections.chatActions(sections, [action], {}, CHECK_ADDENDUM_ORDER);
 		}
 	}
 };

--- a/module/documents/effects/actions/apply-effect-rule-action.mjs
+++ b/module/documents/effects/actions/apply-effect-rule-action.mjs
@@ -33,8 +33,7 @@ export class ApplyEffectRuleAction extends RuleActionDataModel {
 		}
 
 		const targets = selected.map((c) => c.actor);
-		// If there's a configuration provided
-		if (context.event.config) {
+		if (context.config) {
 			/** @type CheckConfigurer **/
 			const config = context.event.config;
 			config.addEffects(this.effect);

--- a/module/documents/effects/actions/clear-effect-rule-action.mjs
+++ b/module/documents/effects/actions/clear-effect-rule-action.mjs
@@ -1,6 +1,9 @@
 import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
 import { RuleActionDataModel } from './rule-action-data-model.mjs';
 import { Effects } from '../../../pipelines/effects.mjs';
+import { SectionChatBuilder } from '../../../helpers/section-chat-builder.mjs';
+import { CommonSections } from '../../../checks/common-sections.mjs';
+import { Flags } from '../../../helpers/flags.mjs';
 
 const fields = foundry.data.fields;
 
@@ -28,6 +31,15 @@ export class ClearEffectRuleAction extends RuleActionDataModel {
 
 	async execute(context, selected) {
 		const action = await Effects.getClearAction(this.identifier, context.sourceInfo);
-		context.config.addTargetedAction(action);
+		if (context.config) {
+			context.config.addTargetedAction(action);
+		} else {
+			const builder = new SectionChatBuilder(context.character.actor, context.item);
+			if (context.item) {
+				CommonSections.itemFlavor(builder.sections, context.item);
+			}
+			CommonSections.chatActions(builder.sections, [action], builder.flags);
+			await builder.create();
+		}
 	}
 }

--- a/module/helpers/inline-helper.mjs
+++ b/module/helpers/inline-helper.mjs
@@ -325,7 +325,7 @@ function getRenderContext(element) {
 
 	let sourceInfo;
 	if (document instanceof ChatMessage) {
-		sourceInfo = document.getFlag(SYSTEM, Flags.ChatMessage.Source);
+		sourceInfo = InlineSourceInfo.fromChatMessage(document);
 	}
 	if (!sourceInfo) {
 		sourceInfo = InlineHelper.determineSource(document, target);

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -276,13 +276,16 @@ async function onFeatureEvent(event) {
 function getSceneCharacters(targets) {
 	/** @type CharacterInfo[] **/
 	let sceneCharacters = [];
+	sceneCharacters.push(...targets);
+
 	if (FUCombat.hasActiveEncounter) {
+		/** @type FUCombatant[] **/
 		const combatants = Array.from(FUCombat.activeEncounter.combatants.values());
 		const combatCharacters = CharacterInfo.fromCombatants(combatants);
 		sceneCharacters.push(...combatCharacters);
 	}
-	const uuids = new Set(sceneCharacters.map((c) => c.actor.uuid));
-	return [...sceneCharacters, ...targets.filter((ec) => !uuids.has(ec.actor.uuid))];
+
+	return [...new Map(sceneCharacters.filter((ci) => ci.actor?.uuid).map((ci) => [ci.actor.uuid, ci])).values()];
 }
 
 /** @type {FUItem | null} */

--- a/styles/css/chat/chat-optional-features.css
+++ b/styles/css/chat/chat-optional-features.css
@@ -50,6 +50,8 @@
 }
 
 .fu-chat__clear-effect {
+	border: 2px solid #B00000;
+	box-shadow: inset 0 0 0 1px rgba(255, 200, 200, 0.4);
 	background-color: #FF5A5A;
 	text-shadow:
 	  0 0 2px rgba(0, 0, 0, 0.85),


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to effect rule actions, chat rendering, and character targeting logic. The main focus is on enhancing the handling of effect rule actions, refining the chat action rendering API, and making the targeting logic for scene characters more robust.

**Effect Rule Actions and Chat Rendering:**

* Added fallback chat rendering for `ClearEffectRuleAction` when no configuration is present, using `SectionChatBuilder` and `CommonSections.chatActions` to ensure actions are displayed in chat.
* Fixed `ApplyEffectRuleAction` to correctly check for configuration presence using `context.config` instead of `context.event.config`.
* Added missing imports to `clear-effect-rule-action.mjs` for `SectionChatBuilder`, `CommonSections`, and `Flags` to support the new chat rendering logic.

**Chat Action API Consistency:**

* Updated `CommonSections.chatActions` to accept a `flags` parameter and updated its usage accordingly, ensuring consistent API usage across the codebase. [[1]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bR74-L79) [[2]](diffhunk://#diff-005ef721ef7deb721a2c6d055ca308544f28db4887357d1c87f94e2427b1252cL117-R117)

**Targeting and Source Info Improvements:**

* Improved the logic for collecting scene characters in `getSceneCharacters` to avoid duplicates by using a `Map` keyed by actor UUID, ensuring each character is only included once.
* Updated `getRenderContext` to obtain source info from chat messages using `InlineSourceInfo.fromChatMessage`, improving accuracy in source determination.

**UI Enhancements:**

* Enhanced the `.fu-chat__clear-effect` CSS class for clearer visual distinction of clear effect actions in chat.