### PR TITLE
Embed render data into damage / resource update events

### DIFF
--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -87,7 +87,7 @@ function attack(inspector, actor, item) {
  * @property {String} origin An id used to prevent cascading.
  */
 
-function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, origin, renderData) {
+async function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, origin, renderData) {
 	const source = CharacterInfo.fromActor(sourceActor);
 	const target = CharacterInfo.fromActor(targetActor);
 	const item = sourceInfo.resolveItem();
@@ -108,7 +108,7 @@ function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, orig
 		origin: origin,
 		renderData: renderData,
 	};
-	Hooks.call(FUHooks.DAMAGE_EVENT, damageEvent);
+	return AsyncHooks.callSequential(FUHooks.DAMAGE_EVENT, damageEvent);
 }
 
 /**
@@ -256,6 +256,7 @@ function loss(actor, resource, amount, origin) {
  * @property {CharacterInfo} source
  * @property {CharacterInfo[]} targets
  * @property {String} origin
+ * @property {FUChatData} renderData
  */
 
 /**
@@ -265,7 +266,7 @@ function loss(actor, resource, amount, origin) {
  * @param {Number} amount
  * @param {String} origin
  */
-function resource(sourceActor, targetActors, resource, amount, origin) {
+async function resource(sourceActor, targetActors, resource, amount, origin, renderData) {
 	const source = CharacterInfo.fromActor(sourceActor);
 	const targets = CharacterInfo.fromActors(targetActors);
 	/** @type ResourceUpdateEvent  **/
@@ -275,8 +276,9 @@ function resource(sourceActor, targetActors, resource, amount, origin) {
 		source: source,
 		targets: targets,
 		origin: origin,
+		renderData: renderData,
 	};
-	Hooks.call(FUHooks.RESOURCE_UPDATE, event);
+	return AsyncHooks.callSequential(FUHooks.RESOURCE_UPDATE, event);
 }
 
 /**

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -83,19 +83,11 @@ function attack(inspector, actor, item) {
  * @property {FUActor} actor
  * @property {Token} token
  * @property {Set<String>} traits
+ * @property {FUChatData} renderData
  * @property {String} origin An id used to prevent cascading.
  */
 
-/**
- * @description Dispatches an event to signal damage taken by an actor
- * @param {FU.damageTypes} type
- * @param {Number} amount
- * @param {Set<String>} traits
- * @param {FUActor} sourceActor
- * @param {FUActor} targetActor
- * @param {InlineSourceInfo} sourceInfo
- */
-function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, origin) {
+function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, origin, renderData) {
 	const source = CharacterInfo.fromActor(sourceActor);
 	const target = CharacterInfo.fromActor(targetActor);
 	const item = sourceInfo.resolveItem();
@@ -114,6 +106,7 @@ function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, orig
 		token: target.token,
 		traits: traits,
 		origin: origin,
+		renderData: renderData,
 	};
 	Hooks.call(FUHooks.DAMAGE_EVENT, damageEvent);
 }

--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -61,6 +61,7 @@ export class MessageRuleAction extends RuleActionDataModel {
 		// Message
 		const _message = this.message || StringUtils.localize('FU.RuleElementTriggered');
 		if (context.renderData && context.source) {
+			// TODO: Resolve actor for pseudo-documents too
 			const actor = context.source.actor !== context.character.actor ? context.item?.parent : null;
 			CommonSections.itemText(context.renderData, _message, actor, context.item, flags, CHECK_ADDENDUM_ORDER);
 		} else {

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -514,8 +514,9 @@ async function process(request) {
 					sections: [],
 					postRenderActions: [],
 				};
-				CommonEvents.damage(request.damageType, damageTaken, context.traits, context.sourceActor, actor, context.sourceInfo, request.origin, renderData);
 
+				await CommonEvents.damage(request.damageType, damageTaken, context.traits, context.sourceActor, actor, context.sourceInfo, request.origin, renderData);
+				await CommonEvents.resource(request.sourceActor, request.targets, resource, -damageTaken, request.origin, renderData);
 				TokenUtils.showFloatyText(actor, `${-damageTaken} ${resource.toUpperCase()}`, color);
 
 				// Chat message
@@ -559,7 +560,6 @@ async function process(request) {
 
 				return result; // keep the result from modifyTokenAttribute if needed
 			}),
-			CommonEvents.resource(request.sourceActor, request.targets, resource, -damageTaken, request.origin),
 		);
 
 		// OPTIONAL: If staggered

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -25,6 +25,7 @@ import { ChatAction } from '../helpers/chat-action.mjs';
 import { CommonSections } from '../checks/common-sections.mjs';
 import { CHECK_DETAILS } from '../checks/default-section-order.mjs';
 import { PressureSystem } from '../systems/pressure-system.mjs';
