### PR TITLE
Encode more trait information for trait rule predicate

### DIFF
--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -2,7 +2,7 @@ import { SYSTEM } from '../helpers/config.mjs';
 import { SETTINGS } from '../settings.js';
 import { Flags } from '../helpers/flags.mjs';
 import { StringUtils } from '../helpers/string-utils.mjs';
-import { Traits } from '../pipelines/traits.mjs';
+import { ActionTraits, Traits } from '../pipelines/traits.mjs';
 import { CheckHooks } from './check-hooks.mjs';
 import { PlayerListEnhancements } from '../helpers/player-list-enhancements.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
@@ -308,12 +308,35 @@ export class CheckConfigurer extends CheckInspector {
 	}
 
 	/**
+	 * @desc Sets a resource gain/loss action.
 	 * @param {FUResourceType} type
-	 * @param {Number} amount
+	 * @param {Number|String} amount
 	 * @return {CheckConfigurer}
 	 */
 	setResource(type, amount) {
 		this.check.additionalData[RESOURCE] = UpdateResourceData.construct(type, amount);
+		// TODO: Encode this trait data elsewhere?
+		switch (type) {
+			case 'hp':
+				this.addTraits(ActionTraits.HitPoint);
+				break;
+			case 'mp':
+				this.addTraits(ActionTraits.MindPoint);
+				break;
+		}
+		if (Number.isInteger(amount)) {
+			if (amount >= 0) {
+				this.addTraits(ActionTraits.Gain);
+			} else {
+				this.addTraits(ActionTraits.Loss);
+			}
+		} else if (typeof amount === 'string') {
+			if (amount.startsWith('-')) {
+				this.addTraits(ActionTraits.Loss);
+			} else {
+				this.addTraits(ActionTraits.Gain);
+			}
+		}
 		return this;
 	}
 

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -1,4 +1,4 @@
-import { CHECK_FLAVOR, CHECK_RESULT, CHECK_ROLL } from './default-section-order.mjs';
+import { CHECK_DETAILS, CHECK_FLAVOR, CHECK_RESULT, CHECK_ROLL } from './default-section-order.mjs';
 import { FUActor } from '../documents/actors/actor.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
 import { ResourcePipeline, ResourceRequest } from '../pipelines/resource-pipeline.mjs';
@@ -25,7 +25,7 @@ import { ChatAction } from '../helpers/chat-action.mjs';
  * @param {number} [order]
  * @param {Boolean} open Defaults to true
  */
