### PR TITLE
Fix weapon trait passing

### DIFF
--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -488,7 +488,7 @@ const spendResource = (sections, actor, item, cost, targets, flags) => {
 		// This can be modified here...
 		await CommonEvents.calculateExpense(actor, item, targets, expense);
 		return {
-			order: CHECK_ACTIONS,
+			order: CHECK_ACTIONS + 500,
 			partial: 'systems/projectfu/templates/chat/partials/chat-item-spend-resource.hbs',
 			data: {
 				name: item.name,

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -1,4 +1,4 @@
-import { CHECK_DETAILS, CHECK_FLAVOR, CHECK_RESULT, CHECK_ROLL } from './default-section-order.mjs';
+import { CHECK_ACTIONS, CHECK_DETAILS, CHECK_FLAVOR, CHECK_RESULT, CHECK_ROLL } from './default-section-order.mjs';
 import { FUActor } from '../documents/actors/actor.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
 import { ResourcePipeline, ResourceRequest } from '../pipelines/resource-pipeline.mjs';
@@ -437,7 +437,7 @@ const actions = (sections, actor, item, targetData, flags, inspector = undefined
 			}
 
 			return {
-				order: CHECK_RESULT,
+				order: CHECK_ACTIONS,
 				partial: 'systems/projectfu/templates/chat/partials/chat-actions.hbs',
 				data: {
 					retarget: true,

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -488,7 +488,7 @@ const spendResource = (sections, actor, item, cost, targets, flags) => {
 		// This can be modified here...
 		await CommonEvents.calculateExpense(actor, item, targets, expense);
 		return {
-			order: CHECK_RESULT,
+			order: CHECK_ACTIONS,
 			partial: 'systems/projectfu/templates/chat/partials/chat-item-spend-resource.hbs',
 			data: {
 				name: item.name,

--- a/module/checks/default-section-order.mjs
+++ b/module/checks/default-section-order.mjs
@@ -11,3 +11,5 @@ export const CHECK_ROLL = -1000;
 export const CHECK_ADDENDUM_ORDER = -900;
 
 export const CHECK_RESULT = 1000;
+
+export const CHECK_ACTIONS = 2000;

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -234,18 +234,8 @@ export class MiscAbilityDataModel extends BaseSkillDataModel {
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
 			config.setWeaponReference(weapon);
 			this.configureCheck(config);
+			await this.addSkillAccuracy(config, actor, item, context);
 			await this.addSkillDamage(config, item, context);
-
-			if (this.accuracy) {
-				check.modifiers.push({
-					label: 'FU.CheckBonus',
-					value: this.accuracy,
-				});
-			}
-
-			if (this.useWeapon.accuracy) {
-				check.modifiers.push(...weaponCheck.modifiers.filter(({ label }) => label !== 'FU.AccuracyCheckBonusGeneric'));
-			}
 		};
 	}
 

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -12,6 +12,7 @@ import { Traits, TraitUtils } from '../../../pipelines/traits.mjs';
 import { ExpressionContext, Expressions } from '../../../expressions/expressions.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
 import { ChooseWeaponDialog } from './choose-weapon-dialog.mjs';
+import { WeaponDataModel } from '../weapon/weapon-data-model.mjs';
 
 /**
  * @property {string} description
@@ -167,7 +168,18 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 			// Weapon support
 			if (weaponData) {
 				if (this.useWeapon.traits && weaponData.traits) {
-					config.addTraitsFromItemModel(weaponData.traits);
+					if (weaponData.traits) {
+						config.addTraitsFromItemModel(weaponData.traits);
+					}
+					if (weaponData instanceof WeaponDataModel) {
+						config
+							.setWeaponTraits({
+								weaponType: weaponData.type.value,
+								weaponCategory: weaponData.category.value,
+								handedness: weaponData.hands.value,
+							})
+							.addTraits(weaponData.damageType.value);
+					}
 				}
 				if (this.useWeapon.damage) {
 					config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -223,8 +223,6 @@ export class SkillDataModel extends BaseSkillDataModel {
 			check.primary = weaponCheck.primary;
 			check.secondary = weaponCheck.secondary;
 
-			/** @type SkillDataModel **/
-			const skill = item.system;
 			const config = CheckConfiguration.configure(check);
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
@@ -232,25 +230,7 @@ export class SkillDataModel extends BaseSkillDataModel {
 			config.setWeaponReference(weapon);
 			config.setHrZero(this.damage.hrZero || modifiers.shift);
 			this.configureCheck(config);
-			await this.addSkillDamage(config, item, context);
-
-			// Weapon support
-			if (skill.useWeapon.traits && weaponData.traits) {
-				config.addTraitsFromItemModel(weaponData.traits);
-			}
-			if (skill.useWeapon.damage) {
-				config.setDamage(this.damage.type || weaponData.damageType.value, weapon.system.damage.value);
-			}
-			if (skill.useWeapon.accuracy) {
-				check.modifiers.push({
-					label: 'FU.CheckBonus',
-					value: weaponData.accuracy.value,
-				});
-				if (weaponData.defense) {
-					config.setTargetedDefense(weaponData.defense);
-				}
-			}
-			config.setWeaponTraits(config.getWeaponTraits());
+			await this.addSkillDamage(config, item, context, weaponData);
 			await this.addSkillAccuracy(config, actor, item, context);
 		};
 	}

--- a/templates/chat/partials/inline-damage-icon.hbs
+++ b/templates/chat/partials/inline-damage-icon.hbs
@@ -1,1 +1,8 @@
-<a class="inline inline-damage"> {{damageType}}<i class="{{affinityIcons}}"></i></a>
+<a class="inline inline-damage">
+	{{#if pressureTrigger}}
+		{{pressureTrigger}}
+	{{else}}
+		{{damageType}}
+	{{/if}}
+	<i class="fu-icon--s {{icon}}"></i>
+</a>


### PR DESCRIPTION
This pull request introduces several improvements and refactorings related to skill and weapon checks, damage handling, and chat section ordering. The most notable changes are the consolidation of weapon support logic within skill models, the introduction of more flexible section ordering for chat actions, and enhancements to the pressure system in damage calculation.

**Skill and Weapon Handling Improvements:**

* Refactored weapon support logic in `SkillDataModel` and `MiscAbilityDataModel` to centralize accuracy and damage calculations in `BaseSkillDataModel.addSkillAccuracy` and `addSkillDamage`, reducing duplication and improving maintainability. Weapon traits, accuracy, and damage are now handled more consistently, and weapon-related modifiers are added directly within these methods. [[1]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0L131-R132) [[2]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R151-R157) [[3]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R168-R194) [[4]](diffhunk://#diff-8a73c984614377bd6825d61edd71b98b036d399ec8c3b99fb329c497e3678436L226-R233) [[5]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93R237-L248)

**Chat Section Ordering Enhancements:**

* Introduced a new `CHECK_ACTIONS` constant for chat section ordering and updated relevant sections (such as actions and resource spending) to use this new order, allowing for more flexible placement of action-related UI elements in the chat log. [[1]](diffhunk://#diff-81516d391b03487d280c0e09a2b1b6665e18cf7fe45c20beb8e62be2f42d7a84R14-R15) [[2]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL1-R1) [[3]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL440-R440) [[4]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL491-R491)

**Damage Pipeline and Pressure System Updates:**

* Enhanced the pressure system in the damage pipeline by adding a `pressureTrigger` property to the damage context, which records the specific trigger (e.g., weapon group or affinity) that caused pressure. The logic for setting this property has been clarified and now supports both affinity-based and trait-based triggers. [[1]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL140-R140) [[2]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bR149) [[3]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bR263-R285)
* Updated the damage pipeline to pass `pressureTrigger` to the damage chat partial, and updated the partial template to display the trigger when present, providing clearer feedback to users when pressure is applied. [[1]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL505-R516) [[2]](diffhunk://#diff-bb6c1ad9d1aa2c4d60a7841695da893f8138f25b7c5eb2625ca13981021d5bafL1-R8)

**Miscellaneous:**

* Minor type and import cleanups, such as updating documentation and ensuring relevant models are imported where needed. [[1]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R15) [[2]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL140-R140)