### PR TITLE
Fix REs not accounting for effect predicates properly

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1656,6 +1656,7 @@
 		"RuleTriggerPerformCheck": "Perform Check",
 		"RuleTriggerResolveCheck": "Resolve Check",
 		"RuleTriggerRenderCheck": "Render Check",
+		"RuleTriggerRenderMessage": "Render Message",
 		"RuleTriggerDamage": "Damage",
 		"RuleTriggerStatus": "Status",
 		"RuleTriggerResourceUpdate": "Resource Update",

--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -437,7 +437,9 @@ async function renderCheck(result, actor, item, flags = {}) {
 	const config = CheckConfiguration.configure(result);
 
 	Hooks.callAll(CheckHooks.renderCheck, renderData, result, actor, item, additionalFlags);
+	// We subscribe to both events here, since either approach would work.
 	await CommonEvents.renderCheck(renderData, config, actor, item);
+	await CommonEvents.renderMessage(renderData, actor, item);
 
 	/**
 	 * @type {CheckSection[]}

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -664,6 +664,32 @@ function notify(source, id, origin) {
 }
 
 /**
+ * @typedef RenderMessageEvent
+ * @property {CheckRenderData} renderData
+ * @property {CharacterInfo} source
+ * @property {*} document A reference to a document such as an actor or item.
+ * @remarks Emitted when a message is about to be rendered.
+ */
+
+/**
+ * @param {CheckRenderData} renderData
+ * @param {FUActor} actor
+ * @param {*} document
+ * @returns {Promise<[]|*>}
+ */
+async function renderMessage(renderData, actor, document = undefined) {
+	const source = CharacterInfo.fromActor(actor);
+
+	/** @type RenderMessageEvent  **/
+	const event = {
+		renderData: renderData,
+		document: document,
+		source: source,
+	};
+	return AsyncHooks.callSequential(FUHooks.RENDER_MESSAGE_EVENT, event);
+}
+
+/**
  * @desc Dispatched when a class feature has been used.
  * @typedef FeatureEvent
  * @property {CharacterInfo} source
@@ -775,6 +801,7 @@ export const CommonEvents = Object.freeze({
 	reveal,
 	opportunity,
 	progress,
+	renderMessage,
 	initializeCheck,
 	performCheck,
 	resolveCheck,

--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -54,7 +54,7 @@ export class MessageRuleAction extends RuleActionDataModel {
 		}
 		// Message
 		const _message = this.message || StringUtils.localize('FU.RuleElementTriggered');
-		if (context.config && context.source && context.renderData) {
+		if (context.renderData && context.source) {
 			const actor = context.source.actor !== context.character.actor ? context.item?.parent : null;
 			CommonSections.itemText(context.renderData, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
 		} else {

--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -54,37 +54,20 @@ export class MessageRuleAction extends RuleActionDataModel {
 		}
 		// Message
 		const _message = this.message || StringUtils.localize('FU.RuleElementTriggered');
-
-		switch (context.eventType) {
-			case FUHooks.RENDER_CHECK_EVENT: {
-				/** @type RenderCheckEvent **/
-				const rce = context.event;
-				const actor = rce.source.actor !== context.character.actor ? context.item?.parent : null;
-				CommonSections.itemText(rce.renderData, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
-				break;
-			}
-
-			case FUHooks.FEATURE_EVENT: {
-				/** @type FeatureEvent **/
-				const fe = context.event;
-				const actor = fe.source.actor !== context.character.actor ? context.item?.parent : null;
-				CommonSections.itemText(fe.builder.sections, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
-				break;
-			}
-
-			default: {
-				const actor = context.character.actor;
-				const content = await FoundryUtils.renderTemplate('chat/partials/chat-item-text', {
-					item: context.item,
-					text: _message,
-				});
-				ChatMessage.create({
-					flags: flags,
-					speaker: ChatMessage.getSpeaker({ actor }),
-					content: content,
-				});
-				break;
-			}
+		if (context.config && context.source && context.renderData) {
+			const actor = context.source.actor !== context.character.actor ? context.item?.parent : null;
+			CommonSections.itemText(context.renderData, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
+		} else {
+			const actor = context.character.actor;
+			const content = await FoundryUtils.renderTemplate('chat/partials/chat-item-text', {
+				item: context.item,
+				text: _message,
+			});
+			ChatMessage.create({
+				flags: flags,
+				speaker: ChatMessage.getSpeaker({ actor }),
+				content: content,
+			});
 		}
 	}
 }

--- a/module/documents/effects/active-effect.mjs
+++ b/module/documents/effects/active-effect.mjs
@@ -39,6 +39,7 @@ import { CommonEvents } from '../../checks/common-events.mjs';
  * @extends ActiveEffect
  * @property {FUActiveEffectModel} system
  * @property {InlineSourceInfo} source
+ * @property {Boolean} disabled Serialized with the document.
  * @inheritDoc
  * */
 export class FUActiveEffect extends ActiveEffectBehaviourMixin(ActiveEffect) {}

--- a/module/documents/effects/rule-element-context.mjs
+++ b/module/documents/effects/rule-element-context.mjs
@@ -8,8 +8,7 @@ import { ExpressionContext } from '../../expressions/expressions.mjs';
  * @property {CharacterInfo} character The character the rule element is being evaluated on.
  * @property {InlineSourceInfo} sourceInfo
  * @property {CheckResultV2|null} check Some events may have check information.
- * @property {CheckConfigurer|null} config Configuration for a check, available in some events. Mutually exclusive with {@linkcode messageBuilder}.
- * @property {SectionChatBuilder|null} messageBuilder Configuration for a chat message. Mutually exclusive with {@linkcode config}.
+ * @property {CheckConfigurer|null} config Configuration for a check, available in events involving the checks pipeline.
  * @property {CheckRenderData} renderData Used for rendering chat messages.
  * @property {FUItem|null} item The item the rule element could be on.
  * @property {CharacterInfo} source The source character of the event.

--- a/module/documents/effects/rule-element-context.mjs
+++ b/module/documents/effects/rule-element-context.mjs
@@ -8,7 +8,9 @@ import { ExpressionContext } from '../../expressions/expressions.mjs';
  * @property {CharacterInfo} character The character the rule element is being evaluated on.
  * @property {InlineSourceInfo} sourceInfo
  * @property {CheckResultV2|null} check Some events may have check information.
- * @property {CheckConfigurer|null} config Configuration for a check, available in some events.
+ * @property {CheckConfigurer|null} config Configuration for a check, available in some events. Mutually exclusive with {@linkcode messageBuilder}.
+ * @property {SectionChatBuilder|null} messageBuilder Configuration for a chat message. Mutually exclusive with {@linkcode config}.
+ * @property {CheckRenderData} renderData Used for rendering chat messages.
  * @property {FUItem|null} item The item the rule element could be on.
  * @property {CharacterInfo} source The source character of the event.
  * @property {CharacterInfo[]} targets The targets of the event.

--- a/module/documents/effects/triggers/render-check-rule-trigger.mjs
+++ b/module/documents/effects/triggers/render-check-rule-trigger.mjs
@@ -9,6 +9,7 @@ const fields = foundry.data.fields;
  * @property {String} identifier The id of an Item to match.
  * @property {Set<CheckType>} checkTypes
  * @property {Set<FUItemGroup>} itemGroups
+ * @property {Boolean} local
  * @inheritDoc
  */
 export class RenderCheckRuleTrigger extends RuleTriggerDataModel {
@@ -67,22 +68,6 @@ export class RenderCheckRuleTrigger extends RuleTriggerDataModel {
 			}
 		}
 
-		if (this.outcome) {
-			for (const target of context.event.targets) {
-				switch (target.check) {
-					case 'hit':
-						if (this.outcome !== 'success') {
-							return false;
-						}
-						break;
-					case 'miss':
-						if (this.outcome !== 'failure') {
-							return false;
-						}
-						break;
-				}
-			}
-		}
 		if (this.identifier) {
 			return context.matchesItem(this.identifier);
 		}

--- a/module/documents/effects/triggers/render-message-rule-trigger.mjs
+++ b/module/documents/effects/triggers/render-message-rule-trigger.mjs
@@ -6,7 +6,6 @@ const fields = foundry.data.fields;
 
 /**
  * @extends RuleTriggerDataModel
- * @property {String} identifier The id of an item to match.
  * @property {Boolean} local
  * @inheritDoc
  */
@@ -25,7 +24,6 @@ export class RenderMessageRuleTrigger extends RuleTriggerDataModel {
 
 	static defineSchema() {
 		const schema = Object.assign(super.defineSchema(), {
-			identifier: new fields.StringField(),
 			local: new fields.BooleanField({ initial: true }),
 		});
 		return schema;

--- a/module/documents/effects/triggers/render-message-rule-trigger.mjs
+++ b/module/documents/effects/triggers/render-message-rule-trigger.mjs
@@ -1,0 +1,63 @@
+import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
+import { RuleTriggerDataModel } from './rule-trigger-data-model.mjs';
+import { FUHooks } from '../../../hooks.mjs';
+
+const fields = foundry.data.fields;
+
+/**
+ * @extends RuleTriggerDataModel
+ * @property {String} identifier The id of an item to match.
+ * @property {Boolean} local
+ * @inheritDoc
+ */
+export class RenderMessageRuleTrigger extends RuleTriggerDataModel {
+	/** @inheritdoc */
+	static get metadata() {
+		return {
+			...super.metadata,
+			eventType: FUHooks.RENDER_MESSAGE_EVENT,
+		};
+	}
+
+	static {
+		Object.defineProperty(this, 'TYPE', { value: 'renderMessageRuleTrigger' });
+	}
+
+	static defineSchema() {
+		const schema = Object.assign(super.defineSchema(), {
+			identifier: new fields.StringField(),
+			local: new fields.BooleanField({ initial: true }),
+		});
+		return schema;
+	}
+
+	static get localization() {
+		return 'FU.RuleTriggerRenderMessage';
+	}
+
+	static get template() {
+		return systemTemplatePath('effects/triggers/render-message-rule-trigger');
+	}
+
+	/**
+	 * @param {RuleElementContext<RenderMessageEvent>} context
+	 * @returns {boolean}
+	 */
+	validateContext(context) {
+		if (this.local) {
+			switch (context.event.document.documentName) {
+				case 'ActiveEffect':
+					if (context.event.document.uuid !== context.effect.uuid) {
+						return false;
+					}
+					break;
+				case 'Item':
+					if (context.event.document.uuid !== context.item.uuid) {
+						return false;
+					}
+					break;
+			}
+		}
+		return true;
+	}
+}

--- a/module/helpers/section-chat-builder.mjs
+++ b/module/helpers/section-chat-builder.mjs
@@ -24,10 +24,21 @@ export class SectionChatBuilder {
 
 	constructor(actor, item) {
 		this.#actor = actor;
+		this.#item = item;
 		this.#flags = {};
 	}
 
+	/**
+	 * @returns {CheckRenderData}
+	 */
 	get sections() {
+		return this.#renderData;
+	}
+
+	/**
+	 * @returns {CheckRenderData}
+	 */
+	get renderData() {
 		return this.#renderData;
 	}
 

--- a/module/hooks.mjs
+++ b/module/hooks.mjs
@@ -145,6 +145,12 @@ export const FUHooks = {
 	 */
 	RENDER_CHECK_EVENT: 'projectfu.events.checks.render',
 	/**
+	 * @description Dispatched when a chat message is about to be rendered.
+	 * @example callback(event)
+	 * @remarks Uses {@link RenderMessageEvent}
+	 */
+	RENDER_MESSAGE_EVENT: 'projectfu.events.chat.render',
+	/**
 	 * @description Dispatched whenever there is a change in active wellsprings.
 	 * @remarks Uses {@link WellspringDataModel}
 	 */

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -242,6 +242,7 @@ async function onRenderCheckEvent(event) {
 	await evaluate(FUHooks.RENDER_CHECK_EVENT, event, event.source, event.targets, {
 		check: event.check,
 		config: event.config,
+		renderData: event.renderData,
 	});
 }
 
@@ -266,7 +267,9 @@ async function onEffectToggledEvent(event) {
  * @returns {Promise<void>}
  */
 async function onFeatureEvent(event) {
-	await evaluate(FUHooks.FEATURE_EVENT, event, event.source, []);
+	await evaluate(FUHooks.FEATURE_EVENT, event, event.source, [], {
+		renderData: event.builder.sections,
+	});
 }
 
 /**
@@ -327,7 +330,7 @@ async function evaluate(type, event, source, targets, data = undefined) {
 	const sceneCharacters = getSceneCharacters([source, ...targets]);
 	for (const character of sceneCharacters) {
 		for (const effect of character.actor.allEffects()) {
-			const disabled = effect.suppressed || effect.disabled;
+			const disabled = effect.isSuppressed || effect.disabled;
 			if (disabled || effect.system.rules.elements.size === 0) {
 				continue;
 			}

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -56,6 +56,7 @@ import { ItemRollRuleTrigger } from '../documents/effects/triggers/item-roll-rul
 import { CalculateExpenseRuleTrigger } from '../documents/effects/triggers/calculate-expense-rule-trigger.mjs';
 import { FeatureRuleTrigger } from '../documents/effects/triggers/feature-rule-trigger.mjs';
 import { FUItem } from '../documents/items/item.mjs';
+import { RenderMessageRuleTrigger } from '../documents/effects/triggers/render-message-rule-trigger.mjs';
 
 function register() {
 	RuleTriggerRegistry.instance.register(systemId, CombatEventRuleTrigger.TYPE, CombatEventRuleTrigger);
@@ -75,6 +76,7 @@ function register() {
 	RuleTriggerRegistry.instance.register(systemId, CreateConsumableRuleTrigger.TYPE, CreateConsumableRuleTrigger);
 	RuleTriggerRegistry.instance.register(systemId, ItemRollRuleTrigger.TYPE, ItemRollRuleTrigger);
 	RuleTriggerRegistry.instance.register(systemId, FeatureRuleTrigger.TYPE, FeatureRuleTrigger);
+	RuleTriggerRegistry.instance.register(systemId, RenderMessageRuleTrigger.TYPE, RenderMessageRuleTrigger);
 
 	RuleActionRegistry.instance.register(systemId, MessageRuleAction.TYPE, MessageRuleAction);
 	RuleActionRegistry.instance.register(systemId, ApplyDamageRuleAction.TYPE, ApplyDamageRuleAction);
@@ -247,6 +249,16 @@ async function onRenderCheckEvent(event) {
 }
 
 /**
+ * @param {RenderMessageEvent} event
+ * @returns {Promise<void>}
+ */
+async function onRenderMessageEvent(event) {
+	await evaluate(FUHooks.RENDER_MESSAGE_EVENT, event, event.source, [], {
+		renderData: event.renderData,
+	});
+}
+
+/**
  * @param {NotificationEvent} event
  * @returns {Promise<void>}
  */
@@ -390,6 +402,7 @@ function initialize() {
 	AsyncHooks.on(FUhooks.CONSUMABLE_CREATE_EVENT, onCreateConsumableEvent);
 	AsyncHooks.on(FUhooks.ITEM_ROLL_EVENT, onItemRoll);
 	AsyncHooks.on(FUhooks.FEATURE_EVENT, onFeatureEvent);
+	AsyncHooks.on(FUHooks.RENDER_MESSAGE_EVENT, onRenderMessageEvent);
 }
 
 export const RuleElements = Object.freeze({

--- a/templates/effects/triggers/render-message-rule-trigger.hbs
+++ b/templates/effects/triggers/render-message-rule-trigger.hbs
@@ -1,0 +1,4 @@
+<div class="fu-rule-element__property">
+	<span>{{localize 'FU.Local'}}</span>
+	{{formGroup trigger.schema.fields.local value=trigger.local name=(pfuConcat path ".local") }}
+</div>


### PR DESCRIPTION
This pull request introduces a new "Render Message" rule trigger system, allowing effects and rule elements to respond to chat message rendering events. It adds the `RenderMessageRuleTrigger` class, new event hooks, and integrates these into the rule element pipeline. Additionally, it refactors how chat messages are constructed and dispatched for active effects, and simplifies the `MessageRuleAction` logic. The changes are grouped below by theme.

**New Render Message Rule Trigger System:**

* Added `RenderMessageRuleTrigger` class, enabling rule elements to react to chat message rendering, with schema, validation, and template. [[1]](diffhunk://#diff-6597565853844be27a78edba25531e8224adfc73a90fd7534e30c8430480e023R1-R63) [[2]](diffhunk://#diff-95e4f42b968d55534ec44417d339a7d34280f0d8b828ea038dbfd338e8c448c9R1-R4)
* Registered the new trigger type in the rule element pipeline and added corresponding localization. [[1]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R59) [[2]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R79) [[3]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R1659)

**Event and Pipeline Updates:**

* Introduced `RENDER_MESSAGE_EVENT` to `FUHooks`, and added event emission and handling in `CommonEvents` and the rule element pipeline. [[1]](diffhunk://#diff-3cb8cae138cf1dd3d54eb69bc1a2f571ec70846b7915881b8c977e8901bb362eR147-R152) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R666-R691) [[3]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R804) [[4]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R247-R257) [[5]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R405)
* Updated `renderCheck` to call both `renderCheck` and new `renderMessage` events, allowing both triggers to be used as needed.

**Chat Message Construction and Active Effect Integration:**

* Refactored `ActiveEffectBehaviourMixin.sendToChat` to use `SectionChatBuilder`, `CommonSections`, and the new `renderMessage` event, improving message construction and extensibility. [[1]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735R9-R12) [[2]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735L260-R288)
* Enhanced `SectionChatBuilder` with new accessors for `renderData`, supporting the new message-building flow.

**Rule Element and Action Refactoring:**

* Simplified `MessageRuleAction` to use a unified context for message rendering, supporting both old and new event types. [[1]](diffhunk://#diff-bdfa4644499f292b4b5082e88dd58b921879a7f9369952b5236924a1c0bd1297L57-R60) [[2]](diffhunk://#diff-bdfa4644499f292b4b5082e88dd58b921879a7f9369952b5236924a1c0bd1297L86-L87)
* Updated `RuleElementContext` to include `messageBuilder` and `renderData` for better context handling in rule triggers and actions.

**Miscellaneous Improvements:**

* Fixed a bug in the rule element evaluation loop (using `isSuppressed` instead of `suppressed`).
* Minor schema and logic adjustments to existing triggers for consistency. [[1]](diffhunk://#diff-7eadcd861d589e27c7920389cd034d54b6f686f77f910d867962b207f97676c6R12) [[2]](diffhunk://#diff-7eadcd861d589e27c7920389cd034d54b6f686f77f910d867962b207f97676c6L70-L85)
* Added a `disabled` property to `FUActiveEffect` documentation.