### PR TITLE
Fix inactive mnemosphere item effects being transferred to actor

### DIFF
--- a/module/documents/items/item-behaviour-mixin.mjs
+++ b/module/documents/items/item-behaviour-mixin.mjs
@@ -45,7 +45,9 @@ export function ItemBehaviourMixin(BaseClass) {
 				for (let collection of Object.values(this.nestedCollections)) {
 					if (collection.documentClass === PseudoItem) {
 						for (let item of collection) {
-							effects.push(...item.transferredEffects);
+							if (this.system.transferNestedItem ? this.system.transferNestedItem(item) : true) {
+								effects.push(...item.transferredEffects);
+							}
 						}
 					}
 				}
@@ -60,10 +62,12 @@ export function ItemBehaviourMixin(BaseClass) {
 				yield effect;
 			}
 			for (let collection of Object.values(this.nestedCollections)) {
-				if (collection.documentClass === PseudoItem) {
+				if (foundry.utils.isSubclass(collection.documentClass, PseudoItem)) {
 					for (let item of collection) {
-						for (let effect of item.allEffects()) {
-							yield effect;
+						if (this.system.transferNestedItem ? this.system.transferNestedItem(item) : true) {
+							for (let effect of item.allEffects()) {
+								yield effect;
+							}
 						}
 					}
 				}

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -326,6 +326,18 @@ async function getTemporaryItem(effect) {
 }
 
 /**
+ * @param {FUActiveEffect} effect
+ * @returns {boolean}
+ */
+function canProcessEffect(effect) {
+	const disabled = effect.isSuppressed || effect.disabled;
+	if (disabled || effect.system.rules.elements.size === 0) {
+		return false;
+	}
+	return true;
+}
+
+/**
  * @param {String} type
  * @param {*} event
  * @param {CharacterInfo} source
@@ -342,8 +354,7 @@ async function evaluate(type, event, source, targets, data = undefined) {
 	const sceneCharacters = getSceneCharacters([source, ...targets]);
 	for (const character of sceneCharacters) {
 		for (const effect of character.actor.allEffects()) {
-			const disabled = effect.isSuppressed || effect.disabled;
-			if (disabled || effect.system.rules.elements.size === 0) {
+			if (!canProcessEffect(effect)) {
 				continue;
 			}
 			/** @type RuleElementContext **/


### PR DESCRIPTION
This pull request introduces improvements to how nested item effects are transferred and processed, as well as refactors effect processing logic for better clarity and maintainability. The most notable changes are the addition of a customizable hook for transferring nested item effects, improved subclass checking, and the extraction of effect processing logic into a dedicated helper function.

**Nested item effect transfer and processing:**

* Added a check to allow customization of whether a nested item's effects should be transferred using a `transferNestedItem` method on `this.system` in `ItemBehaviourMixin`. This enables more granular control over which nested item effects are included.
* Updated subclass checking for nested collections from a strict equality check to using `foundry.utils.isSubclass`, ensuring proper handling of subclasses of `PseudoItem` when processing nested item effects.

**Effect processing logic refactor:**

* Introduced a new helper function `canProcessEffect` in `rule-elements.mjs` to centralize and clarify the logic for determining if an effect should be processed (i.e., not suppressed/disabled and has rule elements).
* Refactored the main evaluation loop in `evaluate` to use the new `canProcessEffect` helper, improving code readability and maintainability.