### PR TITLE
Move Token object and ruler class overrides to earlier in lifecycle

### DIFF
--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -133,6 +133,10 @@ globalThis.projectfu = {
 	},
 };
 
+// These are pulled out of the init hook to ensure they are overridden before any modules that may apply mixins later
+CONFIG.Token.rulerClass = FUTokenRuler;
+CONFIG.Token.objectClass = FUToken;
+
 /* -------------------------------------------- */
 /*  Init Hook                                   */
 /* -------------------------------------------- */
@@ -410,10 +414,6 @@ Hooks.once('init', async () => {
 	// if (!game.settings.get(SYSTEM, SETTINGS.optionEnableDragRuler)) {
 	// 	CONFIG.Token.rulerClass = null;
 	// }
-
-	// Override token ruler class
-	CONFIG.Token.rulerClass = FUTokenRuler;
-	CONFIG.Token.objectClass = FUToken;
 
 	// Preload Handlebars templates.
 	return preloadHandlebarsTemplates();


### PR DESCRIPTION
This PR moves the overrides for `CONFIG.Token.objectClass` and `CONFIG.Token.rulerClass` outside of the `init` hook to ensure it runs before any modules that may apply mixins to these classes, such as [dylan's animated tokens](https://github.com/righthandofvecna/dylans-animated-tokens)