+import { FUChatBuilder } from '../helpers/chat-builder.mjs';
 
 /**
  * @typedef {"incomingDamage.all", "incomingDamage.air", "incomingDamage.bolt", "incomingDamage.dark", "incomingDamage.earth", "incomingDamage.fire", "incomingDamage.ice", "incomingDamage.light", "incomingDamage.poison"} DamagePipelineStepIncomingDamage
@@ -495,28 +496,6 @@ async function process(request) {
 			continue;
 		}
 
-		updates.push(
-			actor.modifyTokenAttribute(`resources.${resource}`, -damageTaken, true).then((result) => {
-				CommonEvents.damage(request.damageType, damageTaken, context.traits, context.sourceActor, actor, context.sourceInfo, request.origin);
-				return result; // keep the result from modifyTokenAttribute if needed
-			}),
-			CommonEvents.resource(request.sourceActor, request.targets, resource, -damageTaken, request.origin),
-		);
-
-		TokenUtils.showFloatyText(actor, `${-damageTaken} ${resource.toUpperCase()}`, color);
-
-		// Dispatch event
-		damageTaken = Math.abs(damageTaken);
-
-		// Chat message
-		const affinityMessage = await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/partials/inline-damage-icon.hbs', {
-			damage: damageTaken,
-			damageType: game.i18n.localize(FU.damageTypes[request.damageType]),
-			pressureTrigger: context.pressureTrigger,
-			icon: FU.affIcon[context.damageType],
-		});
-
-		// Additional content
 		let content = [];
 		/** @type PressureProcessResult **/
 		let pressureProcess;
@@ -527,34 +506,60 @@ async function process(request) {
 			}
 		}
 
-		let flags = Pipeline.initializedFlags(Flags.ChatMessage.Damage, damageTaken);
-		flags = Pipeline.setFlag(flags, Flags.ChatMessage.Source, context.sourceInfo);
-		const rootUuid = actor.resolveUuid();
-
+		// Dispatch damage event, which may end up modifying the damage message
 		updates.push(
-			ChatMessage.create({
-				speaker: ChatMessage.getSpeaker({ actor }),
-				flavor: game.i18n.localize(FU.affType[context.affinity]),
-				flags: flags,
-				content: await FoundryUtils.renderTemplate('chat/chat-apply-damage', {
-					message: context.affinityMessage,
-					actor: actor.name,
-					uuid: actor.uuid,
-					rootUuid: rootUuid,
-					inspect: actor.type === 'npc',
-					// TODO: Replace damage with amount in the localizations
+			actor.modifyTokenAttribute(`resources.${resource}`, -damageTaken, true).then(async (result) => {
+				/** @type FUChatData **/
+				let renderData = {
+					sections: [],
+					postRenderActions: [],
+				};
+				CommonEvents.damage(request.damageType, damageTaken, context.traits, context.sourceActor, actor, context.sourceInfo, request.origin, renderData);
+
+				TokenUtils.showFloatyText(actor, `${-damageTaken} ${resource.toUpperCase()}`, color);
+
+				// Chat message
+				damageTaken = Math.abs(damageTaken);
+				const chat = new FUChatBuilder(actor, request.item).withData(renderData);
+				let flags = Pipeline.initializedFlags(Flags.ChatMessage.Damage, damageTaken);
+				flags = Pipeline.setFlag(flags, Flags.ChatMessage.Source, context.sourceInfo);
+				chat.withFlags(flags);
+				const affinityMessage = await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/partials/inline-damage-icon.hbs', {
 					damage: damageTaken,
-					amount: damageTaken,
-					affinityMessage: affinityMessage,
-					content: content,
-					pressureContent: pressureProcess?.content,
-					from: request.sourceInfo.name,
-					sourceActorUuid: request.sourceInfo.actorUuid,
-					resource: resource.toUpperCase(),
-					sourceItemUuid: request.sourceInfo.itemUuid,
-					breakdown: context.breakdown,
-				}),
+					damageType: game.i18n.localize(FU.damageTypes[request.damageType]),
+					pressureTrigger: context.pressureTrigger,
+					icon: FU.affIcon[context.damageType],
+				});
+				CommonSections.template(
+					chat.sections,
+					'chat/chat-apply-damage',
+					{
+						message: context.affinityMessage,
+						actor: actor.name,
+						uuid: actor.uuid,
+						rootUuid: actor.resolveUuid(),
+						inspect: actor.type === 'npc',
+						// TODO: Replace damage with amount in the localizations
+						damage: damageTaken,
+						amount: damageTaken,
+						affinityMessage: affinityMessage,
+						content: content,
+						pressureContent: pressureProcess?.content,
+						from: request.sourceInfo.name,
+						sourceActorUuid: request.sourceInfo.actorUuid,
+						resource: resource.toUpperCase(),
+						sourceItemUuid: request.sourceInfo.itemUuid,
+						breakdown: context.breakdown,
+					},
+					CHECK_DETAILS,
+				);
+
+				chat.withFlavor(StringUtils.localize(FU.affType[context.affinity]));
+				await chat.create();
+
+				return result; // keep the result from modifyTokenAttribute if needed
 			}),
+			CommonEvents.resource(request.sourceActor, request.targets, resource, -damageTaken, request.origin),
 		);
 
 		// OPTIONAL: If staggered

