### PR TITLE
Fix effects clear automation on start/end combat

### DIFF
--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -401,6 +401,8 @@ export class FUActor extends Actor {
 	 * @typedef ClearEffectOptions
 	 * @property {Boolean} status Whether the effect must have one of the core statuses (dazed, etc...)
 	 * @property {Boolean} duration Whether the effect must have a duration. (Ignored for system statuses, which have no duration by default.)
+	 * @property {Boolean} rest Whether to clear effects with rest. (Skipped when set to false)
+	 * @property {(effect: FUActiveEffect) => boolean} predicate A custom predicate for whether to remove an effect.
 	 */
 
 	/**
@@ -409,6 +411,7 @@ export class FUActor extends Actor {
 	static defaultClearEffectOptions = {
 		status: undefined,
 		duration: undefined,
+		rest: undefined,
 	};
 
 	/**
@@ -428,7 +431,7 @@ export class FUActor extends Actor {
 					}
 					break;
 				case false:
-					if (statusEffectId) {
+					if (statusEffectId && statusEffectId in Effects.STATUS_EFFECTS) {
 						return false;
 					}
 					break;
@@ -446,6 +449,25 @@ export class FUActor extends Actor {
 						return false;
 					}
 					break;
+			}
+
+			switch (options.rest) {
+				case true:
+					if (effect.system.duration.event !== 'rest') {
+						return false;
+					}
+					break;
+				case false:
+					if (effect.system.duration.event === 'rest') {
+						return false;
+					}
+					break;
+			}
+
+			if (options.predicate) {
+				if (!options.predicate(effect)) {
+					return false;
+				}
 			}
 
 			if (statusEffectId) {

--- a/module/pipelines/automation.mjs
+++ b/module/pipelines/automation.mjs
@@ -1,22 +1,218 @@
 import { AsyncHooks } from '../helpers/async-hooks.mjs';
 import { FUHooks } from '../hooks.mjs';
-import { SYSTEM } from '../helpers/config.mjs';
+import { FU, SYSTEM } from '../helpers/config.mjs';
 import { SETTINGS } from '../settings.js';
 import { ResourcePipeline, ResourceRequest } from './resource-pipeline.mjs';
 import { InlineSourceInfo } from '../helpers/inline-helper.mjs';
+import { Pipeline } from './pipeline.mjs';
+import { Targeting } from '../helpers/targeting.mjs';
+import { Flags } from '../helpers/flags.mjs';
+
+/**
+ * @param {CalculateExpenseEvent} event
+ * @returns {Promise<void>}
+ */
+async function onExpenseEvent(event) {
+	if (game.settings.get(SYSTEM, SETTINGS.automationSpendResource)) {
+		const sourceInfo = InlineSourceInfo.fromInstance(event.source.actor, event.item);
+		const request = new ResourceRequest(sourceInfo, [event.source.actor], event.expense.resource, -event.expense.amount);
+		return ResourcePipeline.process(request);
+	}
+}
+
+/**
+ * @param {CombatEvent} event
+ * @returns {Promise<void>}
+ */
+async function promptExpiredEffectRemoval(event) {
+	let count = 0;
+	if (
+		event.actors.every((actor) => {
+			count += actor.temporaryEffects.length;
+			return actor.temporaryEffects.length === 0;
+		})
+	) {
+		return;
+	}
+
+	let message;
+	switch (event.type) {
+		case FU.combatEvent.startOfCombat:
+			message = 'FU.ChatCombatStart';
+			break;
+		case FU.combatEvent.endOfCombat:
+			message = 'FU.ChatCombatEnd';
+			break;
+	}
+
+	const serializedActors = Targeting.serializeTargetData(event.actors);
+	ChatMessage.create({
+		flags: Pipeline.initializedFlags(Flags.ChatMessage.Effects, true),
+		content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-combat-end.hbs', {
+			message: message,
+			actors: JSON.stringify(serializedActors),
+			round: event.round,
+			count: count,
+		}),
+	});
+}
+
+/**
+ * @description Manages active effects during a combat
+ * @param {CombatEvent} event
+ * @returns {Promise<void>}
+ */
+async function manageEffectDuration(event) {
+	console.debug(`Managing active effects on ${event.type}`);
+
+	/** @type ManagedEffectData[] **/
+	const managedEffects = [];
+	const updates = [];
+	const effectsToDelete = [];
+	const autoRemove = game.settings.get(SYSTEM, SETTINGS.optionAutomationRemoveExpiredEffects);
+	const remind = game.settings.get(SYSTEM, SETTINGS.optionAutomationEffectsReminder);
+
+	// TODO: Add source-tracked effects into a single collection to check
+	for (const actor of event.actors) {
+		const effects = actor.temporaryEffects.filter(
+			/** @type FUActiveEffect **/ (effect) => {
+				// The duration data
+				const duration = effect.system.duration;
+				const eventType = FU.effectDuration[duration.event];
+
+				// Not based on this event type
+				if (eventType !== event.type) {
+					return false;
+				}
+
+				// If the event is based on a specific actor
+				if (event.hasActor) {
+					if (duration.tracking === 'self') {
+						if (actor.uuid !== event.actor.uuid) {
+							return false;
+						}
+					} else if (duration.tracking === 'source') {
+						if (effect.sourceInfo.actorUuid !== event.actor.uuid) {
+							return false;
+						}
+					}
+				}
+
+				// Already expired
+				if (duration.remaining === 0) {
+					if (autoRemove) {
+						console.debug(`Automatically removing ${effect.name} on round ${event.round}`);
+						effectsToDelete.push(effect);
+					}
+					return true;
+				}
+
+				// Tick down remaining
+				console.debug(`Decreasing remaining effect duration (${duration.remaining}) of ${effect.name} in ${event.type}`);
+				updates.push(
+					effect.update({
+						[`system.duration.remaining`]: duration.remaining - 1,
+					}),
+				);
+
+				// Just expired
+				const expired = duration.remaining - 1 === 0;
+				if (expired) {
+					if (autoRemove) {
+						console.debug(`Automatically removing ${effect.name}`);
+						effectsToDelete.push(effect);
+					}
+					return true;
+				}
+				// Not yet expired
+				return remind;
+			},
+		);
+
+		if (effects.length > 0) {
+			/** @type ManagedEffectData[] **/
+			const effectData = effects.map((effect) => ({
+				name: effect.name,
+				id: effect.id,
+				img: effect.img,
+				actorName: actor.name,
+				actorId: actor.uuid,
+				remaining: effect.system.duration.remaining - 1, // The update happens later okay?
+				description: effect.description,
+			}));
+
+			managedEffects.push(...effectData);
+		}
+	}
+
+	if (managedEffects.length === 0) {
+		return;
+	}
+	await Promise.all(updates);
+
+	// TODO: Maybe link to the originals if deletions are about to happen
+	ChatMessage.create({
+		//speaker: ChatMessage.getSpeaker({ actor }),
+		flags: Pipeline.initializedFlags(Flags.ChatMessage.Effects, true),
+		content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-manage-effects.hbs', {
+			message: 'FU.ChatManageEffects',
+			effects: managedEffects,
+			round: event.round,
+			event: event.type,
+		}),
+	});
+
+	// Safe to delete now that it's been posted
+	for (const e of effectsToDelete) {
+		e.delete();
+	}
+}
+
+/**
+ * @param {CombatEvent} event
+ * @returns {Promise<void>}
+ */
+async function onCombatEvent(event) {
+	if (!game.settings.get(SYSTEM, SETTINGS.optionAutomationManageEffects)) {
+		return;
+	}
+
+	switch (event.type) {
+		case FU.combatEvent.startOfCombat:
+		case FU.combatEvent.endOfCombat:
+			{
+				if (game.settings.get(SYSTEM, SETTINGS.optionAutomationRemoveExpiredEffects)) {
+					event.actors.forEach((actor) => {
+						actor.clearTemporaryEffects({
+							status: false,
+							rest: false,
+							predicate: (effect) => {
+								// It's handled by the pressure system
+								if (effect.statuses.has('pressure')) {
+									return false;
+								}
+								return true;
+							},
+						});
+					});
+					return;
+				}
+
+				await promptExpiredEffectRemoval(event);
+			}
+			break;
+
+		case FU.combatEvent.startOfTurn:
+		case FU.combatEvent.endOfTurn:
+		case FU.combatEvent.endOfRound:
+			await manageEffectDuration(event);
+			break;
+	}
+}
 
 function initialize() {
-	// Spend Resource
-	AsyncHooks.on(
-		FUHooks.EXPENSE_EVENT,
-		/** @param {CalculateExpenseEvent} event **/ async (event) => {
-			if (game.settings.get(SYSTEM, SETTINGS.automationSpendResource)) {
-				const sourceInfo = InlineSourceInfo.fromInstance(event.source.actor, event.item);
-				const request = new ResourceRequest(sourceInfo, [event.source.actor], event.expense.resource, -event.expense.amount);
-				return ResourcePipeline.process(request);
-			}
-		},
-	);
+	AsyncHooks.on(FUHooks.EXPENSE_EVENT, onExpenseEvent);
+	Hooks.on(FUHooks.COMBAT_EVENT, onCombatEvent);
 }
 
 export const AutomationPipeline = Object.freeze({

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -6,7 +6,6 @@ import { Pipeline } from './pipeline.mjs';
 import { Flags } from '../helpers/flags.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
 import { CommonEvents } from '../checks/common-events.mjs';
-import { SETTINGS } from '../settings.js';
 import { MathHelper } from '../helpers/math-helper.mjs';
 import FoundryUtils from '../helpers/foundry-utils.mjs';
 import { FUItem } from '../documents/items/item.mjs';
@@ -522,163 +521,6 @@ function createEffectFlags(effect, sourceInfo, identifier) {
  */
 
 /**
- * @description Manages active effects during a combat
- * @param {CombatEvent} event
- * @returns {Promise<void>}
- */
-async function manageEffectDuration(event) {
-	console.debug(`Managing active effects on ${event.type}`);
-
-	/** @type ManagedEffectData[] **/
-	const managedEffects = [];
-	const updates = [];
-	const effectsToDelete = [];
-	const autoRemove = game.settings.get(SYSTEM, SETTINGS.optionAutomationRemoveExpiredEffects);
-	const remind = game.settings.get(SYSTEM, SETTINGS.optionAutomationEffectsReminder);
-
-	// TODO: Add source-tracked effects into a single collection to check
-	for (const actor of event.actors) {
-		const effects = actor.temporaryEffects.filter(
-			/** @type FUActiveEffect **/ (effect) => {
-				// The duration data
-				const duration = effect.system.duration;
-				const eventType = FU.effectDuration[duration.event];
-
-				// Not based on this event type
-				if (eventType !== event.type) {
-					return false;
-				}
-
-				// If the event is based on a specific actor
-				if (event.hasActor) {
-					if (duration.tracking === 'self') {
-						if (actor.uuid !== event.actor.uuid) {
-							return false;
-						}
-					} else if (duration.tracking === 'source') {
-						if (effect.sourceInfo.actorUuid !== event.actor.uuid) {
-							return false;
-						}
-					}
-				}
-
-				// Already expired
-				if (duration.remaining === 0) {
-					if (autoRemove) {
-						console.debug(`Automatically removing ${effect.name} on round ${event.round}`);
-						effectsToDelete.push(effect);
-					}
-					return true;
-				}
-
-				// Tick down remaining
-				console.debug(`Decreasing remaining effect duration (${duration.remaining}) of ${effect.name} in ${event.type}`);
-				updates.push(
-					effect.update({
-						[`system.duration.remaining`]: duration.remaining - 1,
-					}),
-				);
-
-				// Just expired
-				const expired = duration.remaining - 1 === 0;
-				if (expired) {
-					if (autoRemove) {
-						console.debug(`Automatically removing ${effect.name}`);
-						effectsToDelete.push(effect);
-					}
-					return true;
-				}
-				// Not yet expired
-				return remind;
-			},
-		);
-
-		if (effects.length > 0) {
-			/** @type ManagedEffectData[] **/
-			const effectData = effects.map((effect) => ({
-				name: effect.name,
-				id: effect.id,
-				img: effect.img,
-				actorName: actor.name,
-				actorId: actor.uuid,
-				remaining: effect.system.duration.remaining - 1, // The update happens later okay?
-				description: effect.description,
-			}));
-
-			managedEffects.push(...effectData);
-		}
-	}
-
-	if (managedEffects.length === 0) {
-		return;
-	}
-	await Promise.all(updates);
-
-	// TODO: Maybe link to the originals if deletions are about to happen
-	ChatMessage.create({
-		//speaker: ChatMessage.getSpeaker({ actor }),
-		flags: Pipeline.initializedFlags(Flags.ChatMessage.Effects, true),
-		content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-manage-effects.hbs', {
-			message: 'FU.ChatManageEffects',
-			effects: managedEffects,
-			round: event.round,
-			event: event.type,
-		}),
-	});
-
-	// Safe to delete now that it's been posted
-	for (const e of effectsToDelete) {
-		e.delete();
-	}
-}
-
-/**
- * @param {CombatEvent} event
- * @returns {Promise<void>}
- */
-async function promptExpiredEffectRemoval(event) {
-	let count = 0;
-	if (
-		event.actors.every((actor) => {
-			count += actor.temporaryEffects.length;
-			return actor.temporaryEffects.length === 0;
-		})
-	) {
-		return;
-	}
-
-	if (game.settings.get(SYSTEM, SETTINGS.optionAutomationRemoveExpiredEffects)) {
-		event.actors.forEach((actor) => {
-			actor.clearTemporaryEffects({
-				duration: true,
-			});
-		});
-		return;
-	}
-
-	let message;
-	switch (event.type) {
-		case FU.combatEvent.startOfCombat:
-			message = 'FU.ChatCombatStart';
-			break;
-		case FU.combatEvent.endOfCombat:
-			message = 'FU.ChatCombatEnd';
-			break;
-	}
-
-	const serializedActors = Targeting.serializeTargetData(event.actors);
-	ChatMessage.create({
-		flags: Pipeline.initializedFlags(Flags.ChatMessage.Effects, true),
-		content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-combat-end.hbs', {
-			message: message,
-			actors: JSON.stringify(serializedActors),
-			round: event.round,
-			count: count,
-		}),
-	});
-}
-
-/**
  * @param {FUActor} actor
  * @param {FUActor[]} targets
  * @param {FUActiveEffect[]} effects
@@ -924,29 +766,6 @@ function onRenderChatMessage(message, element) {
 }
 
 /**
- * @param {CombatEvent} event
- * @returns {Promise<void>}
- */
-async function onCombatEvent(event) {
-	if (!game.settings.get(SYSTEM, SETTINGS.optionAutomationManageEffects)) {
-		return;
-	}
-
-	switch (event.type) {
-		case FU.combatEvent.startOfCombat:
-		case FU.combatEvent.endOfCombat:
-			await promptExpiredEffectRemoval(event);
-			break;
-
-		case FU.combatEvent.startOfTurn:
-		case FU.combatEvent.endOfTurn:
-		case FU.combatEvent.endOfRound:
-			await manageEffectDuration(event);
-			break;
-	}
-}
-
-/**
  * @param {RestEvent} event
  * @returns {Promise<void>}
  */
