### PR TITLE
Add defense targeting option for spells

### DIFF
--- a/module/checks/magic-check.mjs
+++ b/module/checks/magic-check.mjs
@@ -41,7 +41,6 @@ const onProcessCheck = (check, actor, item, registerCallback) => {
 	const { type, critical, fumble } = check;
 	if (type === 'magic') {
 		const config = CheckConfiguration.configure(check);
-		config.setTargetedDefense('mdef');
 		// TODO: Refactor alongside accuracy-checks
 		if (critical) {
 			config.addTraits('critical');

--- a/module/documents/items/spell/spell-data-model.mjs
+++ b/module/documents/items/spell/spell-data-model.mjs
@@ -59,7 +59,7 @@ Hooks.on(CheckHooks.renderCheck, onRenderCheck);
  * @property {UseWeaponDataModel} useWeapon
  * @property {ItemAttributesDataModel} attributes
  * @property {number} accuracy.value
- //* @property {DamageDataModel} damage
+ * @property {Defense} defense
  * @property {EffectApplicationDataModel} effects
  * @property {ResourceDataModel} resource
  * @property {ImprovisedDamageDataModel} impdamage
@@ -89,7 +89,7 @@ export class SpellDataModel extends FUStandardItemDataModel {
 			useWeapon: new EmbeddedDataField(UseWeaponDataModel, {}),
 			attributes: new EmbeddedDataField(ItemAttributesDataModel, { initial: { primary: { value: 'ins' }, secondary: { value: 'mig' } } }),
 			accuracy: new SchemaField({ value: new NumberField({ initial: 0, integer: true, nullable: false }) }),
-			// damage: new EmbeddedDataField(DamageDataModel, {}),
+			defense: new StringField({ initial: 'mdef', choices: Object.keys(FU.defenses), blank: true }),
 			resource: new EmbeddedDataField(ResourceDataModel, {}),
 			effects: new EmbeddedDataField(EffectApplicationDataModel, {}),
 			impdamage: new EmbeddedDataField(ImprovisedDamageDataModel, {}),
@@ -193,7 +193,7 @@ export class SpellDataModel extends FUStandardItemDataModel {
 			});
 
 			this.#addSpellDamage(config, actor, spell, context);
-			config.setTargetedDefense('mdef');
+			config.setTargetedDefense(this.defense);
 		};
 	}
 

--- a/templates/item/partials/item-accuracy-section-legacy.hbs
+++ b/templates/item/partials/item-accuracy-section-legacy.hbs
@@ -5,7 +5,7 @@
 			 'FU.Accuracy'}}</label>
 		</legend>
 
-		<div class="grid grid-3col">
+		<div class="grid grid-4col">
 			<div class="resource-content flexcol flex-group-center">
 				<label for="system.rollInfo.attributes.primary.value" class="resource-label-m">{{localize
 				 'FU.Primary'}}
@@ -26,6 +26,14 @@
 									localize=true}}
 				</select>
 			</div>
+			<label class="resource-label-m resource-content flexcol flex-group-center">
+				{{localize 'FU.Defense'}}
+				<div class="resource-content flexrow flex-group-center">
+					<select name="system.defense" class="resource-inputs resource-text-sm">
+						{{selectOptions defenses selected=system.defense localize=true labelAttr="abbr"}}
+					</select>
+				</div>
+			</label>
 			<div class="resource-content flexcol flex-group-center">
 				<label class="resource-label-m">{{localize 'FU.Bonus'}}</label>
 				<input type="number" name="system.rollInfo.accuracy.value"


### PR DESCRIPTION
This pull request updates the spell data model and user interface to support configurable defenses for spells, rather than always using magic defense (`mdef`). The main changes include introducing a new `defense` field in the spell data model, updating the UI to allow users to select a defense type, and ensuring that spell checks use the selected defense.

**Spell Defense Configuration**

* Added a new `defense` field to the `SpellDataModel`, allowing spells to specify which defense stat they target, with choices populated from `FU.defenses`.
* Updated the spell check logic to use the selected `defense` from the spell data model, instead of always defaulting to `mdef`. [[1]](diffhunk://#diff-45f5f6438b97c6017910d48d2e984222d6582b29d35606f27f3ce2ee8b297654L196-R196) [[2]](diffhunk://#diff-a24a65b13ca3debb615e61d8e99aff910d272322ee740e2ce8027d093a7312b6L44)

**User Interface Enhancements**

* Modified the spell item accuracy section UI to display a dropdown for selecting the defense stat, expanding the grid layout to accommodate the new selector. [[1]](diffhunk://#diff-3bfd963360e98ba147bdbb8b2b1e2a85086fff851f818f8052fe248eecf21724L8-R8) [[2]](diffhunk://#diff-3bfd963360e98ba147bdbb8b2b1e2a85086fff851f818f8052fe248eecf21724R29-R36)

**Documentation Updates**

* Updated property documentation for spells to reflect the new `defense` field.