### PR TITLE
Double Pressure With High Damage Threshold

### DIFF
--- a/module/systems/pressure-system.mjs
+++ b/module/systems/pressure-system.mjs
@@ -29,8 +29,19 @@ async function processVulnerability(context) {
 		return null;
 	}
 
+	console.log('Processing vulnerability:', context);
+
 	// TODO: Refactor to not have to re-resolve
-	pressureClock = await context.actor.updateProgress('pressure', 1);
+
+	// If this NPC is pressured because they are VU to the damage type,
+	// AND the amount of HP loss is equal to or higher than 10 + half their level,
+	// fill the clock by 2
+	if (context.affinity === FU.affValue.vulnerability && context.amount >= 10 + Math.floor(context.actor.system.level.value / 2)) {
+		pressureClock = await context.actor.updateProgress('pressure', 2);
+	} else {
+		pressureClock = await context.actor.updateProgress('pressure', 1);
+	}
+
 	let staggered = false;
 	// If now at max, apply stagger
 	if (pressureClock.isMaximum) {

--- a/module/systems/pressure-system.mjs
+++ b/module/systems/pressure-system.mjs
@@ -29,8 +29,6 @@ async function processVulnerability(context) {
 		return null;
 	}
 
-	console.log('Processing vulnerability:', context);
-
 	// TODO: Refactor to not have to re-resolve
 
 	// If this NPC is pressured because they are VU to the damage type,


### PR DESCRIPTION
This PR adds a check for the pressure system's `processVulnerability` function to increment an actor's Pressure clock by two steps when being triggered because of a damage type VU and the actual damage amount is >= 10 + (half the NPC's level)

Fixes #773 

<img width="542" height="275" alt="image" src="https://github.com/user-attachments/assets/3a6f9215-845b-442a-a789-c9ac4b535bd8" />
