### PR TITLE
Add Loot Item to Party Sheet for Players

### DIFF
--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -21,6 +21,7 @@ import { Checks } from '../checks/checks.mjs';
 import { TreasuresTableRenderer } from '../helpers/tables/treasures-table-renderer.mjs';
 import { ConsumablesTableRenderer } from '../helpers/tables/consumables-table-renderer.mjs';
 import { OtherItemsTableRenderer } from '../helpers/tables/other-items-table-renderer.mjs';
+import { getPrioritizedUserTargeted } from '../helpers/target-handler.mjs';
 import { TechnospheresTableRenderer } from '../helpers/tables/technospheres-table-renderer.mjs';
 import FoundryUtils from '../helpers/foundry-utils.mjs';
 import { ProgressPipeline } from '../pipelines/progress-pipeline.mjs';
@@ -47,6 +48,7 @@ export class FUPartySheet extends FUActorSheet {
 			clearInventory: this.#onClearInventory,
 			createEquipment: this.#onCreateEquipment,
 			shareItem: this.#onShareItem,
+			lootItem: this.#onLootItem,
 			distributeZenit: this.#onDistributeZenit,
 
 			revealMetaCurrency: this.#revealMetaCurrency,
@@ -627,15 +629,35 @@ export class FUPartySheet extends FUActorSheet {
 	}
 
 	static #onShareItem(event, target) {
+		const item = FUPartySheet.#resolveItem(this.actor, target);
+		if (item) {
+			return InventoryPipeline.tradeItem(this.actor, item, 'loot');
+		}
+	}
+
+	static #onLootItem(event, target) {
+		const item = FUPartySheet.#resolveItem(this.actor, target);
+		if (item) {
+			const targetActor = getPrioritizedUserTargeted();
+			if (!targetActor) return;
+
+			return InventoryPipeline.requestTrade(this.actor.uuid, item.uuid, false, targetActor.uuid, {
+				shift: event?.shiftKey ?? false,
+				ctrl: event?.ctrlKey ?? false,
+				alt: event?.altKey ?? false,
+				meta: event?.metaKey ?? false,
+			});
+		}
+	}
+	
+	static #resolveItem(actor, target) {
 		const dataItemId = target.closest('[data-item-id]')?.dataset?.itemId;
-		let item = this.actor.items.get(dataItemId);
+		let item = actor.items.get(dataItemId);
 		if (!item) {
 			const uuid = target.closest('[data-uuid]')?.dataset?.uuid;
 			item = foundry.utils.fromUuidSync(uuid);
 		}
-		if (item) {
-			return InventoryPipeline.tradeItem(this.actor, item, 'loot');
-		}
+		return item;
 	}
 
 	static #onDistributeZenit() {

--- a/templates/table/cell/cell-item-controls.hbs
+++ b/templates/table/cell/cell-item-controls.hbs
@@ -12,12 +12,21 @@
 		</a>
 	{{/unless}}
 	{{#unless hideShare}}
-		<a class="cell-item-controls__control {{#if disableShare ~}} cell-item-controls__control--disabled {{~/if}}"
-		   data-tooltip="{{ localize 'FU.Share' }}"
-		   aria-describedby="tooltip"
-		   data-action="shareItem">
-			<i class="fa fa-share"></i>
-		</a>
+		{{#if isGM}}
+			<a class="cell-item-controls__control {{#if disableShare ~}} cell-item-controls__control--disabled {{~/if}}"
+				data-tooltip="{{ localize 'FU.Share' }}"
+				aria-describedby="tooltip"
+				data-action="shareItem">
+				<i class="fa fa-share"></i>
+			</a>
+		{{else}}
+			<a class="cell-item-controls__control {{#if disableLoot ~}} cell-item-controls__control--disabled {{~/if}}"
+				data-tooltip="{{ localize 'FU.Loot' }}<br>{{ localize 'FU.LootDelete' }}"
+				aria-describedby="tooltip"
+				data-action="lootItem">
+				<i class="fa fa-hand button-style"></i>
+			</a>
+		{{/if}}
 	{{/unless}}
 	{{#unless hideSell}}
 		{{#if isGM}}


### PR DESCRIPTION
Created a fix for #786 .

The Party sheet only showed the "Share Item" button for both GMs and Players. But, that button automatically fails if the user does not own the Party Sheet which Players are not intended to own. This updates to match the old functionality where it would show a "Loot Item" button instead to Players.

- "Loot Item" Button appears on the Party sheet for Players. "Share Item" Button for GMs.
- Added Loot Item function to party sheet.