### PR TITLE
Dice So Nice Doubles Effect Fix

### DIFF
--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -547,8 +547,8 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
 	Hooks.on('diceSoNiceRollStart', (_messageId, context) => {
 		const dice = context.roll.dice;
 		if (dice.reduce((agg, curr) => agg + curr.number, 0) === 2) {
-			const dieValue = dice[0].results[0].check;
-			if (dieValue === (dice[0].results[1] ?? dice[1].results[0]).check) {
+			const dieValue = dice[0].results[0].result;
+			if (dieValue === (dice[0].results[1] ?? dice[1].results[0]).result) {
 				for (const d of dice) {
 					d.options.sfx = { id: 'doubles', result: dieValue };
 				}


### PR DESCRIPTION
Doubles sfx in `diceSoNiceRollStart` hook was using incorrect roll result property, resulting in an error being thrown when effect is enabled

Fixes #663 