--- a/module/pipelines/resource-pipeline.mjs
+++ b/module/pipelines/resource-pipeline.mjs
@@ -11,6 +11,9 @@ import { CheckHooks } from '../checks/check-hooks.mjs';
 import { CheckConfiguration } from '../checks/check-configuration.mjs';
 import { ChatAction } from '../helpers/chat-action.mjs';
 import { ExpressionContext, Expressions } from '../expressions/expressions.mjs';
+import { FUChatBuilder } from '../helpers/chat-builder.mjs';
+import { CommonSections } from '../checks/common-sections.mjs';
+import { CHECK_DETAILS } from '../checks/default-section-order.mjs';
 
 /**
  * @class
@@ -176,13 +179,45 @@ function calculateMissingResource(actor, resourcePath) {
 }
 
 /**
+ * @param request
+ * @param actor
+ * @param amount
+ * @param flavor
+ * @param message
+ * @param template
+ * @param renderData
+ * @returns {Promise<void>}
+ */
+async function createChatMessage(request, actor, amount, flavor, template, message, renderData) {
+	const chat = new FUChatBuilder(actor, request.item).withData(renderData).withFlags(Pipeline.initializedFlags(Flags.ChatMessage.ResourceGain, true)).withFlavor(flavor);
+	CommonSections.template(
+		chat.sections,
+		template,
+		{
+			message: message,
+			actor: actor.name,
+			uuid: actor.uuid,
+			amount: amount,
+			key: request.attributeKey,
+			resource: request.resourceType,
+			resourceLabel: request.resourceLabel,
+			from: request.sourceInfo.name,
+		},
+		CHECK_DETAILS,
+	);
+	return chat.create();
+}
+
+/**
  * @param {ResourceRequest} request
  * @return {Promise<Awaited<unknown>[]>}
  */
 async function processRecovery(request) {
-	const flavor = game.i18n.localize(recoveryFlavor[request.resourceType]);
 	const outgoingRecoveryBonus = request.sourceActor?.system.bonuses.outgoingRecovery[request.resourceType] || 0;
 	const outgoingRecoveryMultiplier = request.sourceActor?.system.multipliers.outgoingRecovery[request.resourceType] || 1;
+	const template = 'chat/chat-apply-recovery';
+	const message = recoveryMessages[request.resourceType];
+	const flavor = game.i18n.localize(recoveryFlavor[request.resourceType]);
 
 	const updates = [];
 	console.debug(`Applying recovery from request with traits: ${[...request.traits].join(', ')}`);
@@ -207,8 +242,16 @@ async function processRecovery(request) {
 				const newValue = Object.defineProperties({}, Object.getOwnPropertyDescriptors(attr));
 				newValue.value = uncappedRecoveryValue;
 				updates.push(
-					actor.modifyTokenAttribute(request.attributeKey, newValue, false, false).then((result) => {
-						CommonEvents.gain(actor, request.resourceType, amountRecovered, request.origin);
+					actor.modifyTokenAttribute(request.attributeKey, newValue, false, false).then(async (result) => {
+						/** @type FUChatData **/
+						let renderData = {
+							sections: [],
+							postRenderActions: [],
+						};
+						await CommonEvents.gain(actor, request.resourceType, amountRecovered, request.origin);
+						await CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, request.amount, request.origin, renderData);
+						await createChatMessage(request, actor, amountRecovered, flavor, template, message, renderData);
+						TokenUtils.showFloatyText(actor, `${amountRecovered} ${request.resourceType.toUpperCase()}`, `lightgreen`);
 						return result;
 					}),
 				);
@@ -230,33 +273,22 @@ async function processRecovery(request) {
 					continue;
 				}
 				updates.push(
-					actor.modifyTokenAttribute(request.attributeKey, amountRecovered, true).then((result) => {
+					actor.modifyTokenAttribute(request.attributeKey, amountRecovered, true).then(async (result) => {
+						/** @type FUChatData **/
+						let renderData = {
+							sections: [],
+							postRenderActions: [],
+						};
 						CommonEvents.gain(actor, request.resourceType, amountRecovered, request.origin);
+						await CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, request.amount, request.origin, renderData);
+						await createChatMessage(request, actor, amountRecovered, flavor, template, message, renderData);
+						TokenUtils.showFloatyText(actor, `${amountRecovered} ${request.resourceType.toUpperCase()}`, `lightgreen`);
 						return result;
 					}),
 				);
 			}
 		}
-		TokenUtils.showFloatyText(actor, `${amountRecovered} ${request.resourceType.toUpperCase()}`, `lightgreen`);
-		updates.push(
-			ChatMessage.create({
-				speaker: ChatMessage.getSpeaker({ actor }),
-				flavor: flavor,
-				flags: Pipeline.initializedFlags(Flags.ChatMessage.ResourceGain, true),
-				content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-apply-recovery.hbs', {
-					message: recoveryMessages[request.resourceType],
-					actor: actor.name,
-					uuid: actor.uuid,
-					amount: amountRecovered,
-					key: request.attributeKey,
-					resource: request.resourceType,
-					resourceLabel: request.resourceLabel,
-					from: request.sourceInfo.name,
-				}),
-			}),
-		);
 	}
