### PR TITLE
Add identifier support for calculate damage, calculate expense

### DIFF
--- a/module/documents/effects/rule-element-context.mjs
+++ b/module/documents/effects/rule-element-context.mjs
@@ -61,11 +61,30 @@ export class RuleElementContext {
 				if (item.system.fuid === id) {
 					return true;
 				}
-				if (item.name === id) {
+				if (item.name.toLowerCase() === id.toLowerCase()) {
 					return true;
 				}
 			}
 		}
+		return false;
+	}
+
+	/**
+	 * @return {Boolean} True if the item in the event is that of the item the rule element is attached to.
+	 */
+	isLocalItem() {
+		if (!this.item || !this.sourceInfo?.itemUuid) {
+			return false;
+		}
+
+		if (this.event.sourceInfo) {
+			return this.event.sourceInfo.itemUuid === this.sourceInfo.itemUuid;
+		}
+
+		if (this.event.item) {
+			return this.event.item.uuid === this.sourceInfo.itemUuid;
+		}
+
 		return false;
 	}
 

--- a/module/documents/effects/rule-element-context.mjs
+++ b/module/documents/effects/rule-element-context.mjs
@@ -41,7 +41,7 @@ export class RuleElementContext {
 	}
 
 	/**
-	 * @param {String} id
+	 * @param {String} id An identifier to match against.
 	 * @return {Boolean}
 	 */
 	matchesItem(id) {

--- a/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
@@ -10,6 +10,7 @@ const fields = foundry.data.fields;
  * @property {Set<FUItemGroup>} damageSources
  * @property {Set<DamageType>} damageTypes
  * @property {String} identifier
+ * @property {Boolean} local
  * @inheritDoc
  */
 export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
@@ -30,6 +31,7 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 			damageSources: new fields.SetField(new fields.StringField()),
 			damageTypes: new fields.SetField(new fields.StringField()),
 			identifier: new fields.StringField(),
+			local: new fields.BooleanField(),
 		});
 		return schema;
 	}
@@ -55,6 +57,11 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 		}
 		if (this.identifier) {
 			if (!context.matchesItem(this.identifier)) {
+				return false;
+			}
+		}
+		if (this.local && context.item) {
+			if (context.event.sourceInfo.itemUuid !== context.sourceInfo.itemUuid) {
 				return false;
 			}
 		}

--- a/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
@@ -60,8 +60,8 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 				return false;
 			}
 		}
-		if (this.local && context.item) {
-			if (context.event.sourceInfo.itemUuid !== context.sourceInfo.itemUuid) {
+		if (this.local) {
+			if (!context.isLocalItem()) {
 				return false;
 			}
 		}

--- a/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
@@ -9,6 +9,7 @@ const fields = foundry.data.fields;
  * @extends RuleTriggerDataModel
  * @property {Set<FUItemGroup>} damageSources
  * @property {Set<DamageType>} damageTypes
+ * @property {String} identifier
  * @inheritDoc
  */
 export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
@@ -28,6 +29,7 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 		const schema = Object.assign(super.defineSchema(), {
 			damageSources: new fields.SetField(new fields.StringField()),
 			damageTypes: new fields.SetField(new fields.StringField()),
+			identifier: new fields.StringField(),
 		});
 		return schema;
 	}
@@ -50,6 +52,11 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 		}
 		if (this.damageTypes.size > 0 && !this.damageTypes.has(context.event.type)) {
 			return false;
+		}
+		if (this.identifier) {
+			if (!context.matchesItem(this.identifier)) {
+				return false;
+			}
 		}
 		return true;
 	}

--- a/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
@@ -12,6 +12,7 @@ const fields = foundry.data.fields;
  * @extends RuleTriggerDataModel
  * @property {FUResourceType} resource
  * @property {FUExpenseSource} expenseSource
+ * @property {String} identifier
  * @property {TraitsPredicateDataModel} traits
  * @inheritDoc
  */
@@ -40,6 +41,7 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 				choices: Object.keys(FU.expenseSource),
 				blank: true,
 			}),
+			identifier: new fields.StringField(),
 			traits: new fields.EmbeddedDataField(TraitsPredicateDataModel, {
 				options: TraitUtils.getOptions(FeatureTraits),
 			}),
@@ -73,6 +75,11 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 		}
 		if (!this.traits.evaluate(context.event.expense.traits)) {
 			return false;
+		}
+		if (this.identifier) {
+			if (!context.matchesItem(this.identifier)) {
+				return false;
+			}
 		}
 		return true;
 	}

--- a/module/documents/effects/triggers/initialize-check-rule-trigger.mjs
+++ b/module/documents/effects/triggers/initialize-check-rule-trigger.mjs
@@ -60,8 +60,8 @@ export class InitializeCheckRuleTrigger extends RuleTriggerDataModel {
 		}
 
 		// If this RE is on an item, and it doesn't match the item in the event.
