### PR TITLE
Compendium Updates to Psychic Gifts

### DIFF
--- a/src/packs/skills/classFeature_Atmokinesis_PN6y0O0YDvtzFDAy.json
+++ b/src/packs/skills/classFeature_Atmokinesis_PN6y0O0YDvtzFDAy.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "When you deal damage",
-      "description": "<p>That damage becomes <strong>air</strong> or <strong>bolt</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】</strong>.</p>"
+      "description": "<p>That damage becomes <strong>air</strong> or <strong>bolt</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】</strong>.</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF152",
     "fuid": "atmokinesis"
@@ -111,10 +111,10 @@
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "coreVersion": "13.348",
+    "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1767268451276,
-    "lastModifiedBy": "J5B4HfVqUaCPvzGg",
+    "modifiedTime": 1771230778401,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null

--- a/src/packs/skills/classFeature_Clairvoyance_SbBJH4ofSkOHZ7Mo.json
+++ b/src/packs/skills/classFeature_Clairvoyance_SbBJH4ofSkOHZ7Mo.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "When an NPC becomes your focus or when you create a Bond towards an NPC",
-      "description": "<p>You ask the Game Master a single question about that NPC, and the Game Master must answer truthfully. Then, describe what sensation revealed this information to you. You may use this gift <strong>only once</strong> on each NPC.</p><hr /><p><strong>You Spend: </strong>@LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Psychic Gift}<br /><strong>Progress: </strong>@CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
+      "description": "<p>You ask the Game Master a single question about that NPC, and the Game Master must answer truthfully. Then, describe what sensation revealed this information to you. You may use this gift <strong>only once</strong> on each NPC.</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF152",
     "fuid": "clairvoyance"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1770368201538,
+    "modifiedTime": 1771230673556,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/classFeature_Gravitokinesis_sDiqo6su9LgYDQVh.json
+++ b/src/packs/skills/classFeature_Gravitokinesis_sDiqo6su9LgYDQVh.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "When you deal damage",
-      "description": "<p>That damage becomes <strong>earth</strong> or <strong>physical</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】</strong>. If the source deals damage to one or more <strong>flying</strong> creatures, they are forced to land immediately.</p>"
+      "description": "<p>That damage becomes <strong>earth</strong> or <strong>physical</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】</strong>. If the source deals damage to one or more <strong>flying</strong> creatures, they are forced to land immediately.</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF153",
     "fuid": "gravitokinesis"
@@ -111,10 +111,10 @@
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "coreVersion": "13.348",
+    "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1767268541710,
-    "lastModifiedBy": "J5B4HfVqUaCPvzGg",
+    "modifiedTime": 1771230923802,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null

--- a/src/packs/skills/classFeature_Life_Transference_PN8CkQbxXS6v01gk.json
+++ b/src/packs/skills/classFeature_Life_Transference_PN8CkQbxXS6v01gk.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "When you cause one or more enemies to lose HP",
-      "description": "<p>Choose yourself or an ally who is your <strong>focus</strong>: if the chosen creature is in <strong>Crisis</strong>, they recover an amount of Hit Points equal to <strong>【5 + (the number of filled sections in your Brainwave Clock, multiplied by 5)】.</strong></p>"
+      "description": "<p>Choose yourself or an ally who is your <strong>focus</strong>: if the chosen creature is in <strong>Crisis</strong>, they recover an amount of Hit Points equal to <strong>【5 + (the number of filled sections in your Brainwave Clock, multiplied by 5)】.</strong></p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Target Recovers:</strong> @GAIN[5+(&amp;cs('brainwave-clock')*5) hp]{5 + (Brainwave × 5) HP}<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF153",
     "fuid": "life-transference"
@@ -117,10 +117,10 @@
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "coreVersion": "13.348",
+    "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1767894223941,
-    "lastModifiedBy": "J5B4HfVqUaCPvzGg",
+    "modifiedTime": 1771231013589,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null

--- a/src/packs/skills/classFeature_Photokinesis_Gl94a8Sykg9WZhPs.json
+++ b/src/packs/skills/classFeature_Photokinesis_Gl94a8Sykg9WZhPs.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "When you deal damage",
-      "description": "<p>That damage becomes <strong>dark</strong> or <strong>light</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】.</strong></p>"
+      "description": "<p>That damage becomes <strong>dark</strong> or <strong>light</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】.</strong></p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF153",
     "fuid": "photokinesis"