-	updates.push(CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, request.amount, request.origin));
 	return Promise.all(updates);
 }
 
@@ -275,6 +307,8 @@ const lossFlavor = {
  */
 async function processLoss(request) {
 	const flavor = game.i18n.localize(lossFlavor[request.resourceType]);
+	const template = 'chat/chat-apply-loss';
+	const message = 'FU.ChatResourceLoss';
 
 	const updates = [];
 	console.debug(`Applying loss from request with traits: ${[...request.traits].join(', ')}`);
@@ -294,40 +328,36 @@ async function processLoss(request) {
 			const updateData = {};
 			updateData[`system.${request.attributeValuePath}`] = newValue;
 			updates.push(
-				actor.update(updateData).then((result) => {
+				actor.update(updateData).then(async (result) => {
+					/** @type FUChatData **/
+					let renderData = {
+						sections: [],
+						postRenderActions: [],
+					};
 					CommonEvents.loss(actor, request.resourceType, amountLost, request.origin);
+					await CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, amountLost, request.origin, renderData);
+					TokenUtils.showFloatyText(actor, `${amountLost} ${request.resourceType.toUpperCase()}`, `lightyellow`);
+					await createChatMessage(request, actor, Math.abs(amountLost), flavor, template, message, renderData);
 					return result;
 				}),
 			);
 		} else {
 			updates.push(
-				actor.modifyTokenAttribute(request.attributeKey, amountLost, true).then((result) => {
+				actor.modifyTokenAttribute(request.attributeKey, amountLost, true).then(async (result) => {
+					/** @type FUChatData **/
+					let renderData = {
+						sections: [],
+						postRenderActions: [],
+					};
 					CommonEvents.loss(actor, request.resourceType, amountLost, request.origin);
+					await CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, amountLost, request.origin, renderData);
+					TokenUtils.showFloatyText(actor, `${amountLost} ${request.resourceType.toUpperCase()}`, `lightyellow`);
+					await createChatMessage(request, actor, Math.abs(amountLost), flavor, template, message, renderData);
 					return result;
 				}),
 			);
 		}
-
-		TokenUtils.showFloatyText(actor, `${amountLost} ${request.resourceType.toUpperCase()}`, `lightyellow`);
-		updates.push(
-			ChatMessage.create({
-				speaker: ChatMessage.getSpeaker({ actor }),
-				flavor: flavor,
-				flags: Pipeline.initializedFlags(Flags.ChatMessage.ResourceLoss, true),
-				content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/chat/chat-apply-loss.hbs', {
-					message: 'FU.ChatResourceLoss',
-					actor: actor.name,
-					amount: Math.abs(amountLost),
-					uuid: actor.uuid,
-					key: request.attributeKey,
-					resource: request.resourceType,
-					resourceLabel: request.resourceLabel,
-					from: request.sourceInfo.name,
-				}),
-			}),
-		);
 	}
-	updates.push(CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, amount, request.origin));
 	return Promise.all(updates);
 }
 

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -128,6 +128,8 @@ async function onAttackEvent(event) {
 	await evaluate(FUHooks.ATTACK_EVENT, event, event.source, event.targets, event.check);
 }
 