-		if (this.local && context.item) {
-			if (context.event.sourceInfo.itemUuid !== context.sourceInfo.itemUuid) {
+		if (this.local) {
+			if (!context.isLocalItem()) {
 				return false;
 			}
 		}

--- a/module/documents/effects/triggers/render-check-rule-trigger.mjs
+++ b/module/documents/effects/triggers/render-check-rule-trigger.mjs
@@ -62,8 +62,8 @@ export class RenderCheckRuleTrigger extends RuleTriggerDataModel {
 		}
 
 		// If this RE is on an item, and it doesn't match the item in the event.
-		if (this.local && context.item) {
-			if (context.event.sourceInfo.itemUuid !== context.sourceInfo.itemUuid) {
+		if (this.local) {
+			if (!context.isLocalItem()) {
 				return false;
 			}
 		}

--- a/module/documents/effects/triggers/render-check-rule-trigger.mjs
+++ b/module/documents/effects/triggers/render-check-rule-trigger.mjs
@@ -6,7 +6,7 @@ const fields = foundry.data.fields;
 
 /**
  * @extends RuleTriggerDataModel
- * @property {String} identifier The id of an Item to match.
+ * @property {String} identifier The id of an item to match.
  * @property {Set<CheckType>} checkTypes
  * @property {Set<FUItemGroup>} itemGroups
  * @property {Boolean} local
@@ -68,8 +68,11 @@ export class RenderCheckRuleTrigger extends RuleTriggerDataModel {
 			}
 		}
 
+		// Check identifier
 		if (this.identifier) {
-			return context.matchesItem(this.identifier);
+			if (!context.matchesItem(this.identifier)) {
+				return false;
+			}
 		}
 		return true;
 	}

--- a/templates/effects/triggers/calculate-damage-rule-trigger.hbs
+++ b/templates/effects/triggers/calculate-damage-rule-trigger.hbs
@@ -12,3 +12,8 @@
 	<span>{{localize 'FU.Identifier'}}</span>
 	<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
 </label>
+
+<div class="fu-rule-element__property">
+	<span>{{localize 'FU.Local'}}</span>
+	{{formGroup trigger.schema.fields.local value=trigger.local name=(pfuConcat path ".local") }}
+</div>

--- a/templates/effects/triggers/calculate-damage-rule-trigger.hbs
+++ b/templates/effects/triggers/calculate-damage-rule-trigger.hbs
@@ -8,12 +8,14 @@
 	{{formGroup trigger.schema.fields.damageTypes value=trigger.damageTypes options=options.damageTypeOptions name=(pfuConcat path ".damageTypes") classes="fu-rule-element__set stacked"}}
 </label>
 
-<label class="fu-rule-element__property">
-	<span>{{localize 'FU.Identifier'}}</span>
-	<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
-</label>
+<div class="fu-rule-element__property-row">
+	<div class="fu-rule-element__property">
+		<span>{{localize 'FU.Local'}}</span>
+		{{formGroup trigger.schema.fields.local value=trigger.local name=(pfuConcat path ".local") }}
+	</div>
 
-<div class="fu-rule-element__property">
-	<span>{{localize 'FU.Local'}}</span>
-	{{formGroup trigger.schema.fields.local value=trigger.local name=(pfuConcat path ".local") }}
+	<label class="fu-rule-element__property">
+		<span>{{localize 'FU.Identifier'}}</span>
+		<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
+	</label>
 </div>

--- a/templates/effects/triggers/calculate-damage-rule-trigger.hbs
+++ b/templates/effects/triggers/calculate-damage-rule-trigger.hbs
@@ -7,3 +7,8 @@
 	<span>{{localize 'FU.DamageType'}}</span>
 	{{formGroup trigger.schema.fields.damageTypes value=trigger.damageTypes options=options.damageTypeOptions name=(pfuConcat path ".damageTypes") classes="fu-rule-element__set stacked"}}
 </label>
+
+<label class="fu-rule-element__property">
+	<span>{{localize 'FU.Identifier'}}</span>
+	<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
+</label>

--- a/templates/effects/triggers/calculate-expense-rule-trigger.hbs
+++ b/templates/effects/triggers/calculate-expense-rule-trigger.hbs
@@ -13,4 +13,10 @@
 	</select>
 </label>
 
+<label class="fu-rule-element__property">
+	<span>{{localize 'FU.Identifier'}}</span>
+	<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
+</label>
+
 {{pfuTraits trigger.traits (pfuConcat path ".traits")}}
+

--- a/templates/effects/triggers/render-check-rule-trigger.hbs
+++ b/templates/effects/triggers/render-check-rule-trigger.hbs
@@ -8,12 +8,15 @@
 	{{formGroup trigger.schema.fields.itemGroups value=trigger.itemGroups options=options.itemGroupOptions name=(pfuConcat path ".itemGroups") classes="fu-rule-element__set stacked"}}
 </div>
 
-<label class="fu-rule-element__property">
-	<span>{{localize 'FU.Identifier'}}</span>
-	<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
-</label>
+<div class="fu-rule-element__property-row">
+	<div class="fu-rule-element__property">
+		<span>{{localize 'FU.Local'}}</span>
+		{{formGroup trigger.schema.fields.local value=trigger.local name=(pfuConcat path ".local") }}
+	</div>
 
-<div class="fu-rule-element__property">
-	<span>{{localize 'FU.Local'}}</span>
-	{{formGroup trigger.schema.fields.local value=trigger.local name=(pfuConcat path ".local") }}
+	<label class="fu-rule-element__property">
+		<span>{{localize 'FU.Identifier'}}</span>
+		<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
+	</label>
 </div>
+


### PR DESCRIPTION
This pull request enhances the flexibility and consistency of rule triggers by improving how items are matched in various triggers and by refining the UI for configuring these triggers. The main improvements include making item identifier matching case-insensitive, introducing a reusable method to determine if an event is local to the rule's item, and exposing new configuration options in the UI for specifying item identifiers and local matching.

**Rule Trigger Logic Improvements:**

* Made the `matchesItem` method in `RuleElementContext` perform case-insensitive matching for item names, allowing for more robust identifier comparison.
* Added a new `isLocalItem` method to `RuleElementContext` to standardize and simplify checks for whether the event's item matches the rule element's attached item. This method is now used in multiple triggers to determine "local" context. [[1]](diffhunk://#diff-a4dd45039af90babd14628a40003e27f206997feb3e7380f82b6d0afef7c1d4cL64-R90) [[2]](diffhunk://#diff-f81bfcba1551c306e494a762888fcbb8880e5f59a32c0c63710f417f46101266L63-R64) [[3]](diffhunk://#diff-7eadcd861d589e27c7920389cd034d54b6f686f77f910d867962b207f97676c6L65-R75)
* Updated `CalculateDamageRuleTrigger`, `CalculateExpenseRuleTrigger`, and `RenderCheckRuleTrigger` to support an `identifier` property for matching specific items, and a `local` property for restricting triggers to the originating item. The logic for these checks now uses the improved context methods. [[1]](diffhunk://#diff-bd1170de739958d13641dfc457f1d455c293029e80e93472f609f3380b52fc61R12-R13) [[2]](diffhunk://#diff-bd1170de739958d13641dfc457f1d455c293029e80e93472f609f3380b52fc61R33-R34) [[3]](diffhunk://#diff-bd1170de739958d13641dfc457f1d455c293029e80e93472f609f3380b52fc61R58-R67) [[4]](diffhunk://#diff-c8b50dc47133649c16ff0e7d52b0c6fb84d98b643a140fd347d7d1d045c5815cR15) [[5]](diffhunk://#diff-c8b50dc47133649c16ff0e7d52b0c6fb84d98b643a140fd347d7d1d045c5815cR44) [[6]](diffhunk://#diff-c8b50dc47133649c16ff0e7d52b0c6fb84d98b643a140fd347d7d1d045c5815cR79-R83) [[7]](diffhunk://#diff-7eadcd861d589e27c7920389cd034d54b6f686f77f910d867962b207f97676c6L9-R9) [[8]](diffhunk://#diff-7eadcd861d589e27c7920389cd034d54b6f686f77f910d867962b207f97676c6L65-R75)

**User Interface Enhancements:**

* Updated the Handlebars templates (`calculate-damage-rule-trigger.hbs`, `calculate-expense-rule-trigger.hbs`, `render-check-rule-trigger.hbs`) to add form fields for the new `identifier` and `local` properties, making these options configurable via the UI. [[1]](diffhunk://#diff-b4ad863c29d9c9623f23e5ad90fa251f14fe20b34ba2b389b8e8b61c2594dea2R10-R21) [[2]](diffhunk://#diff-6993cea8fa9d6f9173a46ca507ae0efe354b78291517f788c062b5929146c87fR16-R22) [[3]](diffhunk://#diff-762e02d55f3f888e253e8f773eb9ca46ba8a2a61740e1c974399a1d94a6adbdfR11-R22)

**Documentation and Comments:**

* Improved JSDoc comments for better clarity, especially regarding the purpose of the `identifier` and `local` properties in trigger classes. [[1]](diffhunk://#diff-a4dd45039af90babd14628a40003e27f206997feb3e7380f82b6d0afef7c1d4cL44-R44) [[2]](diffhunk://#diff-7eadcd861d589e27c7920389cd034d54b6f686f77f910d867962b207f97676c6L9-R9)

These changes collectively make rule triggers more powerful and easier to configure, while also improving code maintainability by centralizing matching logic.