@@ -111,10 +111,10 @@
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "coreVersion": "13.348",
+    "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1767268675681,
-    "lastModifiedBy": "J5B4HfVqUaCPvzGg",
+    "modifiedTime": 1771231033997,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null

--- a/src/packs/skills/classFeature_Psychic_Backlash_RikYwc1dD7YIEn3k.json
+++ b/src/packs/skills/classFeature_Psychic_Backlash_RikYwc1dD7YIEn3k.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "After an enemy succeeds on an Opposed Check  against you or causes you to lose Hit Points",
-      "description": "<p>That enemy loses an amount of Mind Points equal to <strong>【5 + (the number of filled sections in your Brainwave Clock, multiplied by 5)】</strong>. Then, choose one option: that enemy suffers <strong>dazed</strong>; or that enemy suffers <strong>shaken</strong>.</p><hr /><p><strong>You Spend: </strong>@LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Psychic Gift}<br /><strong>Target Suffers:</strong> @LOSS[10+(&amp;cs('brainwave-clock')*5) mp]{Psychic Backlash} + @EFFECT[dazed] or @EFFECT[shaken]<br /><strong>Progress: </strong>@CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
+      "description": "<p>That enemy loses an amount of Mind Points equal to <strong>【5 + (the number of filled sections in your Brainwave Clock, multiplied by 5)】</strong>. Then, choose one option: that enemy suffers <strong>dazed</strong>; or that enemy suffers <strong>shaken</strong>.</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Target Suffers:</strong> @LOSS[5+(&amp;cs('brainwave-clock')*5) mp]{5 + (Brainwave × 5) MP} + @EFFECT[dazed] or @EFFECT[shaken]<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF153",
     "fuid": "psychic-backlash"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1770368301979,
+    "modifiedTime": 1771230989779,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/classFeature_Psychic_Shield_aqgXqI567dkudwMN.json
+++ b/src/packs/skills/classFeature_Psychic_Shield_aqgXqI567dkudwMN.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "After an enemy you can see performs an  Accuracy Check or a Magic Check",
-      "description": "<p>You may treat your Defense and Magic Defense scores as being equal to <strong>【your current Willpower die size + (the number of filled sections in your Brainwave Clock, multiplied by 2)】</strong> against that Check (you may still use your normal scores if better).</p><hr /><p><strong>You Spend: </strong>@LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Psychic Gift}<br /><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.skills.Item.hNeylrus4Ii8hIKa]<br /><strong>Progress: </strong>@CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
+      "description": "<p>You may treat your Defense and Magic Defense scores as being equal to <strong>【your current Willpower die size + (the number of filled sections in your Brainwave Clock, multiplied by 2)】</strong> against that Check (you may still use your normal scores if better).</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.skills.Item.hNeylrus4Ii8hIKa]<br /><strong>Progress: </strong>@CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF153",
     "fuid": "psychic-shield"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1770632443514,
+    "modifiedTime": 1771230933632,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/classFeature_Reassuring_Presence_ohueXD1PGP1TTRlq.json
+++ b/src/packs/skills/classFeature_Reassuring_Presence_ohueXD1PGP1TTRlq.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "After you cover an ally with the Guard action",
-      "description": "<p>That ally recovers an amount of Mind Points equal to <strong>【10 + (the number of filled sections in your Brainwave Clock, multiplied by 5)】</strong>. If that ally is your <strong>focus</strong>, they heal from a single status effect of their choice out of <strong>dazed</strong>, <strong>enraged</strong>, and <strong>shaken</strong>.</p><hr /><p><strong>Cost: </strong>@LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Psychic Gift}<br /><strong>Ally Recovers:</strong> @GAIN[10+(&amp;cs('brainwave-clock')*5) mp]{Reassuring Presence}<br /><strong>Progress: </strong>@CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
+      "description": "<p>That ally recovers an amount of Mind Points equal to <strong>【10 + (the number of filled sections in your Brainwave Clock, multiplied by 5)】</strong>. If that ally is your <strong>focus</strong>, they heal from a single status effect of their choice out of <strong>dazed</strong>, <strong>enraged</strong>, and <strong>shaken</strong>.</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Ally Recovers:</strong> @GAIN[10+(&amp;cs('brainwave-clock')*5) mp]{10 + (Brainwave × 5) MP}<br /><strong>Progress: </strong>@CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF153",
     "fuid": "reassuring-presence"