@@ -969,7 +788,6 @@ const STATUS_EFFECTS = Object.freeze({ ...FU.temporaryEffects });
  * @description Initialize the pipeline's hooks
  */
 function initialize() {
-	Hooks.on(FUHooks.COMBAT_EVENT, onCombatEvent);
 	Hooks.on(FUHooks.REST_EVENT, onRestEvent);
 	Hooks.on('renderChatMessageHTML', onRenderChatMessage);
 }


### PR DESCRIPTION
This pull request refactors and improves the handling of temporary effects during combat and rest events. The main changes include moving the management of effect durations and reminders from the `effects.mjs` pipeline into the `automation.mjs` pipeline, expanding the options for clearing effects, and improving the logic for determining which effects to clear. The changes also introduce a more flexible predicate-based approach for effect removal and ensure that chat notifications are sent appropriately.

**Effect management and pipeline refactoring:**

* Moved combat effect management logic (`manageEffectDuration`, `promptExpiredEffectRemoval`, and `onCombatEvent`) from `module/pipelines/effects.mjs` to `module/pipelines/automation.mjs`, consolidating effect automation responsibilities and cleaning up the effects pipeline. [[1]](diffhunk://#diff-d6f9ea78b1515b652469949a35fd7bec87d9ee4e1c5ab6932690b6dc6e9abec6L3-R215) [[2]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL524-L680) [[3]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL926-L948) [[4]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fL972)

**Enhancements to effect clearing options:**

* Added new options to the `clearTemporaryEffects` method in `FUActor`, including a `rest` flag to control clearing effects on rest events and a `predicate` function for custom effect filtering. The default options were updated accordingly. [[1]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420R404-R405) [[2]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420R414) [[3]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420R454-R472)

**Logic improvements for effect removal:**

* Improved logic to ensure that only core status effects are checked for existence before removal and that rest-based effects are handled according to the new options. [[1]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420L431-R434) [[2]](diffhunk://#diff-efaf3b079d4b4ecbdcb7cb4a760eada889e35896c213a659256b0704d433f420R454-R472)

**Code cleanup and dependency updates:**

* Removed unused imports and updated dependencies in the affected files to reflect the new structure.

These changes make effect management more modular, flexible, and maintainable, while also providing more granular control over how and when effects are cleared during gameplay.