+// TODO: Use the full FURenderData object, not just sections
+
 /**
  * @param {DamageEvent} event
  * @returns {Promise<void>}
@@ -143,7 +145,9 @@ async function onDamageEvent(event) {
  * @returns {Promise<void>}
  */
 async function onResourceEvent(event) {
-	await evaluate(FUHooks.RESOURCE_UPDATE, event, event.source, event.targets);
+	await evaluate(FUHooks.RESOURCE_UPDATE, event, event.source, event.targets, {
+		renderData: event.renderData.sections,
+	});
 }
 
 /**
@@ -306,22 +310,20 @@ function getSceneCharacters(targets) {
 }
 
 /** @type {FUItem | null} */
-let temporaryItem = null;
+//let temporaryItem = null;
 
 /**
  * @param {FUActiveEffect} effect
  * @returns {Promise<game.projectfu.FUItem|null>}
  */
 async function getTemporaryItem(effect) {
-	if (!temporaryItem) {
-		temporaryItem = await FUItem.create(
-			{
-				name: 'TemporaryItem',
-				type: 'rule',
-			},
-			{ temporary: true },
-		);
-	}
+	const temporaryItem = await FUItem.create(
+		{
+			name: 'TemporaryItem',
+			type: 'rule',
+		},
+		{ temporary: true },
+	);
 	temporaryItem.name = effect.name;
 	temporaryItem.img = effect.img;
 	return temporaryItem;
@@ -399,15 +401,14 @@ function initialize() {
 	Hooks.on(FUHooks.COMBAT_EVENT, onCombatEvent);
 	Hooks.on(FUHooks.ATTACK_EVENT, onAttackEvent);
 	Hooks.on(FUHooks.STATUS_EVENT, onStatusEvent);
-	Hooks.on(FUHooks.DAMAGE_EVENT, onDamageEvent);
-	Hooks.on(FUHooks.RESOURCE_UPDATE, onResourceEvent);
+	AsyncHooks.on(FUHooks.DAMAGE_EVENT, onDamageEvent);
+	AsyncHooks.on(FUHooks.RESOURCE_UPDATE, onResourceEvent);
 	Hooks.on(FUHooks.SPELL_EVENT, onSpellEvent);
 	Hooks.on(FUHooks.PERFORM_CHECK_EVENT, onPerformCheckEvent);
 	Hooks.on(FUHooks.RESOLVE_CHECK_EVENT, onResolveCheckEvent);
 	Hooks.on(FUHooks.NOTIFICATION_EVENT, onNotificationEvent);
 	Hooks.on(FUHooks.EFFECT_TOGGLED_EVENT, onEffectToggledEvent);
 	Hooks.on(FUHooks.CALCULATE_DAMAGE_EVENT, onCalculateDamageEvent);
-	//AsyncHooks.on(FUHooks.CALCULATE_DAMAGE_EVENT, onCalculateDamageEvent);
 	AsyncHooks.on(FUHooks.CALCULATE_RESOURCE_EVENT, onCalculateResourceEvent);
 	AsyncHooks.on(FUHooks.CALCULATE_EXPENSE_EVENT, onCalculateExpenseEvent);
 	AsyncHooks.on(FUHooks.RENDER_CHECK_EVENT, onRenderCheckEvent);

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -133,7 +133,9 @@ async function onAttackEvent(event) {
  * @returns {Promise<void>}
  */
 async function onDamageEvent(event) {
-	await evaluate(FUHooks.DAMAGE_EVENT, event, event.source, [CharacterInfo.fromActor(event.actor)]);
+	await evaluate(FUHooks.DAMAGE_EVENT, event, event.source, [CharacterInfo.fromActor(event.actor)], {
+		renderData: event.renderData.sections,
+	});
 }
 
 /**

--- a/templates/chat/chat-apply-damage.hbs
+++ b/templates/chat/chat-apply-damage.hbs
@@ -1,49 +1,51 @@
-<section>
-    {{{localize message actor=actor damage=damage amount=amount type=affinityMessage from=from resource=resource}}}.
-</section>
-
-{{#each content as |section|}}
+<main>
 	<section>
-		{{{section}}}
+		{{{localize message actor=actor damage=damage amount=amount type=affinityMessage from=from resource=resource}}}.
 	</section>
-{{/each}}
 
-<section style="margin-top: 4px; display: flex; justify-content: space-between; ">
-    <div>
-        <a data-action="revertDamage" data-uuid="{{uuid}}" data-amount="{{damage}}" data-resource="{{resource}}" data-tooltip="{{localize 'FU.ChatRevertDamage'}}">
-            <span class='fu-tag button flex-group-center' style="font-size: 1rem;"><i class="icon fas fa-undo"></i></span>
-        </a>
+	{{#each content as |section|}}
+		<section>
+			{{{section}}}
+		</section>
+	{{/each}}
 
-        <a data-action="toggleBreakdown" data-tooltip="{{localize 'FU.ChatToggleDamageBreakdown'}}">
-            <span class='fu-tag button flex-group-center' style="font-size: 1rem;"><i class="icon fa fa-info-circle"></i></span>
-        </a>
-
-		{{#if inspect}}
-			<a data-action="inspectActor" data-uuid="{{rootUuid}}" data-tooltip="{{localize 'FU.Inspect'}}">
-				<span class='fu-tag button flex-group-center' style="font-size: 1rem;"><i class="icon fa fa-search"></i></span>
+	<section style="margin-top: 4px; display: flex; justify-content: space-between; ">
+		<div>
+			<a data-action="revertDamage" data-uuid="{{uuid}}" data-amount="{{damage}}" data-resource="{{resource}}" data-tooltip="{{localize 'FU.ChatRevertDamage'}}">
+				<span class='fu-tag button flex-group-center' style="font-size: 1rem;"><i class="icon fas fa-undo"></i></span>
 			</a>
-		{{/if}}
-    </div>
-</section>
 
-<section id="breakdown" class="hidden">
-	<table class="table-compact">
-		<caption>{{localize 'FU.Breakdown'}}</caption>
-		<thead>
+			<a data-action="toggleBreakdown" data-tooltip="{{localize 'FU.ChatToggleDamageBreakdown'}}">
+				<span class='fu-tag button flex-group-center' style="font-size: 1rem;"><i class="icon fa fa-info-circle"></i></span>
+			</a>
+
+			{{#if inspect}}
+				<a data-action="inspectActor" data-uuid="{{rootUuid}}" data-tooltip="{{localize 'FU.Inspect'}}">
+					<span class='fu-tag button flex-group-center' style="font-size: 1rem;"><i class="icon fa fa-search"></i></span>
+				</a>
+			{{/if}}
+		</div>
+	</section>
+
+	<section id="breakdown" class="hidden">
+		<table class="table-compact">
+			<caption>{{localize 'FU.Breakdown'}}</caption>
+			<thead>
 			<tr>
 				<th>{{localize 'FU.Step'}}</th>
 				<th>{{localize 'FU.Effect'}}</th>
 				<th>{{localize 'FU.Total'}}</th>
 			</tr>
-		</thead>
-		<tbody>
-		{{#each breakdown}}
-			<tr>
-				<th>{{localize this.step}}</th>
-				<td>{{this.effect}}</td>
-				<td>{{this.total}}</td>
-			</tr>
-		{{/each}}
-		</tbody>
-	</table>
-</section>
+			</thead>
+			<tbody>
+			{{#each breakdown}}
+				<tr>
+					<th>{{localize this.step}}</th>
+					<td>{{this.effect}}</td>
+					<td>{{this.total}}</td>
+				</tr>
+			{{/each}}
+			</tbody>
+		</table>
+	</section>
+</main>


### PR DESCRIPTION
This pull request introduces a significant refactor to the event handling and chat message generation for damage and resource updates in the system. The main improvements include transitioning event dispatching to asynchronous hooks, integrating richer render data for chat messages, and consolidating chat message creation logic for both damage and resource pipelines. These changes enhance extensibility, improve chat output quality, and ensure consistent handling of events and UI feedback.

**Event Handling Refactor and Asynchronous Processing**

* Converted `damage` and `resource` event dispatch functions in `module/checks/common-events.mjs` to asynchronous, allowing sequential async processing via `AsyncHooks.callSequential`. Both events now include a `renderData` property for richer chat message integration. [[1]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R86-R90) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R109-R111) [[3]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R259) [[4]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L275-R269) [[5]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R279-R281)

* Updated event listeners in `module/pipelines/rule-elements.mjs` to use `AsyncHooks.on` for `DAMAGE_EVENT` and `RESOURCE_UPDATE`, and to pass `renderData.sections` to rule evaluation. [[1]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484L400-L408) [[2]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R131-R150)

**Chat Message Generation Improvements**

* Refactored the damage pipeline (`module/pipelines/damage-pipeline.mjs`) to build chat messages using the new `FUChatBuilder` and `renderData`, ensuring chat content is assembled after event processing and includes all relevant sections. Floaty text and affinity messages are shown after event hooks complete. [[1]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL498-L519) [[2]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bR509-R541) [[3]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL556-R561) [[4]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bR28)

* Refactored the resource pipeline (`module/pipelines/resource-pipeline.mjs`) to use a unified `createChatMessage` function with `FUChatBuilder`, passing `renderData` and template information. Floaty text and chat messages are now created after event hooks, ensuring extensibility and consistency. [[1]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8R181-R220) [[2]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8L210-R254) [[3]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8L233-L259) [[4]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8R310-R311) [[5]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8L297-L330) [[6]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8R14-R16)

**Template and UI Enhancements**

* Updated `chat-apply-damage.hbs` template to wrap content in a `<main>` tag, improving semantic structure. [[1]](diffhunk://#diff-e1b3548dcb9c7bb0398d960d1f331412342296dbe78e0b50aa371c251ffdcdbaR1) [[2]](diffhunk://#diff-e1b3548dcb9c7bb0398d960d1f331412342296dbe78e0b50aa371c251ffdcdbaR51)

**Miscellaneous**

* Minor improvements to rule action message handling and temporary item creation for effects. [[1]](diffhunk://#diff-bdfa4644499f292b4b5082e88dd58b921879a7f9369952b5236924a1c0bd1297R64) [[2]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484L307-L322)

<img width="383" height="436" alt="image" src="https://github.com/user-attachments/assets/5ce663d6-cba3-4a23-87e6-bc368817e885" />