@@ -32,7 +32,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1770368954326,
+    "modifiedTime": 1771231004957,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/classFeature_Thermokinesis_rM8RIy8usVdVO0ro.json
+++ b/src/packs/skills/classFeature_Thermokinesis_rM8RIy8usVdVO0ro.json
@@ -13,7 +13,7 @@
     "featureType": "projectfu.psychicGift",
     "data": {
       "trigger": "When you deal damage",
-      "description": "<p>That damage becomes <strong>fire</strong> or <strong>ice</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】</strong>.</p>"
+      "description": "<p>That damage becomes <strong>fire</strong> or <strong>ice</strong>, and its source deals extra damage equal to <strong>【2 + the number of filled sections in your Brainwave Clock】</strong>.</p><hr /><p><strong>You Spend:</strong> @LOSS[max(5, (&amp;cs('brainwave-clock')*5)) mp]{Lose Brainwave MP}<br /><strong>Progress:</strong> @CLOCK[brainwave-clock update 1]{Advance Brainwave Clock}</p>"
     },
     "source": "FUTF152",
     "fuid": "thermokinesis"
@@ -111,10 +111,10 @@
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "coreVersion": "13.348",
+    "coreVersion": "13.351",
     "createdTime": 1711423314741,
-    "modifiedTime": 1767268794451,
-    "lastModifiedBy": "J5B4HfVqUaCPvzGg",
+    "modifiedTime": 1771231040087,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,
     "exportSource": null

--- a/src/packs/skills/skill_Psychic_Gifts_uiXJvj0qK0pVfnwY.json
+++ b/src/packs/skills/skill_Psychic_Gifts_uiXJvj0qK0pVfnwY.json
@@ -7,7 +7,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>Each time you take this Skill, you gain a <strong>gift</strong> (see <strong>Techno Fantasy Atlas</strong>, page <strong>152</strong>).</p><p>The rules for gifts and for the <strong>Brainwave </strong>clock can be found in the next page.</p><hr /><p>For <strong>gift</strong> breakdown and a list of Psychic Gifts, refer to: @UUID[Compendium.projectfu.handouts.JournalEntry.mcjpTrTkosKxoyCc]{Psychic Gift Rules}<br />To <strong>automate</strong>, VTT Instructions can be found here: @UUID[Compendium.projectfu.handouts.JournalEntry.mcjpTrTkosKxoyCc.JournalEntryPage.uafn9l51ROzc9q0w]{Psychic Gift VTT Instructions}</p>",
+    "description": "<p>Each time you take this Skill, you gain a <strong>gift</strong> (see <strong>Techno Fantasy Atlas</strong>, page <strong>152</strong>).</p><p>The rules for gifts and for the <strong>Brainwave </strong>clock can be found in the next page.</p><hr /><p>For <strong>gift</strong> breakdown, refer to: @UUID[Compendium.projectfu.handouts.JournalEntry.mcjpTrTkosKxoyCc]{Psychic Gift Rules}<br />For a list of <strong>Psychic Gifts</strong> refer to: @UUID[Compendium.projectfu.skills.Item.uiXJvj0qK0pVfnwY]<br />To <strong>automate</strong>, VTT Instructions can be found here: @UUID[Compendium.projectfu.handouts.JournalEntry.mcjpTrTkosKxoyCc.JournalEntryPage.uafn9l51ROzc9q0w]{Psychic Gift VTT Instructions}</p>",
     "isFavored": {
       "value": false
     },
@@ -208,7 +208,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711424945464,
-    "modifiedTime": 1770368039045,
+    "modifiedTime": 1771231100429,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,


### PR DESCRIPTION
Added inline buttons for spending MP and advancing the Brainwave Clock back to Psychic Gifts where they were removed.

In situations where a Player can't or won't use the Rule Element automation for any of the Psychic Gifts, It is useful to have the inline buttons to spend MP based off the Brainwave Clock filled segment and the button to automatically progress the clock in the description of every Psychic Gift.

Also, decided to update some of the labeling and add a direct link to the Psychic Gift List to the Psychic Gift Skill.