### PR TITLE
Improve actor effect id resolution

### DIFF
--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -263,7 +263,7 @@ export class FUActor extends Actor {
 	}
 
 	/**
-	 * @return {Generator<ActiveEffect, void, void>}
+	 * @return {Generator<FUActiveEffect, void, void>}
 	 * @remarks Includes effects from items
 	 */
 	*allEffects() {
@@ -315,23 +315,13 @@ export class FUActor extends Actor {
 	}
 
 	/**
-	 * @param {String} name The name of the effect, one of its statuses, or its fuid
+	 * @param {String} id The name of the effect, one of its statuses, or its fuid
 	 * @returns {FUActiveEffect}
 	 */
-	resolveEffect(name) {
-		name = name.toLowerCase();
+	resolveEffect(id) {
+		id = id.toLowerCase();
 		return Array.from(this.allEffects()).find((effect) => {
-			if (effect.name.toLowerCase() === name) {
-				return true;
-			}
-			if (effect.statuses.has(name)) {
-				return true;
-			}
-			if (effect.identifier === name) {
-				return true;
-			}
-
-			return false;
+			return effect.matches(id);
 		});
 	}
 

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -974,6 +974,7 @@ export const Effects = Object.freeze({
 	promptApplyEffect,
 	getTargetedAction,
 	getClearAction,
+	createEffectFlags,
 
 	BOONS_AND_BANES,
 	DAMAGE_TYPES,


### PR DESCRIPTION
This pull request improves how effects are identified and managed within actors and active effects. The main focus is on making effect resolution more robust and flexible by introducing a new `matches` method and enhancing effect creation with better source tracking.

**Effect Resolution Enhancements:**

* Added a `matches` method to the `ActiveEffectBehaviourMixin` that checks if an effect matches a given identifier by name, status, identifier, or source info FUID. This centralizes and simplifies effect matching logic.
* Updated the `resolveEffect` method in `FUActor` to use the new `matches` method, improving code clarity and consistency in effect lookups.
* Changed the generator return type for `allEffects` in `FUActor` to yield `FUActiveEffect` instead of `ActiveEffect`, clarifying the type of effects handled.

**Effect Creation and Source Tracking:**

* Enhanced the `_preCreate` method in `ActiveEffectBehaviourMixin` to automatically set source flags using `InlineSourceInfo` when creating effects directly from a compendium item, improving traceability of effect origins.

**General Maintenance:**

* Added a missing import for `InlineSourceInfo` in `active-effect-behaviour-mixin.mjs` to support new source tracking functionality.
* Added `createEffectFlags` to the exports in `effects.mjs` for broader utility.