### PR TITLE
Update the weapon rule predicate

### DIFF
--- a/module/checks/check-configuration.mjs
+++ b/module/checks/check-configuration.mjs
@@ -458,7 +458,7 @@ export class CheckConfigurer extends CheckInspector {
 	/**
 	 * @param {FUItem} weapon An item that is of the weapon type.
 	 */
-	setWeapon(weapon) {
+	setWeaponReference(weapon) {
 		this.check.additionalData[WEAPON_USED] = weapon.uuid;
 	}
 

--- a/module/documents/effects/predicates/weapon-rule-predicate.mjs
+++ b/module/documents/effects/predicates/weapon-rule-predicate.mjs
@@ -70,9 +70,19 @@ export class WeaponRulePredicate extends RulePredicateDataModel {
 			case FUHooks.RESOLVE_CHECK_EVENT:
 			case FUHooks.RENDER_CHECK_EVENT:
 				{
+					// Try to resolve the weapon used
 					if (character.actor === context.event.source.actor) {
-						/** @type FUItem **/
-						attackItem = context.event.item;
+						const weaponReference = context.config.getWeaponReference();
+						if (weaponReference) {
+							attackItem = fromUuidSync(weaponReference);
+						} else {
+							/** @type FUItemGroup **/
+							const itemGroup = context.event.itemGroup;
+							switch (itemGroup) {
+								case 'attack':
+									attackItem = context.event.item;
+							}
+						}
 					}
 				}
 				break;
@@ -95,6 +105,7 @@ export class WeaponRulePredicate extends RulePredicateDataModel {
 			return false;
 		}
 
+		// If it's a PC weapon
 		if (attackItem.system instanceof WeaponDataModel || attackItem instanceof CustomWeaponDataModel) {
 			/** @type {WeaponDataModel|CustomWeaponDataModel} **/
 			const weaponData = attackItem.system;
@@ -112,13 +123,16 @@ export class WeaponRulePredicate extends RulePredicateDataModel {
 			if (this.martial && this.martial !== weaponData.isMartial.value) {
 				return false;
 			}
-		} else if (attackItem.system instanceof BasicItemDataModel) {
+		}
+		// If it's an NPC attack
+		else if (attackItem.system instanceof BasicItemDataModel) {
 			/** @type {BasicItemDataModel} **/
 			const attackData = attackItem.system;
 			if (this.weaponType && this.weaponType !== attackData.type.value) {
 				return false;
 			}
 		}
+
 		return true;
 	}
 }

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -202,7 +202,7 @@ export class MiscAbilityDataModel extends BaseSkillDataModel {
 		return async (check, actor, item) => {
 			const config = CheckConfiguration.configure(check);
 			await this.configureAttributeCheck(config, actor, item);
-			config.setWeapon(this.parent);
+			config.setWeaponReference(this.parent);
 		};
 	}
 
@@ -232,7 +232,7 @@ export class MiscAbilityDataModel extends BaseSkillDataModel {
 			const config = CheckConfiguration.configure(check);
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
-			config.setWeapon(weapon);
+			config.setWeaponReference(weapon);
 			this.configureCheck(config);
 			await this.addSkillDamage(config, item, context);
 

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -112,7 +112,7 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 		if (this.damage.hasDamage) {
 			if (this.useWeapon.damage) {
 				const weapon = await this.getWeapon(actor);
-				config.setWeapon(weapon);
+				config.setWeaponReference(weapon);
 				/** @type WeaponDataModel **/
 				const weaponData = weapon.system;
 				config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);

--- a/module/documents/items/skill/choose-weapon-dialog.mjs
+++ b/module/documents/items/skill/choose-weapon-dialog.mjs
@@ -1,6 +1,7 @@
 import { FU } from '../../../helpers/config.mjs';
 import { CharacterDataModel } from '../../actors/character/character-data-model.mjs';
 import { NpcDataModel } from '../../actors/npc/npc-data-model.mjs';
+import FoundryUtils from '../../../helpers/foundry-utils.mjs';
 
 /**
  * @param {FUActor} actor
@@ -60,22 +61,13 @@ async function prompt(actor, includeWeaponModules = false) {
 		return equippedWeapons[0];
 	}
 
+	const title = game.i18n.localize('FU.ChooseWeaponDialogTitle');
 	const data = {
 		equippedWeapons,
 		FU,
 	};
-
-	const content = await foundry.applications.handlebars.renderTemplate('/systems/projectfu/templates/dialog/dialog-choose-weapon.hbs', data);
-
-	const { selected } = await foundry.applications.api.DialogV2.input({
-		window: { title: game.i18n.localize('FU.ChooseWeaponDialogTitle') },
-		label: game.i18n.localize('FU.Submit'),
-		rejectClose: false,
-		content: content,
-		ok: {
-			label: 'FU.Confirm',
-		},
-	});
+	const content = await FoundryUtils.renderTemplate('dialog/dialog-choose-weapon', data);
+	const { selected } = await FoundryUtils.input(title, content);
 
 	if (selected) {
 		return actor.items.get(selected) ?? null;

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -229,7 +229,7 @@ export class SkillDataModel extends BaseSkillDataModel {
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
 
-			config.setWeapon(weapon);
+			config.setWeaponReference(weapon);
 			config.setHrZero(this.damage.hrZero || modifiers.shift);
 			this.configureCheck(config);
 			await this.addSkillDamage(config, item, context);

--- a/module/documents/items/spell/spell-data-model.mjs
+++ b/module/documents/items/spell/spell-data-model.mjs
@@ -175,6 +175,7 @@ export class SpellDataModel extends FUStandardItemDataModel {
 					check.secondary = weaponAttributes.secondary;
 					attributeOverride = true;
 					config.addWeaponAccuracy(weapon);
+					config.setWeaponReference(weapon);
 				}
 			}
 

--- a/module/ui/features/item-selection-dialog.mjs
+++ b/module/ui/features/item-selection-dialog.mjs
@@ -46,7 +46,7 @@ export class ItemSelectionDialog {
 	}
 
 	/**
-	 * @returns {Object[]} selected
+	 * @returns {Promise<Object[]>} selected
 	 */
 	async open() {
 		// We cache the item descriptions here...

--- a/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
+++ b/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
@@ -147,7 +147,45 @@
           "tracking": "self",
           "remaining": 1
         },
-        "stack": 1
+        "stack": 1,
+        "rules": {
+          "elements": {
+            "n51WK4vf6h7Pn9Rt": {
+              "type": "ruleElement",
+              "_id": "n51WK4vf6h7Pn9Rt",
+              "trigger": {
+                "_id": "NkUGhN3O6wegQ14w",
+                "type": "performCheckRuleTrigger",
+                "eventRelation": "source",
+                "checkTypes": [
+                  "magic"
+                ]
+              },
+              "predicates": {
+                "YAHJUD5SD1ClxolQ": {
+                  "type": "checkRulePredicate",
+                  "_id": "YAHJUD5SD1ClxolQ",
+                  "result": null
+                }
+              },
+              "actions": {
+                "OVdMuTH6qx98kFEi": {
+                  "type": "modifyCheckRuleAction",
+                  "_id": "OVdMuTH6qx98kFEi",
+                  "bonus": "$sl"
+                }
+              }
+            }
+          },
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "basic"
+          }
+        }
       },
       "changes": [
         {
@@ -167,12 +205,12 @@
       "_stats": {
         "compendiumSource": null,
         "duplicateSource": null,
-        "coreVersion": "13.346",
+        "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1743535722306,
-        "modifiedTime": 1743537376516,
-        "lastModifiedBy": "JXPd932s9DHQRD0w",
+        "modifiedTime": 1770314520387,
+        "lastModifiedBy": "J5B4HfVqUaCPvzGg",
         "exportSource": null
       },
       "_key": "!items.effects!v6rTedHMjbLuLdN3.DhBhEANF8jRMaBo4"

--- a/templates/dialog/dialog-choose-weapon.hbs
+++ b/templates/dialog/dialog-choose-weapon.hbs
@@ -1,9 +1,10 @@
-<div>
+<main class="background">
     {{#each equippedWeapons}}
         <div>
 			<label class="flexrow">
             	<input type="radio" name="selected" value="{{id}}" class="flex0">
-				<span class="flexcol">
+				<span class="flexrow flex-group-left">
+					{{pfuItemAnchor this}}
                     <strong>{{name}}</strong>
 					{{#if (eq type 'weapon')}}
 						<span>
@@ -36,4 +37,4 @@
 			</label>
         </div>
     {{/each}}
-</div>
+</main>


### PR DESCRIPTION
This pull request refactors how weapon references are set and retrieved during checks, standardizing the method name to `setWeaponReference` across the codebase. It also updates the weapon selection dialog to use utility helpers for rendering and input, and enhances the Spellblade skill with new rule elements. Minor improvements to UI and documentation are included.

**Weapon Reference Handling:**
- Renamed the `setWeapon` method to `setWeaponReference` in `CheckConfigurer` and updated all usages to improve clarity and consistency when storing weapon references by UUID. [[1]](diffhunk://#diff-a9e8cf5c6eb9e1df14abbbef3f093c1c7fc0df669748dcf3694767a635d9b14bL461-R461) [[2]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L205-R205) [[3]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L235-R235) [[4]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0L115-R115) [[5]](diffhunk://#diff-8a73c984614377bd6825d61edd71b98b036d399ec8c3b99fb329c497e3678436L232-R232) [[6]](diffhunk://#diff-45f5f6438b97c6017910d48d2e984222d6582b29d35606f27f3ce2ee8b297654R178)
- In `WeaponRulePredicate`, improved logic to resolve the weapon used in a check by retrieving the weapon reference from the configuration and falling back to the event item if necessary.
- Clarified handling of PC weapons versus NPC attacks for predicate evaluation, making the code more explicit and maintainable. [[1]](diffhunk://#diff-94f6ffd1f0628c12265a70f976958c99af474c8e26095aa84c4f15cf353a2da2R108) [[2]](diffhunk://#diff-94f6ffd1f0628c12265a70f976958c99af474c8e26095aa84c4f15cf353a2da2L115-R135)

**Dialog and UI Improvements:**
- Refactored the weapon selection dialog to use `FoundryUtils` helpers for template rendering and input, simplifying the code and improving maintainability. [[1]](diffhunk://#diff-67f4898cb450f05b190e55c9b9dd6762e24733f10f7543b4afe3dd5d194232fdR4) [[2]](diffhunk://#diff-67f4898cb450f05b190e55c9b9dd6762e24733f10f7543b4afe3dd5d194232fdR64-R70)
- Updated the dialog's template structure for improved styling and accessibility. [[1]](diffhunk://#diff-c253a9ef3e1d24bd1f49873961026bae3d676ffc9edfdaff35c0cc672f5a07cfL1-R7) [[2]](diffhunk://#diff-c253a9ef3e1d24bd1f49873961026bae3d676ffc9edfdaff35c0cc672f5a07cfL39-R40)
- Corrected the return type documentation for the `ItemSelectionDialog.open` method to indicate it returns a Promise.

**Skill and Rule Enhancements:**
- Added a new rule element to the Spellblade skill, enabling a bonus to magic checks based on skill level, and updated metadata for the skill. [[1]](diffhunk://#diff-86087dec0e4ca283af85c1bcbf2d4296b7770eb7e869faf283f99bf10c102550L150-R188) [[2]](diffhunk://#diff-86087dec0e4ca283af85c1bcbf2d4296b7770eb7e869faf283f99bf10c102550L170-R213)- Update choose weapon dialog too