-const description = (sections, description, summary, order, open = true) => {
+const description = (sections, description, summary, order = CHECK_DETAILS, open = true) => {
 	if (summary || description) {
 		sections.push(async () => ({
 			partial: 'systems/projectfu/templates/chat/partials/chat-item-description.hbs',
@@ -178,7 +178,7 @@ const clock = (sections, clock, order) => {
  * @param {Tag[]} tags
  * @param {number} [order]
  */
-const tags = (sections, tags = [], order) => {
+const tags = (sections, tags = [], order = CHECK_DETAILS) => {
 	tags = tags.filter((tag) => !('show' in tag) || tag.show);
 	if (tags.length > 0) {
 		sections.push(async () => ({
@@ -353,6 +353,8 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 				}
 				const request = new ResourceRequest(sourceInfo, targets, resourceData.type, ra);
 				actions.push(ResourcePipeline.getTargetedAction(request));
+
+				// Trait data
 			}
 
 			const effectData = inspector.getEffects();

--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -6,6 +6,7 @@ import { Flags } from '../../../helpers/flags.mjs';
 import { Pipeline } from '../../../pipelines/pipeline.mjs';
 import { CHECK_ADDENDUM_ORDER } from '../../../checks/default-section-order.mjs';
 import { StringUtils } from '../../../helpers/string-utils.mjs';
+import { InlineSourceInfo } from '../../../helpers/inline-helper.mjs';
 
 const { StringField } = foundry.data.fields;
 
@@ -46,7 +47,13 @@ export class MessageRuleAction extends RuleActionDataModel {
 
 	async execute(context, selected) {
 		// Flag information
-		let flags = Pipeline.initializedFlags(Flags.ChatMessage.Source, context.sourceInfo);
+		let sourceInfo;
+		if (context.item) {
+			sourceInfo = new InlineSourceInfo(context.item.name, context.source.actor.uuid, context.item.uuid);
+		} else {
+			sourceInfo = context.sourceInfo;
+		}
+		let flags = Pipeline.initializedFlags(Flags.ChatMessage.Source, sourceInfo);
 		flags = Pipeline.setFlag(flags, Flags.ChatMessage.Item, context.item.uuid);
 		if (context.check) {
 			flags = Pipeline.setFlag(flags, Flags.ChatMessage.CheckV2, context.check);

--- a/module/documents/items/common/traits-predicate-data-model.mjs
+++ b/module/documents/items/common/traits-predicate-data-model.mjs
@@ -21,43 +21,30 @@ export class TraitsPredicateDataModel extends TraitsDataModel {
 	}
 
 	/**
-	 * @param {Iterable<String>} traits
+	 * @param {Iterable<string>} traits
 	 */
 	evaluate(traits) {
-		// If no traits were set
-		if (this.empty) {
-			return true;
-		}
-		// If the traits were not defined but expected
-		if (!traits) {
-			return false;
-		}
+		// No constraints → always valid
+		if (this.empty) return true;
+
+		// Constraints exist but nothing to evaluate against
+		if (!traits) return false;
+
+		const traitSet = new Set(traits);
+		const values = this.values;
 
 		switch (this.quantifier) {
 			case 'any':
-				for (const t of traits) {
-					if (this.has(t)) {
-						return true;
-					}
-				}
-				return false;
+				return values.some((t) => traitSet.has(t));
 
 			case 'all':
-				for (const t of traits) {
-					if (!this.has(t)) {
-						return false;
-					}
-				}
-				break;
+				return values.every((t) => traitSet.has(t));
 
 			case 'none':
-				for (const t of traits) {
-					if (this.has(t)) {
-						return false;
-					}
-				}
-				break;
+				return values.every((t) => !traitSet.has(t));
+
+			default:
+				return false;
 		}
-		return true;
 	}
 }

--- a/module/helpers/chat-action.mjs
+++ b/module/helpers/chat-action.mjs
@@ -15,6 +15,7 @@ import FoundryUtils from './foundry-utils.mjs';
  * @property {String} classes
  * @property {String} style
  * @property {String} color
+ * @property {String[]} traits Traits for this action.
  * @property {Boolean} targeted Whether this action can be used on targeted tokens (during the chat message generation)
  * @property {Boolean} selected Whether this action can be used on selected tokens instead.
  * @remarks Expects an action handler where dataset.id is a reference to an actor
@@ -134,6 +135,15 @@ export class ChatAction {
 	 */
 	withImage(img) {
 		this.img = img;
+		return this;
+	}
+
+	/**
+	 * @param {String[]} traits
+	 * @returns {ChatAction}
+	 */
+	withTraits(traits) {
+		this.traits = traits;
 		return this;
 	}
 

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -761,6 +761,7 @@ function getTargetedAction(damageData, sourceInfo, traits) {
 		.setFlag(Flags.ChatMessage.Damage)
 		.withSelected()
 		.withLabel('FU.ChatApplyDamage')
+		.withTraits(traits)
 		.requiresOwner();
 }
 

--- a/module/pipelines/resource-pipeline.mjs
+++ b/module/pipelines/resource-pipeline.mjs
@@ -430,6 +430,7 @@ function getTargetedAction(request) {
 		amount: request.amount,
 		resource: StringUtils.localize(FU.resources[request.resourceType]),
 	});
+
 	return new ChatAction('updateResource', resourceIcon, tooltip, {
 		amount: request.amount,
 		type: request.resourceType,
@@ -439,6 +440,7 @@ function getTargetedAction(request) {
 		.setFlag(request.gain ? Flags.ChatMessage.ResourceGain : Flags.ChatMessage.ResourceLoss)
 		.withLabel(tooltip)
 		.withColor(request.gain ? 'var(--color-hp)' : 'var(--color-hp-crisis)')
+		.withTraits(request.traits)
 		.withSelected();
 }
 

--- a/module/pipelines/traits.mjs
+++ b/module/pipelines/traits.mjs
@@ -2,6 +2,20 @@ import { StringUtils } from '../helpers/string-utils.mjs';
 // NOTE: This should not have no further dependencies!
 
 /**
+ * @description A list of common traits.
+ * @remarks Automatically converted to kebab case.
+ * @remarks These are generally used by items and inline actions.
+ */
+export const ActionTraits = Object.freeze({
+	Damage: 'damage',
+	Restore: 'restore',
+	Gain: 'gain',
+	Loss: 'loss',
+	HitPoint: 'hit-point',
+	MindPoint: 'mind-point',
+});
+
+/**
  * @description A list of traits supported by items
  * @remarks Automatically converted to kebab case.
  * @remarks These are generally used by items and inline actions.
@@ -11,8 +25,7 @@ export const ConsumableTraits = Object.freeze({
 	ElementalShard: 'elemental-shard',
 	Magisphere: 'magisphere',
 	Infusion: 'infusion',
-	Damage: 'damage',
-	Restore: 'restore',
+	...ActionTraits,
 });
 
 /**

--- a/src/packs/skills/skill_Cognitive_Focus_idQdS82bEICiB0zL.json
+++ b/src/packs/skills/skill_Cognitive_Focus_idQdS82bEICiB0zL.json
@@ -114,7 +114,12 @@
       "value": false
     },
     "defense": "def",
-    "fuid": "cognitive-focus"
+    "fuid": "cognitive-focus",
+    "effects": {
+      "entries": [
+        "focus"
+      ]
+    }
   },
   "effects": [
     {
@@ -172,24 +177,37 @@
               "type": "ruleElement",
               "_id": "A7MrxrxfDKnAqbnm",
               "trigger": {
-                "_id": "u6AjRktMwCaJfd13",
-                "type": "calculateResourceRuleTrigger",
+                "_id": "f4pz9aSChgNSBYI5",
+                "type": "renderCheckRuleTrigger",
                 "eventRelation": "source",
-                "resource": "hp",
-                "change": "increment"
+                "checkTypes": [],
+                "itemGroups": [],
+                "local": false,
+                "identifier": ""
               },
               "predicates": {
                 "mjxbVDAi3pjY51Tc": {
                   "type": "targetEffectRulePredicate",
                   "_id": "mjxbVDAi3pjY51Tc",
                   "effect": "focus"
+                },
+                "0zURdqfxPfCjRhSi": {
+                  "type": "traitsRulePredicate",
+                  "_id": "0zURdqfxPfCjRhSi",
+                  "traits": {
+                    "entries": [
+                      "gain",
+                      "hit-point"
+                    ],
+                    "quantifier": "all"
+                  }
                 }
               },
               "actions": {
-                "5GTWgNn2AhVEqwVK": {
-                  "type": "modifyResourceRuleAction",
-                  "_id": "5GTWgNn2AhVEqwVK",
-                  "amount": "$sl*2"
+                "mYbH78f8MSjL2Gzo": {
+                  "type": "messageRuleAction",
+                  "_id": "mYbH78f8MSjL2Gzo",
+                  "message": "<p>Your focus recovers an additional @GAIN[&sl('cognitive-focus')*2 hp].</p>"
                 }
               }
             },
@@ -197,17 +215,19 @@
               "type": "ruleElement",
               "_id": "R1OHDd7sJEu9967V",
               "trigger": {
-                "_id": "6Na9slMQvWaVF0CZ",
-                "type": "calculateResourceRuleTrigger",
+                "_id": "1Mc0Ko9kFW543UK0",
+                "type": "renderCheckRuleTrigger",
                 "eventRelation": "source",
-                "resource": "mp",
-                "change": "increment"
+                "checkTypes": [],
+                "itemGroups": [],
+                "local": false,
+                "identifier": ""
               },
               "actions": {
-                "kOP4dT13ZRPGlyGO": {
-                  "type": "modifyResourceRuleAction",
-                  "_id": "kOP4dT13ZRPGlyGO",
-                  "amount": "$sl*2"
+                "gL2C8YwZzHTmV4Ob": {
+                  "type": "messageRuleAction",
+                  "_id": "gL2C8YwZzHTmV4Ob",
+                  "message": "<p>Your focus recovers an additional @GAIN[&sl('cognitive-focus')*2 mp].</p>"
                 }
               },
               "predicates": {
@@ -215,6 +235,16 @@
                   "type": "targetEffectRulePredicate",
                   "_id": "2hVcpxTfAMd4x1op",
                   "effect": "focus"
+                },
+                "ZjlRUGVlgWRJLf8n": {
+                  "type": "traitsRulePredicate",
+                  "_id": "ZjlRUGVlgWRJLf8n",
+                  "traits": {
+                    "entries": [
+                      "gain",
+                      "mind-point"
+                    ]
+                  }
                 }
               }
             },
@@ -265,11 +295,11 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1767260254243,
-        "modifiedTime": 1767287979950,
+        "modifiedTime": 1770244894248,
         "lastModifiedBy": "J5B4HfVqUaCPvzGg"
       },
       "_key": "!items.effects!idQdS82bEICiB0zL.3vHmCpjussdJcEgM"
@@ -290,9 +320,9 @@
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "coreVersion": "13.348",
+    "coreVersion": "13.351",
     "createdTime": 1711424945464,
-    "modifiedTime": 1767265983679,
+    "modifiedTime": 1770237282989,
     "lastModifiedBy": "J5B4HfVqUaCPvzGg",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/templates/common/traits.hbs
+++ b/templates/common/traits.hbs
@@ -1,8 +1,10 @@
 {{#if model.quantifier}}
 	<div class="fu-rule-element__group">
-		<label class="fu-rule-element__group__header flex-group-center">
-			<i class="ra ra-aries"></i>{{localize 'FU.Traits'}}
-		</label>
+		{{#if showLabel}}
+			<label class="fu-rule-element__group__header flex-group-center">
+				<i class="ra ra-aries"></i>{{localize 'FU.Traits'}}
+			</label>
+		{{/if}}
 		<div class="fu-traits fu-rule-element__property">
 			{{#if showLabel}}
 				<span>{{localize 'FU.Traits'}}</span>

--- a/templates/effects/predicates/traits-rule-predicate.hbs
+++ b/templates/effects/predicates/traits-rule-predicate.hbs
@@ -1,1 +1,1 @@
-{{pfuTraits predicate.traits (pfuConcat path ".traits")}}
+{{pfuTraits predicate.traits (pfuConcat path ".traits") showLabel=false}}


### PR DESCRIPTION
This pull request introduces a more robust and consistent handling of traits throughout resource actions, predicates, and chat actions, improving the system's ability to track and evaluate trait-based effects. The changes also update the Cognitive Focus skill to use trait-based predicates and messaging for resource recovery, aligning it with the new trait system.

**Trait System Enhancements**

* Added a new `ActionTraits` object in `traits.mjs` to centralize common action traits (e.g., `damage`, `gain`, `loss`, `hit-point`, `mind-point`), and updated `ConsumableTraits` to include these traits for consistency. [[1]](diffhunk://#diff-c7ba096b3ea846ecd41a7b1f28bbfe881b50852688505bc3cad550dfc1405297R4-R17) [[2]](diffhunk://#diff-c7ba096b3ea846ecd41a7b1f28bbfe881b50852688505bc3cad550dfc1405297L14-R28)
* Updated `CheckConfigurer.setResource` to automatically add relevant traits (`Gain`, `Loss`, `HitPoint`, `MindPoint`) to checks based on resource type and amount, ensuring trait data is encoded for resource actions.

**Predicate and Evaluation Improvements**

* Refactored `TraitsPredicateDataModel.evaluate` to use a set-based approach for trait evaluation, improving performance and correctness for `any`, `all`, and `none` quantifiers.
* Improved `TraitsRulePredicate.validateContext` to consistently gather traits from consumables, check configs, and item system traits, always using a set for evaluation.

**Resource and Chat Action Trait Integration**

* Extended `ChatAction` and resource/damage pipelines to support trait arrays, allowing actions to carry trait metadata for downstream processing and UI. [[1]](diffhunk://#diff-efd7d445d98d0eb05af7e82ab7f0a9ce67a96b1943d2e5fa080921b0eb374c88R18) [[2]](diffhunk://#diff-efd7d445d98d0eb05af7e82ab7f0a9ce67a96b1943d2e5fa080921b0eb374c88R141-R149) [[3]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bR764) [[4]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8R443)

**Cognitive Focus Skill Update**

* Updated the Cognitive Focus skill to use trait-based predicates and messaging, replacing direct resource modification triggers with `renderCheckRuleTrigger` and trait-based checks (`gain`, `hit-point`, `mind-point`). [[1]](diffhunk://#diff-9cef53bc2f9189b665cce92e9ff513080bb60f7dd7f2d65c94ea6b6696caa02eL117-R122) [[2]](diffhunk://#diff-9cef53bc2f9189b665cce92e9ff513080bb60f7dd7f2d65c94ea6b6696caa02eL175-R247)

**UI and Template Adjustments**

* Modified trait display templates to allow optional label rendering for improved UI flexibility. [[1]](diffhunk://#diff-b9c893ea6cfda35b17b1fb6050d8f424f2557fe45147fd7cb97045d3cabe18c5R3-R7) [[2]](diffhunk://#diff-7d4d176e0c0a009ec990740092b196fc4cb5517c169332d5112c6234e74176beL1-R1)

These changes together make trait handling more explicit and reliable across the codebase, laying the groundwork for more advanced trait-driven mechanics and UI features.