### PR TITLE
Improve clear effect procedure

### DIFF
--- a/module/documents/effects/active-effect-model.mjs
+++ b/module/documents/effects/active-effect-model.mjs
@@ -4,10 +4,10 @@ import { RuleElementDataModel } from './rule-element-data-model.mjs';
 import { SubDocumentCollectionField } from '../sub/sub-document-collection-field.mjs';
 
 /**
- * @description THe active effect model for this system
+ * @description The active effect model for this system.
  * @property {String} type The type of the effect
  * @property {ActiveEffectPredicateModel} predicate Used for toggling the effect
- * @property {String} duration.event The combat event which decrements the duration. Once it reaches 0, the effect is over.
+ * @property {FUEffectDuration} duration.event The combat event which decrements the duration. Once it reaches 0, the effect is over.
  * @property {Number} duration.interval The number of occurrences between events
  * @property {Number} duration.remaining The number of intervals left.
  * @property {String} tracking Whom is the duration tracked on

--- a/module/documents/effects/active-effect.mjs
+++ b/module/documents/effects/active-effect.mjs
@@ -39,6 +39,7 @@ import { CommonEvents } from '../../checks/common-events.mjs';
  * @extends ActiveEffect
  * @property {FUActiveEffectModel} system
  * @property {InlineSourceInfo} source
+ * @property {Set<String>} statuses
  * @property {Boolean} disabled Serialized with the document.
  * @inheritDoc
  * */

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -620,9 +620,9 @@ FU.duration = {
 	special: 'FU.Special',
 };
 
-// /**
-//  * @typedef {'startOfCombat' | 'startOfTurn' | 'endOfTurn' | 'endOfRound' | 'endOfCombat'} FUCombatEventType
-//  */
+/**
+ * @typedef {'startOfCombat' | 'startOfTurn' | 'endOfTurn' | 'endOfRound' | 'endOfCombat'} FUCombatEventType
+ */
 
 /**
  * @description Events dispatched during conflict scenes
@@ -634,6 +634,10 @@ FU.combatEvent = {
 	endOfRound: 'FU.EndOfRound',
 	endOfCombat: `FU.EndOfCombat`,
 };
+
+/**
+ * @typedef {'none' | 'startOfTurn' | 'endOfTurn' | 'endOfRound' | 'endOfScene' | 'rest'} FUEffectDuration
+ */
 
 /**
  * @description Active effect durations

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -649,7 +649,9 @@ async function promptExpiredEffectRemoval(event) {
 
 	if (game.settings.get(SYSTEM, SETTINGS.optionAutomationRemoveExpiredEffects)) {
 		event.actors.forEach((actor) => {
-			actor.clearTemporaryEffects(false, false);
+			actor.clearTemporaryEffects({
+				duration: true,
+			});
 		});
 		return;
 	}
@@ -793,9 +795,9 @@ async function getClearAction(id, sourceInfo) {
 			name = StringUtils.localize(effectData.name);
 		}
 	}
-	// Clear all effects
+	// Clear status effects
 	else {
-		name = `${StringUtils.localize('FU.All')} ${StringUtils.localize('FU.Effects')}`;
+		name = `${StringUtils.localize('FU.All')} ${StringUtils.localize('FU.StatusEffect')}`;
 		icon = 'ra ra-biohazard';
 	}
 
@@ -891,7 +893,9 @@ function onRenderChatMessage(message, element) {
 					effect.delete();
 				}
 			} else {
-				actor.clearTemporaryEffects();
+				actor.clearTemporaryEffects({
+					status: true,
+				});
 			}
 		});
 	});
@@ -937,7 +941,9 @@ async function onCombatEvent(event) {
  */
 async function onRestEvent(event) {
 	// Remove statuses and other effects that last until rest
-	event.actor.clearTemporaryEffects(true, false);
+	event.actor.clearTemporaryEffects({
+		duration: true,
+	});
 }
 
 const BOONS_AND_BANES = Object.freeze(

--- a/styles/css/chat/chat-optional-features.css
+++ b/styles/css/chat/chat-optional-features.css
@@ -50,7 +50,7 @@
 }
 
 .fu-chat__clear-effect {
-	border: 2px solid #b00000;
+	border: 1px solid #b00000;
 	box-shadow: inset 0 0 0 1px rgba(255, 200, 200, 0.4);
 	background-color: #ff5a5a;
 	text-shadow:


### PR DESCRIPTION
This pull request refactors how temporary effects are cleared from actors, introducing a more flexible options-based approach to filtering which effects are removed. It also improves type definitions, updates documentation, and tweaks some UI styling. The main focus is on making effect removal more explicit and maintainable, especially regarding statuses and durations.

**Effect Removal Logic and API Improvements:**

* Refactored `FUActor.clearTemporaryEffects` to accept an `options` object (`ClearEffectOptions`) instead of positional parameters, allowing more granular control over which effects are cleared (e.g., by status or duration). Updated all usages to the new API. [[1]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420R400-R451) [[2]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420L423-R461) [[3]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL652-R654) [[4]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL894-R898) [[5]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL940-R946)
* Updated the documentation and type annotations for effect removal and active effect models to use new and more accurate types (`FUEffectDuration`, `FUCombatEventType`). [[1]](diffhunk://#diff-1617c9e3f869d139e205fc2d502f0d7b3c27f58087a82c44ab956c4f1ec9b6b2L7-R10) [[2]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5L623-R625) [[3]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5R638-R641)

**Status and Duration Handling:**

* Improved logic in `clearTemporaryEffects` to better distinguish between status effects and duration-based effects, using the new options pattern for clarity and future extensibility. [[1]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420R400-R451) [[2]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420L423-R461)

**User Interface:**

* Changed the border thickness of `.fu-chat__clear-effect` from 2px to 1px for a subtler appearance in the chat UI.