### PR TITLE
Allow invoking trait rerolling without FP

### DIFF
--- a/module/checks/check-reroll.mjs
+++ b/module/checks/check-reroll.mjs
@@ -27,7 +27,7 @@ function addRerollEntry(application, menuItems) {
 			const message = game.messages.get(messageId);
 			const flag = message?.getFlag(SYSTEM, Flags.ChatMessage.CheckV2);
 			const speakerActor = ChatMessage.getSpeakerActor(message?.speaker);
-			return message && message.isRoll && flag && speakerActor?.type === 'character' && !flag.fumble && speakerActor.system.resources.fp.value;
+			return message && message.isRoll && flag && speakerActor?.type === 'character' && !flag.fumble;
 		},
 		callback: async (li) => {
 			const messageId = li.dataset.messageId;
@@ -143,7 +143,7 @@ const getRerollParams = async (check, actor) => {
 
 				return {
 					trait: trait.value,
-					value: trait.dataset.value,
+					value: trait.dataset.value ?? '',
 					selection: selection,
 					ignoreFp: ignoreFp,
 				};

--- a/templates/dialog/dialog-check-reroll.hbs
+++ b/templates/dialog/dialog-check-reroll.hbs
@@ -1,38 +1,28 @@
 <fieldset class="resource-content">
 	<legend>{{localize 'FU.ChatContextRerollFabula'}}</legend>
 	{{#each traits}}
-		<fieldset>
-			<label class="checkbox">
-				<input type="radio" name="trait" value="{{this.type}}">
-				<span>{{localize (pfuConcat 'FU.' (pfuCapitalize this.type))}}:</span>
-				<strong class="trait">{{this.value}}</strong>
-			</label>
-		</fieldset>
+		<label class="checkbox">
+			<input type="radio" name="trait" value="{{this.type}}">
+			<span>{{localize (pfuConcat 'FU.' (pfuCapitalize this.type))}}:</span>
+			<strong class="trait">{{this.value}}</strong>
+		</label>
 	{{/each}}
 </fieldset>
 <fieldset class="resource-content flexrow">
 	<div class="flexrow">
 		<label class="checkbox">
 			<input type="checkbox" name="results" value="attr1" class="flex0">
-			<span class="roll-container">
-				<span class="roll">{{attr1.result}}</span>
-			</span>
-			<span>{{localize (pfuConcat 'FU.Attribute' (pfuCapitalize attr1.attribute))}}</span>
+			{{pfuIconAttribute attr1.attribute value=attr1.result}}
+		</label>
+		<label class="checkbox">
+			<input type="checkbox" name="results" value="attr2" class="flex0">
+			{{pfuIconAttribute attr2.attribute value=attr2.result}}
 		</label>
 	</div>
 	<div class="flexrow">
 		<label class="checkbox">
-			<input type="checkbox" name="results" value="attr2" class="flex0">
-			<span class="roll-container">
-				<span class="roll">{{attr2.result}}</span>
-			</span>
-			<span>{{localize (pfuConcat 'FU.Attribute' (pfuCapitalize attr2.attribute))}}</span>
+			<input type="checkbox" name="ignore-fp">
+			<span>{{localize 'FU.DialogIgnoreFPCost'}}</span>
 		</label>
 	</div>
-</fieldset>
-<fieldset class="resource-content">
-	<label class="checkbox">
-		<input type="checkbox" name="ignore-fp">
-		<span>{{localize 'FU.DialogIgnoreFPCost'}}</span>
-	</label>
 </fieldset>


### PR DESCRIPTION
This pull request updates the reroll check functionality and dialog UI, mainly improving the user interface and handling of reroll parameters. The most significant changes include simplifying the reroll eligibility logic, improving the dialog's attribute display, and ensuring safer handling of form values.

### Logic and Behavior Changes

* Removed the requirement that a character must have FP (Fabula Points) available to be eligible for a reroll, allowing rerolls even if FP is depleted.

* Ensured that the reroll dialog always provides a string value for the selected trait, defaulting to an empty string if not present, which prevents potential errors when submitting the dialog.

### UI and Template Improvements

* Refactored the `dialog-check-reroll.hbs` template to remove unnecessary fieldset wrappers and streamline the structure, making the markup cleaner and easier to maintain.

* Updated the attribute result display in the reroll dialog to use the `pfuIconAttribute` helper, providing a more visually consistent and user-friendly representation of attribute rolls.