### PR TITLE
Compendium Updates for Heroic Skills + Spells

### DIFF
--- a/src/packs/game-master/effect_Effect__Shell_60Gs2LnMIy6uPGhK.json
+++ b/src/packs/game-master/effect_Effect__Shell_60Gs2LnMIy6uPGhK.json
@@ -1,10 +1,11 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "kumybsJQq2dMThg5",
+  "name": "Effect: Shell",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "_id": "60Gs2LnMIy6uPGhK",
+  "img": "icons/magic/defensive/barrier-shield-dome-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-shell",
     "cost": {
       "value": 0
     },
@@ -12,8 +13,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Shell",
+      "img": "icons/magic/defensive/barrier-shield-dome-pink.webp",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -33,8 +34,7 @@
             "name": "",
             "current": 0,
             "max": 6,
-            "style": "basic",
-            "step": 1
+            "style": "basic"
           }
         }
       },
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "IL48sEc38UMJ2sM0",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
+          "key": "system.affinities.physical",
           "mode": 0,
           "value": "upgrade",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you gain Resistance to <strong>physical </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -68,12 +68,18 @@
         "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "createdTime": 1771280543484,
+        "modifiedTime": 1771280819060,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!60Gs2LnMIy6uPGhK.IL48sEc38UMJ2sM0"
     }
   ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mA8SNY2rY4X5tOHa": 3
+  },
   "flags": {},
   "_stats": {
     "compendiumSource": null,
@@ -82,15 +88,9 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280533277,
+    "modifiedTime": 1771280541194,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
-  "ownership": {
-    "default": 0,
-    "mA8SNY2rY4X5tOHa": 3
-  },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_key": "!items!60Gs2LnMIy6uPGhK"
 }

--- a/src/packs/game-master/effect_Effect__War_Cry_aKy3uZj38HTEBtG1.json
+++ b/src/packs/game-master/effect_Effect__War_Cry_aKy3uZj38HTEBtG1.json
@@ -1,10 +1,11 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "kumybsJQq2dMThg5",
+  "name": "Effect: War Cry",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "_id": "aKy3uZj38HTEBtG1",
+  "img": "icons/sundries/flags/banner-flag-red-white.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-war-cry",
     "cost": {
       "value": 0
     },
@@ -12,8 +13,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "War Cry",
+      "img": "icons/sundries/flags/banner-flag-red-white.webp",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -33,8 +34,7 @@
             "name": "",
             "current": 0,
             "max": 6,
-            "style": "basic",
-            "step": 1
+            "style": "basic"
           }
         }
       },
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "ADR6O0kN9j1HNY72",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.accuracy.accuracyCheck",
+          "mode": 2,
+          "value": "1",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, each target gains a +1 bonus to Accuracy Checks.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -68,12 +68,18 @@
         "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "createdTime": 1771280683878,
+        "modifiedTime": 1771280828265,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!aKy3uZj38HTEBtG1.ADR6O0kN9j1HNY72"
     }
   ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mA8SNY2rY4X5tOHa": 3
+  },
   "flags": {},
   "_stats": {
     "compendiumSource": null,
@@ -82,15 +88,9 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280650830,
+    "modifiedTime": 1771280681456,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
-  "ownership": {
-    "default": 0,
-    "mA8SNY2rY4X5tOHa": 3
-  },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_key": "!items!aKy3uZj38HTEBtG1"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Air__F7vItVCE5aVZjgG7.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Air__F7vItVCE5aVZjgG7.json
@@ -1,10 +1,11 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Air)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "_id": "F7vItVCE5aVZjgG7",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-air",
     "cost": {
       "value": 0
     },
@@ -12,8 +13,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Air)",
+      "img": "systems/projectfu/styles/static/affinities/icons/air.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -33,8 +34,7 @@
             "name": "",
             "current": 0,
             "max": 6,
-            "style": "basic",
-            "step": 1
+            "style": "basic"
           }
         }
       },
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.air",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>air</strong> damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -68,12 +68,18 @@
         "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "createdTime": 1771280762676,
+        "modifiedTime": 1771281112440,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!F7vItVCE5aVZjgG7.BdTKt9mxqBDGbnAR"
     }
   ],
+  "sort": 100000,
+  "ownership": {
+    "default": 0,
+    "mA8SNY2rY4X5tOHa": 3
+  },
   "flags": {},
   "_stats": {
     "compendiumSource": null,
@@ -82,15 +88,9 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280746348,
+    "modifiedTime": 1771280839488,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
-  "ownership": {
-    "default": 0,
-    "mA8SNY2rY4X5tOHa": 3
-  },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_key": "!items!F7vItVCE5aVZjgG7"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Bolt__3u8TxdveQgM4THLr.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Bolt__3u8TxdveQgM4THLr.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Bolt)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-bolt",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Bolt)",
+      "img": "systems/projectfu/styles/static/affinities/icons/bolt.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.bolt",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>bolt </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281144696
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!3u8TxdveQgM4THLr.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280837774,
+    "modifiedTime": 1771280861381,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "3u8TxdveQgM4THLr",
+  "sort": 300000,
+  "_key": "!items!3u8TxdveQgM4THLr"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Dark__l9D9CW5snjAFoWxw.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Dark__l9D9CW5snjAFoWxw.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Dark)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-dark",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Dark)",
+      "img": "systems/projectfu/styles/static/affinities/icons/dark.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.dark",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>dark </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281169661
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!l9D9CW5snjAFoWxw.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280839468,
+    "modifiedTime": 1771280883026,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "l9D9CW5snjAFoWxw",
+  "sort": 200000,
+  "_key": "!items!l9D9CW5snjAFoWxw"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Earth__3arDuXneGG264kpd.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Earth__3arDuXneGG264kpd.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Earth)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-earth",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Earth)",
+      "img": "systems/projectfu/styles/static/affinities/icons/earth.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.earth",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>earth </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281182640
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!3arDuXneGG264kpd.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280841357,
+    "modifiedTime": 1771280913656,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "3arDuXneGG264kpd",
+  "sort": 0,
+  "_key": "!items!3arDuXneGG264kpd"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Fire__U91NHOxpVmtqN7Pd.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Fire__U91NHOxpVmtqN7Pd.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Fire)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-fire",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Fire)",
+      "img": "systems/projectfu/styles/static/affinities/icons/fire.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.fire",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>fire </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281196021
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!U91NHOxpVmtqN7Pd.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280843178,
+    "modifiedTime": 1771280939404,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "U91NHOxpVmtqN7Pd",
+  "sort": 0,
+  "_key": "!items!U91NHOxpVmtqN7Pd"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Ice__MSU4wyOjHh7X29oJ.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Ice__MSU4wyOjHh7X29oJ.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Ice)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-ice",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Ice)",
+      "img": "systems/projectfu/styles/static/affinities/icons/ice.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.ice",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>ice </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281204746
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!MSU4wyOjHh7X29oJ.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280845111,
+    "modifiedTime": 1771280985430,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "MSU4wyOjHh7X29oJ",
+  "sort": 0,
+  "_key": "!items!MSU4wyOjHh7X29oJ"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Light__gJaiSQQKpyl79uEM.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Light__gJaiSQQKpyl79uEM.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Light)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-light",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Light)",
+      "img": "systems/projectfu/styles/static/affinities/icons/light.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.light",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>light</strong> damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281214880
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!gJaiSQQKpyl79uEM.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280847040,
+    "modifiedTime": 1771281011153,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "gJaiSQQKpyl79uEM",
+  "sort": 0,
+  "_key": "!items!gJaiSQQKpyl79uEM"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Physical__TBaMhx4AMwamseGE.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Physical__TBaMhx4AMwamseGE.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Physical)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-physical",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Physical)",
+      "img": "systems/projectfu/styles/static/affinities/icons/physical.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.physical",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>physical </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281225367
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!TBaMhx4AMwamseGE.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280850216,
+    "modifiedTime": 1771281037474,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "TBaMhx4AMwamseGE",
+  "sort": 0,
+  "_key": "!items!TBaMhx4AMwamseGE"
 }

--- a/src/packs/game-master/effect_Effect__Weaken__Poison__I6AH3hPvNHDqFggI.json
+++ b/src/packs/game-master/effect_Effect__Weaken__Poison__I6AH3hPvNHDqFggI.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "qtilkg7wFw1xG6Pb",
+  "name": "Effect: Weaken (Poison)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/unholy/strike-hand-glow-pink.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-weaken-poison",
     "cost": {
       "value": 0
     },
@@ -12,8 +12,8 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Weaken (Poison)",
+      "img": "systems/projectfu/styles/static/affinities/icons/poison.png",
       "system": {
         "duration": {
           "event": "endOfScene",
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "BdTKt9mxqBDGbnAR",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
-          "mode": 0,
-          "value": "upgrade",
+          "key": "system.bonuses.incomingDamage.poison",
+          "mode": 2,
+          "value": "5",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you suffer 5 extra damage from all sources that deal <strong>poison </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771281237109
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!I6AH3hPvNHDqFggI.BdTKt9mxqBDGbnAR"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771280851512,
+    "modifiedTime": 1771281067171,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "I6AH3hPvNHDqFggI",
+  "sort": 0,
+  "_key": "!items!I6AH3hPvNHDqFggI"
 }

--- a/src/packs/game-master/folders_Effects_kumybsJQq2dMThg5.json
+++ b/src/packs/game-master/folders_Effects_kumybsJQq2dMThg5.json
@@ -1,0 +1,22 @@
+{
+  "type": "Item",
+  "folder": "PpBzAnM7EK75ayIT",
+  "name": "Effects",
+  "color": "#5b2e0b",
+  "sorting": "a",
+  "_id": "kumybsJQq2dMThg5",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
+    "modifiedTime": 1771280500125
+  },
+  "_key": "!folders!kumybsJQq2dMThg5"
+}

--- a/src/packs/game-master/folders_Weaken_qtilkg7wFw1xG6Pb.json
+++ b/src/packs/game-master/folders_Weaken_qtilkg7wFw1xG6Pb.json
@@ -1,0 +1,21 @@
+{
+  "type": "Item",
+  "folder": "kumybsJQq2dMThg5",
+  "name": "Weaken",
+  "color": null,
+  "sorting": "a",
+  "_id": "qtilkg7wFw1xG6Pb",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!qtilkg7wFw1xG6Pb"
+}

--- a/src/packs/game-master/spell_Area_Status_1JaRWZz48d1dtVN0.json
+++ b/src/packs/game-master/spell_Area_Status_1JaRWZz48d1dtVN0.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>Every enemy you can see suffers <strong>(choose one: dazed, shaken, slow, weak)</strong>.</p><hr /><ul><li><p><strong>Targets Suffers:</strong> @EFFECT[dazed], @EFFECT[shaken], @EFFECT[slow], or @EFFECT[weak]</p></li></ul>",
+    "description": "<p>Every enemy you can see suffers <strong>(choose one: dazed, shaken, slow, weak)</strong>.</p>",
     "class": {
       "value": "NPC"
     },
@@ -104,7 +104,12 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "dazed",
+        "shaken",
+        "slow",
+        "weak"
+      ]
     },
     "targeting": {
       "rule": "special",
@@ -125,7 +130,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280289359,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Curse_XL_S291phTQNL0qbGYa.json
+++ b/src/packs/game-master/spell_Curse_XL_S291phTQNL0qbGYa.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>The target suffers (<strong>choose two: dazed, shaken, slow, weak</strong>).</p><hr /><ul><li><p><strong>Target Suffers:</strong> @EFFECT[dazed], @EFFECT[shaken], @EFFECT[slow], or @EFFECT[weak]</p></li></ul>",
+    "description": "<p>The target suffers (<strong>choose two: dazed, shaken, slow, weak</strong>).</p>",
     "class": {
       "value": "NPC"
     },
@@ -108,21 +108,29 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "dazed",
+        "shaken",
+        "slow",
+        "weak"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280348762,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Curse_rEWv1yWQHse3soqn.json
+++ b/src/packs/game-master/spell_Curse_rEWv1yWQHse3soqn.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>The target suffers (<strong>choose one: dazed, shaken, slow, weak</strong>).</p><hr /><ul><li><p><strong>Target Suffers:</strong> @EFFECT[dazed], @EFFECT[shaken], @EFFECT[slow], or @EFFECT[weak]</p></li></ul>",
+    "description": "<p>The target suffers (<strong>choose one: dazed, shaken, slow, weak</strong>).</p>",
     "class": {
       "value": "NPC"
     },
@@ -108,21 +108,29 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "dazed",
+        "shaken",
+        "slow",
+        "weak"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280326775,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Cursed_Breath_e5IBMtSXDyfWo0kb.json
+++ b/src/packs/game-master/spell_Cursed_Breath_e5IBMtSXDyfWo0kb.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>The target suffers <strong>【HR + 15】</strong> <strong>(choose type)</strong> damage and suffers <strong>(choose one: dazed, shaken, slow, weak)</strong>.</p><hr /><ul><li><p><strong>Target Suffers:</strong> @EFFECT[dazed], @EFFECT[shaken], @EFFECT[slow], or @EFFECT[weak]</p></li></ul>",
+    "description": "<p>The target suffers <strong>【HR + 15】</strong> <strong>(choose type)</strong> damage and suffers <strong>(choose one: dazed, shaken, slow, weak)</strong>.</p>",
     "class": {
       "value": "NPC"
     },
@@ -108,21 +108,29 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "dazed",
+        "shaken",
+        "slow",
+        "weak"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280369566,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Lick_Wounds_Up14pnEa8pWzGkDD.json
+++ b/src/packs/game-master/spell_Lick_Wounds_Up14pnEa8pWzGkDD.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>You recover 20 Hit Points. This amount increases to 30 Hit Points if you are <strong>level 20 or higher</strong>, to 40 Hit Points if you are <strong>level 40 or higher</strong>, or to 50 Hit Points if you are <strong>level 60</strong> or higher.</p>",
+    "description": "<p>You recover 20 Hit Points.</p><p>This amount increases to 30 Hit Points if you are <strong>level 20 or higher</strong>, to 40 Hit Points if you are <strong>level 40 or higher</strong>, or to 50 Hit Points if you are <strong>level 60</strong> or higher.</p>",
     "class": {
       "value": "NPC"
     },
@@ -125,7 +125,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280402888,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Poison_PYXh4QmqJDiA2tqy.json
+++ b/src/packs/game-master/spell_Poison_PYXh4QmqJDiA2tqy.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>Each target hit by this spell suffers @EFFECT[poisoned].</p>",
+    "description": "<p>Each target hit by this spell suffers <strong>poisoned</strong>.</p>",
     "class": {
       "value": "NPC"
     },
@@ -65,10 +65,10 @@
     "rollInfo": {
       "attributes": {
         "primary": {
-          "value": "dex"
+          "value": "ins"
         },
         "secondary": {
-          "value": "dex"
+          "value": "wlp"
         }
       },
       "accuracy": {
@@ -108,21 +108,26 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "poisoned"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280435411,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Rage_dSlyecqTxIXXSa1l.json
+++ b/src/packs/game-master/spell_Rage_dSlyecqTxIXXSa1l.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>Each target hit by this spell suffers @EFFECT[enraged].</p>",
+    "description": "<p>Each target hit by this spell suffers <strong>enraged</strong>.</p>",
     "class": {
       "value": "NPC"
     },
@@ -108,21 +108,26 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "enraged"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280459480,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Shell_zf8HeDLrqXVMhGt4.json
+++ b/src/packs/game-master/spell_Shell_zf8HeDLrqXVMhGt4.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>Until this spell ends, you gain Resistance to <strong>physical</strong> damage.</p><hr /><ul><li><p><strong>You Receive:</strong> @TYPE[affinity physical resistance e:eos i:1 t:source]</p></li></ul>",
+    "description": "<p>Until this spell ends, you gain Resistance to <strong>physical</strong> damage.</p>",
     "class": {
       "value": "NPC"
     },
@@ -108,21 +108,26 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "Compendium.projectfu.game-master.Item.60Gs2LnMIy6uPGhK"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280630751,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_War_Cry_sJc4OnOFGBTiQEzs.json
+++ b/src/packs/game-master/spell_War_Cry_sJc4OnOFGBTiQEzs.json
@@ -1,12 +1,12 @@
 {
   "name": "War Cry",
   "type": "spell",
-  "img": "icons/skills/wounds/injury-face-impact-orange.webp",
+  "img": "icons/sundries/flags/banner-flag-red-white.webp",
   "system": {
     "summary": {
       "value": ""
     },
-    "description": "<p>Until this spell ends, each target gains a +1 bonus to Accuracy Checks.</p><hr /><ul><li><p><strong>Targets Receive: </strong>@EFFECT[Compendium.projectfu.actor-effects.Item.62RZnGQvUWIEyeJ7 e:eos i:1 t:source]{Effect: War Cry}</p></li></ul>",
+    "description": "<p>Until this spell ends, each target gains a +1 bonus to Accuracy Checks.</p>",
     "class": {
       "value": "NPC"
     },
@@ -108,21 +108,26 @@
       "type": "hp"
     },
     "effects": {
-      "entries": []
+      "entries": [
+        "Compendium.projectfu.game-master.Item.aKy3uZj38HTEBtG1"
+      ]
     },
     "traits": []
   },
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771280721082,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/game-master/spell_Weaken_AUIhgG59yCsNnaT4.json
+++ b/src/packs/game-master/spell_Weaken_AUIhgG59yCsNnaT4.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>Until this spell ends, the target suffers 5 extra damage from all sources that deal <strong>(choose type)</strong> damage.</p><hr /><ul><li><p><strong>Target Suffers:</strong> @EFFECT[Compendium.projectfu.actor-effects.Item.6JCfyn7Ewt0AJndC e:eos i:1 t:source]{Effect: Weaken (Physical)}, @EFFECT[Compendium.projectfu.actor-effects.aI4tsuVswH5gfGab e:eos i:1 t:source]{Effect: Weaken (Air)}, @EFFECT[Compendium.projectfu.actor-effects.MRNCMGIcZStGVV9J e:eos i:1 t:source]{Effect: Weaken (Bolt)}, @EFFECT[Compendium.projectfu.actor-effects.zFQpa3KcSAmBCWdE e:eos i:1 t:source]{Effect: Weaken (Dark)}, @EFFECT[Compendium.projectfu.actor-effects.YpXM5ClzMzIcwCgd e:eos i:1 t:source]{Effect: Weaken (Earth}, @EFFECT[Compendium.projectfu.actor-effects.dAFACJSQzCbcU9We e:eos i:1 t:source]{Effect: Weaken (Fire)}, @EFFECT[Compendium.projectfu.actor-effects.BVOW692emrw4yxR0 e:eos i:1 t:source]{Effect: Weaken (Ice)}, @EFFECT[Compendium.projectfu.actor-effects.aPBdnNy1hA8aRctl e:eos i:1 t:source]{Effect: Weaken (Light)}, or @EFFECT[Compendium.projectfu.actor-effects.2sXIFIXiWxRHt8CP e:eos i:1 t:source]{Effect: Weaken (Poison)}</p></li></ul>",
+    "description": "<p>Until this spell ends, the target suffers 5 extra damage from all sources that deal <strong>(choose type)</strong> damage.</p><hr /><p><strong>Target Suffers:</strong> @EFFECT[Compendium.projectfu.game-master.Item.F7vItVCE5aVZjgG7], @EFFECT[Compendium.projectfu.game-master.Item.3u8TxdveQgM4THLr], @EFFECT[Compendium.projectfu.game-master.Item.l9D9CW5snjAFoWxw], @EFFECT[Compendium.projectfu.game-master.Item.3arDuXneGG264kpd], @EFFECT[Compendium.projectfu.game-master.Item.U91NHOxpVmtqN7Pd], @EFFECT[Compendium.projectfu.game-master.Item.MSU4wyOjHh7X29oJ], @EFFECT[Compendium.projectfu.game-master.Item.gJaiSQQKpyl79uEM], @EFFECT[Compendium.projectfu.game-master.Item.TBaMhx4AMwamseGE], or @EFFECT[Compendium.projectfu.game-master.Item.I6AH3hPvNHDqFggI]</p>",
     "class": {
       "value": "NPC"
     },
@@ -115,14 +115,17 @@
   "effects": [],
   "flags": {
     "core": {},
-    "cf": {}
+    "cf": {},
+    "projectfu": {
+      "favorite": false
+    }
   },
   "_stats": {
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1690417015023,
-    "modifiedTime": 1770872387812,
+    "modifiedTime": 1771281323348,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/effect_Effect__Nether_Slash__Fire_Resist__gJWZDrbPrRIA0Udi.json
+++ b/src/packs/heroic-skills/effect_Effect__Nether_Slash__Fire_Resist__gJWZDrbPrRIA0Udi.json
@@ -1,10 +1,11 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "QtAH9h7yA18Xt7Ga",
+  "name": "Effect: Nether Slash (Fire Resist)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "_id": "gJWZDrbPrRIA0Udi",
+  "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-red.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-nether-slash-fire-resist",
     "cost": {
       "value": 0
     },
@@ -12,11 +13,11 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Nether Slash (Fire Resist)",
+      "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-red.webp",
       "system": {
         "duration": {
-          "event": "endOfScene",
+          "event": "startOfTurn",
           "interval": 1,
           "tracking": "self",
           "remaining": 1
@@ -33,8 +34,7 @@
             "name": "",
             "current": 0,
             "max": 6,
-            "style": "basic",
-            "step": 1
+            "style": "basic"
           }
         }
       },
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "Src1r6gZ1bxNWOn3",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
+          "key": "system.affinities.fire",
           "mode": 0,
           "value": "upgrade",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>You gain Resistance to <strong>fire</strong> damage until the start of your next turn.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -68,12 +68,18 @@
         "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "createdTime": 1771282762989,
+        "modifiedTime": 1771282818644,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!gJWZDrbPrRIA0Udi.Src1r6gZ1bxNWOn3"
     }
   ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "mA8SNY2rY4X5tOHa": 3
+  },
   "flags": {},
   "_stats": {
     "compendiumSource": null,
@@ -82,15 +88,9 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771282718363,
+    "modifiedTime": 1771282812937,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
-  "ownership": {
-    "default": 0,
-    "mA8SNY2rY4X5tOHa": 3
-  },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_key": "!items!gJWZDrbPrRIA0Udi"
 }

--- a/src/packs/heroic-skills/effect_Effect__Nether_Slash__Ice_Resist__YD0Qid4TdxUVksXQ.json
+++ b/src/packs/heroic-skills/effect_Effect__Nether_Slash__Ice_Resist__YD0Qid4TdxUVksXQ.json
@@ -1,10 +1,10 @@
 {
-  "folder": "awpXMmcK8pUDEUcc",
-  "name": "Effect: Awaken (MIG)",
+  "folder": "QtAH9h7yA18Xt7Ga",
+  "name": "Effect: Nether Slash (Ice Resist)",
   "type": "effect",
-  "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
+  "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-red.webp",
   "system": {
-    "fuid": "effect-awaken-mig",
+    "fuid": "effect-nether-slash-ice-resist",
     "cost": {
       "value": 0
     },
@@ -12,11 +12,11 @@
   },
   "effects": [
     {
-      "name": "Awaken (MIG)",
-      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "name": "Nether Slash (Ice Resist)",
+      "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-red.webp",
       "system": {
         "duration": {
-          "event": "endOfScene",
+          "event": "startOfTurn",
           "interval": 1,
           "tracking": "self",
           "remaining": 1
@@ -44,17 +44,17 @@
         "combat": null
       },
       "disabled": false,
-      "_id": "GS8gEfxwHzU6mt0Y",
+      "_id": "Src1r6gZ1bxNWOn3",
       "type": "base",
       "changes": [
         {
-          "key": "system.attributes.mig",
+          "key": "system.affinities.ice",
           "mode": 0,
           "value": "upgrade",
           "priority": null
         }
       ],
-      "description": "<p>Until this spell ends, you treat your <strong>Might</strong> as one die size higher.</p>",
+      "description": "<p>You gain Resistance to <strong>ice </strong>damage until the start of your next turn.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,9 +69,9 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1771281631722
+        "modifiedTime": 1771282842526
       },
-      "_key": "!items.effects!SocdSpwFMRBjPiR4.GS8gEfxwHzU6mt0Y"
+      "_key": "!items.effects!YD0Qid4TdxUVksXQ.Src1r6gZ1bxNWOn3"
     }
   ],
   "flags": {},
@@ -82,15 +82,15 @@
     "coreVersion": "13.351",
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
-    "createdTime": 1770624325060,
-    "modifiedTime": 1771281626605,
+    "createdTime": 1771282804868,
+    "modifiedTime": 1771282829344,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {
     "default": 0,
     "mA8SNY2rY4X5tOHa": 3
   },
-  "_id": "SocdSpwFMRBjPiR4",
-  "sort": 700000,
-  "_key": "!items!SocdSpwFMRBjPiR4"
+  "_id": "YD0Qid4TdxUVksXQ",
+  "sort": 0,
+  "_key": "!items!YD0Qid4TdxUVksXQ"
 }

--- a/src/packs/heroic-skills/folders_Nether_Slash_QtAH9h7yA18Xt7Ga.json
+++ b/src/packs/heroic-skills/folders_Nether_Slash_QtAH9h7yA18Xt7Ga.json
@@ -1,0 +1,21 @@
+{
+  "type": "Item",
+  "folder": "4LuFJav8aop3vdnu",
+  "name": "Nether Slash",
+  "color": null,
+  "sorting": "a",
+  "_id": "QtAH9h7yA18Xt7Ga",
+  "description": "",
+  "sort": 0,
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "lastModifiedBy": null
+  },
+  "_key": "!folders!QtAH9h7yA18Xt7Ga"
+}

--- a/src/packs/heroic-skills/heroic_Brambleheart_FvqC34UYxD3O2bFt.json
+++ b/src/packs/heroic-skills/heroic_Brambleheart_FvqC34UYxD3O2bFt.json
@@ -77,7 +77,7 @@
           "priority": null
         }
       ],
-      "description": "<p>You are Resistant to <strong>light</strong> damage and <strong>poison</strong> damage.</p><p>After you lose Hit Points, if you are in <strong>Crisis</strong> and a <strong>magiseed</strong> is present in your <strong>garden</strong>, you may fill <strong>1 section</strong> of your <strong>Growth Clock</strong>.</p>",
+      "description": "<p>You are Resistant to <strong>light</strong> damage and <strong>poison</strong> damage.</p><p>After you lose Hit Points, if you are in <strong>Crisis</strong> and a <strong>magiseed</strong> is present in your <strong>garden</strong>, you may fill <strong>1 section</strong> of your <strong>Growth Clock</strong>.</p><p>Additionally, when you use the <strong>Shadow Strike</strong> Skill, you may have your attack deal <strong>poison</strong> damage instead of <strong>dark</strong> damage. If you do, it deals extra damage equal to <strong>【twice the number of filled sections in your Growth Clock】</strong>.</p>",
       "transfer": true,
       "statuses": [],
       "flags": {
@@ -95,7 +95,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": null,
-        "modifiedTime": 1770886268337,
+        "modifiedTime": 1771282528880,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },
@@ -137,6 +137,34 @@
                   "message": "<p>You may fill <strong>1 section</strong> of your <strong>Growth Clock</strong>.</p>"
                 }
               }
+            },
+            "sq0oDoutTdJGv6WZ": {
+              "type": "ruleElement",
+              "_id": "sq0oDoutTdJGv6WZ",
+              "trigger": {
+                "_id": "YiX1UqBTMiMUO35C",
+                "type": "calculateDamageRuleTrigger",
+                "eventRelation": "source",
+                "damageSources": [
+                  "attack"
+                ],
+                "damageTypes": [],
+                "local": false,
+                "identifier": "shadow-strike"
+              },
+              "actions": {
+                "Trb1ORR4Fthzw5fs": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "Trb1ORR4Fthzw5fs",
+                  "damageTypes": [
+                    "poison"
+                  ],
+                  "amount": "2*&cs('garden')",
+                  "cost": {
+                    "amount": null
+                  }
+                }
+              }
             }
           }
         }
@@ -158,7 +186,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1770877728957,
+    "modifiedTime": 1771285249431,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Ceaseless_Battlefield_sSq9Z065pczkdBLZ.json
+++ b/src/packs/heroic-skills/heroic_Ceaseless_Battlefield_sSq9Z065pczkdBLZ.json
@@ -95,7 +95,135 @@
     },
     "fuid": "ceaseless-battlefield"
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Ceaseless Battlefield",
+      "img": "icons/sundries/gaming/chess-pawn-white-glass.webp",
+      "system": {
+        "duration": {
+          "event": "none",
+          "interval": 1,
+          "tracking": "self",
+          "remaining": 1
+        },
+        "type": "default",
+        "predicate": {
+          "crisisInteraction": "none"
+        },
+        "rules": {
+          "elements": {
+            "NjPkFBisD5mpvsWD": {
+              "type": "ruleElement",
+              "_id": "NjPkFBisD5mpvsWD",
+              "trigger": {
+                "_id": "N8cdMJzky48FzWXb",
+                "type": "calculateExpenseRuleTrigger",
+                "eventRelation": "source",
+                "resource": "mp",
+                "expenseSource": "skill",
+                "traits": {
+                  "entries": [],
+                  "quantifier": "any"
+                },
+                "identifier": "bishops-edict"
+              },
+              "actions": {
+                "zYkdHthJiIHXvHBw": {
+                  "type": "modifyExpenseRuleAction",
+                  "_id": "zYkdHthJiIHXvHBw",
+                  "amount": "0.5",
+                  "operation": "multiply"
+                }
+              }
+            },
+            "kpxwrUTB7jVkhbHe": {
+              "type": "ruleElement",
+              "_id": "kpxwrUTB7jVkhbHe",
+              "trigger": {
+                "_id": "lfF7wHg6BAtfR02l",
+                "type": "calculateExpenseRuleTrigger",
+                "eventRelation": "source",
+                "resource": "mp",
+                "expenseSource": "skill",
+                "traits": {
+                  "entries": [],
+                  "quantifier": "any"
+                },
+                "identifier": "charging-cavalry"
+              },
+              "actions": {
+                "EsOpeoTnp4Ykb19M": {
+                  "type": "modifyExpenseRuleAction",
+                  "_id": "EsOpeoTnp4Ykb19M",
+                  "amount": "0.5",
+                  "operation": "multiply"
+                }
+              }
+            },
+            "C4LaB9K2j26OL0Iw": {
+              "type": "ruleElement",
+              "_id": "C4LaB9K2j26OL0Iw",
+              "trigger": {
+                "_id": "CdyJUvSo0V12BCjU",
+                "type": "calculateExpenseRuleTrigger",
+                "eventRelation": "source",
+                "resource": "mp",
+                "expenseSource": "skill",
+                "traits": {
+                  "entries": [],
+                  "quantifier": "any"
+                },
+                "identifier": "kings-castle"
+              },
+              "actions": {
+                "VqRbwlQtXDU75brJ": {
+                  "type": "modifyExpenseRuleAction",
+                  "_id": "VqRbwlQtXDU75brJ",
+                  "amount": "0.5",
+                  "operation": "multiply"
+                }
+              }
+            }
+          },
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "basic"
+          }
+        }
+      },
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "disabled": false,
+      "_id": "Ejt7E1O7r1aIWzpe",
+      "type": "base",
+      "changes": [],
+      "description": "<p>The MP costs for <strong>Bishop's Edict</strong>, <strong>Charging Cavalry</strong>, and <strong>King's Castle</strong> are halved. </p>",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "projectfu",
+        "systemVersion": "#{VERSION}#",
+        "createdTime": 1771283421596,
+        "modifiedTime": 1771283574450,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
+      },
+      "_key": "!items.effects!sSq9Z065pczkdBLZ.Ejt7E1O7r1aIWzpe"
+    }
+  ],
   "folder": "gaT6Lef2xP8TZKnF",
   "ownership": {
     "default": 0,

--- a/src/packs/heroic-skills/heroic_Dreamslice_jdhnFWPhnFtLRLe8.json
+++ b/src/packs/heroic-skills/heroic_Dreamslice_jdhnFWPhnFtLRLe8.json
@@ -142,6 +142,13 @@
                   "_id": "Roqixz9AYyZImi4G",
                   "outcome": "success",
                   "result": null
+                },
+                "SuCS8XvGUBqiaajH": {
+                  "type": "weaponRulePredicate",
+                  "_id": "SuCS8XvGUBqiaajH",
+                  "categories": [
+                    "sword"
+                  ]
                 }
               }
             }
@@ -179,7 +186,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770955523195,
-        "modifiedTime": 1770956002798,
+        "modifiedTime": 1771284494235,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!jdhnFWPhnFtLRLe8.lC0vrmonf2x2uiO1"
@@ -196,7 +203,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711473807263,
-    "modifiedTime": 1770956169859,
+    "modifiedTime": 1771285262898,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Nether_Slash_DkaqHnTnEw2eMRDa.json
+++ b/src/packs/heroic-skills/heroic_Nether_Slash_DkaqHnTnEw2eMRDa.json
@@ -6,7 +6,7 @@
     "summary": {
       "value": "Converts Shadow Strike into fire or ice."
     },
-    "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Darkblade</strong>, <strong>Elementalist</strong> and <strong>Pilot</strong>, and have acquired the <strong>Shadow Strike</strong> Skill.</p><hr /><p>When you use the <strong>Shadow Strike</strong> Skill, you may choose <strong>fire</strong> or <strong>ice</strong>. If you do, all damage dealt by this attack becomes of the chosen type instead of <strong>dark</strong> (its damage type cannot change, as usual), and you gain Resistance to the damage type you did not choose until the start of your next turn.</p><p>When you perform a <strong>free attack</strong> with a <strong>melee</strong> weapon as part of the <strong>Shadow Strike</strong> Skill, the attack may target enemies that cannot be targeted by <strong>melee</strong> attacks.</p>",
+    "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Darkblade</strong>, <strong>Elementalist</strong> and <strong>Pilot</strong>, and have acquired the <strong>Shadow Strike</strong> Skill.</p><hr /><p>When you use the @UUID[Compendium.projectfu.skills.Item.W5hE9L8x7AsJI7a1]{Shadow Strike} Skill, you may choose <strong>fire</strong> or <strong>ice</strong>. If you do, all damage dealt by this attack becomes of the chosen type instead of <strong>dark</strong> (its damage type cannot change, as usual), and you gain Resistance to the damage type you did not choose until the start of your next turn.</p><p>When you perform a <strong>free attack</strong> with a <strong>melee</strong> weapon as part of the <strong>Shadow Strike</strong> Skill, the attack may target enemies that cannot be targeted by <strong>melee</strong> attacks.</p><hr /><p><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.heroic-skills.Item.gJWZDrbPrRIA0Udi] or @EFFECT[Compendium.projectfu.heroic-skills.Item.YD0Qid4TdxUVksXQ]</p>",
     "class": {
       "value": ""
     },
@@ -32,7 +32,153 @@
     },
     "fuid": "nether-slash"
   },
-  "effects": [],
+  "effects": [
+    {
+      "name": "Nether Slash",
+      "img": "icons/magic/fire/dagger-rune-enchant-flame-strong-red.webp",
+      "system": {
+        "duration": {
+          "event": "none",
+          "interval": 1,
+          "tracking": "self",
+          "remaining": 1
+        },
+        "type": "default",
+        "predicate": {
+          "crisisInteraction": "none"
+        },
+        "rules": {
+          "elements": {
+            "wScMVICn0F2ev7dk": {
+              "type": "ruleElement",
+              "_id": "wScMVICn0F2ev7dk",
+              "trigger": {
+                "_id": "8T4P54R2WEUd1osm",
+                "type": "calculateDamageRuleTrigger",
+                "eventRelation": "source",
+                "damageSources": [
+                  "skill"
+                ],
+                "damageTypes": [],
+                "local": false,
+                "identifier": "shadow-strike"
+              },
+              "actions": {
+                "xKBD8uKbfnzC3QIT": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "xKBD8uKbfnzC3QIT",
+                  "damageTypes": [
+                    "fire"
+                  ],
+                  "amount": "",
+                  "cost": {
+                    "amount": null
+                  }
+                }
+              }
+            },
+            "NKCQxdlVWP9lSNMF": {
+              "type": "ruleElement",
+              "_id": "NKCQxdlVWP9lSNMF",
+              "trigger": {
+                "_id": "wxxPXqhBvvX1UAHu",
+                "type": "calculateDamageRuleTrigger",
+                "eventRelation": "source",
+                "damageSources": [
+                  "skill"
+                ],
+                "damageTypes": [],
+                "local": false,
+                "identifier": "shadow-strike"
+              },
+              "actions": {
+                "nGF5hAaWFTccUdvR": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "nGF5hAaWFTccUdvR",
+                  "damageTypes": [
+                    "ice"
+                  ],
+                  "amount": "",
+                  "cost": {
+                    "amount": null
+                  }
+                }
+              }
+            },
+            "V9bQPirBkNCOhBVR": {
+              "type": "ruleElement",
+              "_id": "V9bQPirBkNCOhBVR",
+              "trigger": {
+                "_id": "JtQAyZwVfFRVfMpz",
+                "type": "renderCheckRuleTrigger",
+                "eventRelation": "source",
+                "checkTypes": [],
+                "itemGroups": [
+                  "skill"
+                ],
+                "local": false,
+                "identifier": "shadow-strike"
+              },
+              "predicates": {},
+              "actions": {
+                "3Atfvxwmd0FJmkYQ": {
+                  "type": "messageRuleAction",
+                  "_id": "3Atfvxwmd0FJmkYQ",
+                  "message": "<p>If you changed the damage to <strong>fire</strong> or <strong>ice</strong>, you gain Resistance to the damage type you did not choose.</p>"
+                },
+                "jTpilrr1G8rOePO4": {
+                  "type": "applyEffectRuleAction",
+                  "_id": "jTpilrr1G8rOePO4",
+                  "effect": "Compendium.projectfu.heroic-skills.Item.gJWZDrbPrRIA0Udi"
+                },
+                "ZMgJg0536UjwnISg": {
+                  "type": "applyEffectRuleAction",
+                  "_id": "ZMgJg0536UjwnISg",
+                  "effect": "Compendium.projectfu.heroic-skills.Item.YD0Qid4TdxUVksXQ"
+                }
+              },
+              "selector": "self"
+            }
+          },
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "basic"
+          }
+        }
+      },
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "disabled": false,
+      "_id": "GhlfMRLPbvFfYsSe",
+      "type": "base",
+      "changes": [],
+      "description": "",
+      "origin": null,
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {},
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "projectfu",
+        "systemVersion": "#{VERSION}#",
+        "createdTime": 1771282679453,
+        "modifiedTime": 1771283346460,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
+      },
+      "_key": "!items.effects!DkaqHnTnEw2eMRDa.GhlfMRLPbvFfYsSe"
+    }
+  ],
   "flags": {
     "core": {},
     "projectfu": {
@@ -47,7 +193,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771012828527,
+    "modifiedTime": 1771285299046,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Paso_Doble_h8keSqFfvEilNhF7.json
+++ b/src/packs/heroic-skills/heroic_Paso_Doble_h8keSqFfvEilNhF7.json
@@ -116,7 +116,7 @@
               "type": "ruleElement",
               "_id": "lhWH7pURWojI0Zgx",
               "trigger": {
-                "_id": "jtyeiU4x6USZzLKZ",
+                "_id": "67ua5hzY1RXHqhok",
                 "type": "renderCheckRuleTrigger",
                 "eventRelation": "source",
                 "checkTypes": [
@@ -133,6 +133,30 @@
                   "type": "messageRuleAction",
                   "_id": "kgb5OOAOyfqNqBuE",
                   "message": "<p>While you are in <strong>Crisis</strong>, you ignore the MP cost.</p>"
+                }
+              }
+            },
+            "Q95dMk0g4AHFStD0": {
+              "type": "ruleElement",
+              "_id": "Q95dMk0g4AHFStD0",
+              "trigger": {
+                "_id": "lSPJvwv3It3BMmMf",
+                "type": "calculateExpenseRuleTrigger",
+                "eventRelation": "source",
+                "resource": "mp",
+                "expenseSource": "skill",
+                "traits": {
+                  "entries": [],
+                  "quantifier": "any"
+                },
+                "identifier": "follow-my-lead"
+              },
+              "actions": {
+                "GzWahT3Bq3W9768E": {
+                  "type": "modifyExpenseRuleAction",
+                  "_id": "GzWahT3Bq3W9768E",
+                  "amount": "0",
+                  "operation": "multiply"
                 }
               }
             }
@@ -170,7 +194,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770763544541,
-        "modifiedTime": 1770763769039,
+        "modifiedTime": 1771283945234,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!h8keSqFfvEilNhF7.Le5vpTg6eOOHgTTZ"
@@ -192,7 +216,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684669665,
-    "modifiedTime": 1770763527289,
+    "modifiedTime": 1771285278245,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
+++ b/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
@@ -165,7 +165,12 @@
                 "YAHJUD5SD1ClxolQ": {
                   "type": "checkRulePredicate",
                   "_id": "YAHJUD5SD1ClxolQ",
-                  "result": null
+                  "result": null,
+                  "attributes": {
+                    "primary": {
+                      "value": "dex"
+                    }
+                  }
                 },
                 "jhaZQdISJVvn4vew": {
                   "type": "weaponRulePredicate",
@@ -225,7 +230,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1743535722306,
-        "modifiedTime": 1770343420812,
+        "modifiedTime": 1771351077371,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },

--- a/src/packs/skills/skill_Wardancer_L4LqyZu7NPjavyaf.json
+++ b/src/packs/skills/skill_Wardancer_L4LqyZu7NPjavyaf.json
@@ -11,7 +11,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>After you perform a <strong>dance</strong>, your attacks with <strong>brawling</strong>, <strong>dagger</strong>, <strong>flail</strong>, <strong>sword</strong>, and <strong>thrown weapons</strong> deal <strong>【SL】</strong> extra damage until the start of your next turn. If you have an <strong>arcane </strong>weapon equipped<strong>, </strong>offensive spells (@ICON[offensive]) you cast also deal <strong>【SL】</strong> extra damage until the start of your next turn.</p><hr /><p><strong>You:</strong> @EFFECT[Compendium.projectfu.skills.Item.T9rvLMTdI2aICL1u]</p>",
+    "description": "<p>After you perform a <strong>dance</strong>, your attacks with <strong>brawling</strong>, <strong>dagger</strong>, <strong>flail</strong>, <strong>sword</strong>, and <strong>thrown weapons</strong> deal <strong>【SL】</strong> extra damage until the start of your next turn. If you have an <strong>arcane </strong>weapon equipped<strong>, </strong>offensive spells (@ICON[offensive]) you cast also deal <strong>【SL】</strong> extra damage until the start of your next turn.</p><hr /><p><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.skills.Item.T9rvLMTdI2aICL1u]</p>",
     "isFavored": {
       "value": false
     },
@@ -140,7 +140,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706560640482,
-    "modifiedTime": 1770279262467,
+    "modifiedTime": 1771284033466,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/spells/effect_Effect__Acceleration_O8ZlgIEzCodMsadz.json
+++ b/src/packs/spells/effect_Effect__Acceleration_O8ZlgIEzCodMsadz.json
@@ -49,7 +49,7 @@
         }
       },
       "changes": [],
-      "description": "<p>At the end of each of their turns, the target may choose <strong>one</strong> option: perform a <strong>free attack</strong> with a weapon they have equipped; <strong>or</strong> perform the <strong>Spell</strong> action for free, casting a spell with a <strong>total MP cost equal to or lower than 10</strong> (paying its MP cost). After the same creature benefits from this effect a second time, this spell ends.</p>",
+      "description": "<p>Until this spell ends, at the end of each of your turns, you may choose <strong>one</strong> option:</p><ul><li><p>Perform a <strong>free attack</strong> with a weapon they have equipped.</p></li><li><p>Perform the <strong>Spell</strong> action for free, casting a spell with a <strong>total MP cost equal to or lower than 10</strong> (paying its MP cost).</p></li></ul><p>After you benefit from this effect a second time, this spell ends.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -63,7 +63,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1742672629257,
-        "modifiedTime": 1770629030553,
+        "modifiedTime": 1771281450278,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },

--- a/src/packs/spells/effect_Effect__Anomaly_rOzrw717cgCgjTZ7.json
+++ b/src/packs/spells/effect_Effect__Anomaly_rOzrw717cgCgjTZ7.json
@@ -47,7 +47,7 @@
         }
       },
       "changes": [],
-      "description": "<p>You alter the very nature of your target. Until this spell ends, if the target would suffer damage of a type they Absorb or are Immune to, they are instead treated as if they were Vulnerable to that damage type. Once that happens, this spell ends.</p>",
+      "description": "<p>Until this spell ends, if you would suffer damage of a type you Absorb or are Immune to, you are instead treated as if you were Vulnerable to that damage type. Once that happens, this spell ends.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -61,7 +61,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1744487288438,
-        "modifiedTime": 1770629037079,
+        "modifiedTime": 1771281491174,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },

--- a/src/packs/spells/effect_Effect__Aura_j37149fnaCxNS08N.json
+++ b/src/packs/spells/effect_Effect__Aura_j37149fnaCxNS08N.json
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Aura</strong> spell ends, you treat your <strong>Magic Defense</strong> as being equal to 12. This value increases to 13 at <strong>level 20</strong>, or to 14 at <strong>level 40</strong>.</p>",
+      "description": "<p>Until this spell ends, you treat your <strong>Magic Defense</strong> as being equal to 12. This value increases to 13 at <strong>level 20</strong>, or to 14 at <strong>level 40</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770623966060,
-        "modifiedTime": 1770627275317,
+        "modifiedTime": 1771281568810,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!j37149fnaCxNS08N.M8M8UYTrWoAbj0F5"

--- a/src/packs/spells/effect_Effect__Awaken__DEX__lS4NFmMsRQKik2wz.json
+++ b/src/packs/spells/effect_Effect__Awaken__DEX__lS4NFmMsRQKik2wz.json
@@ -5,7 +5,7 @@
   "_id": "lS4NFmMsRQKik2wz",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
   "system": {
-    "fuid": "effect-awaken",
+    "fuid": "effect-awaken-dex",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Awaken</strong> spell ends, you treat your <strong>Dexterity</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you treat your <strong>Dexterity</strong> as one die size higher.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770624209206,
-        "modifiedTime": 1770631764613,
+        "modifiedTime": 1771281611853,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!lS4NFmMsRQKik2wz.GS8gEfxwHzU6mt0Y"
@@ -89,7 +89,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770624192535,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281574406,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "_key": "!items!lS4NFmMsRQKik2wz"

--- a/src/packs/spells/effect_Effect__Awaken__INS__vUP4Ve1DYa6LmHwZ.json
+++ b/src/packs/spells/effect_Effect__Awaken__INS__vUP4Ve1DYa6LmHwZ.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
   "system": {
-    "fuid": "effect-awaken",
+    "fuid": "effect-awaken-ins",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Awaken</strong> spell ends, you treat your <strong>Insight </strong>as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you treat your <strong>Insight </strong>as one die size higher.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631773955
+        "modifiedTime": 1771281621474
       },
       "_key": "!items.effects!vUP4Ve1DYa6LmHwZ.GS8gEfxwHzU6mt0Y"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770624323905,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281616459,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Awaken__WLP__z63l91zniIYaS30H.json
+++ b/src/packs/spells/effect_Effect__Awaken__WLP__z63l91zniIYaS30H.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/awaken.png",
   "system": {
-    "fuid": "effect-awaken",
+    "fuid": "effect-awaken-wlp",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Awaken</strong> spell ends, you treat your <strong>Willpower</strong> as one die size higher.</p>",
+      "description": "<p>Until this spell ends, you treat your <strong>Willpower</strong> as one die size higher.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631791449
+        "modifiedTime": 1771281643108
       },
       "_key": "!items.effects!z63l91zniIYaS30H.GS8gEfxwHzU6mt0Y"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770624327572,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281637381,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Barrier_kIqy89LUoYwqRltb.json
+++ b/src/packs/spells/effect_Effect__Barrier_kIqy89LUoYwqRltb.json
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Barrier </strong>spell ends, you treat your <strong>Defense</strong> as being equal to 12. This value increases to 13 at <strong>level 20</strong>, or to 14 at <strong>level 40</strong>.</p>",
+      "description": "<p>Until this spell ends, you treat your <strong>Defense</strong> as being equal to 12. This value increases to 13 at <strong>level 20</strong>, or to 14 at <strong>level 40</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770627307689
+        "modifiedTime": 1771281650607
       },
       "_key": "!items.effects!kIqy89LUoYwqRltb.M8M8UYTrWoAbj0F5"
     }

--- a/src/packs/spells/effect_Effect__Divination_7Lt7jZqWTtyWXzYR.json
+++ b/src/packs/spells/effect_Effect__Divination_7Lt7jZqWTtyWXzYR.json
@@ -50,7 +50,7 @@
         }
       },
       "changes": [],
-      "description": "<p>You glimpse briefly into the future. Until this spell ends, after a creature you can see performs a Check, if it was not a <strong>fumble</strong> nor a <strong>critical success</strong>, you may force that creature to reroll both dice. Once you have forced <strong>two</strong> rerolls this way, this spell ends.</p>",
+      "description": "<p>Until this spell ends, after a creature you can see performs a Check, if it was not a <strong>fumble</strong> nor a <strong>critical success</strong>, you may force that creature to reroll both dice. Once you have forced <strong>two</strong> rerolls this way, this spell ends.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -64,7 +64,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1744503925677,
-        "modifiedTime": 1770629042304,
+        "modifiedTime": 1771281504834,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },

--- a/src/packs/spells/effect_Effect__Elemental_Shroud__Air__xp2bMd7jkx1rfjrb.json
+++ b/src/packs/spells/effect_Effect__Elemental_Shroud__Air__xp2bMd7jkx1rfjrb.json
@@ -5,7 +5,7 @@
   "_id": "xp2bMd7jkx1rfjrb",
   "img": "systems/projectfu/styles/static/compendium/classes/elementalist/spells/elemental_shroud.png",
   "system": {
-    "fuid": "effect-elemental-shroud",
+    "fuid": "effect-elemental-shroud-air",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Elemental Shroud</strong> spell ends, you gain Resistance to <strong>air</strong> damage.</p>",
+      "description": "<p>Until this spell ends, you gain Resistance to <strong>air</strong> damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770627717689,
-        "modifiedTime": 1770631565269,
+        "modifiedTime": 1771281362577,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!xp2bMd7jkx1rfjrb.kHcShxkx44ViFsOr"
@@ -89,7 +89,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627702784,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281580321,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "_key": "!items!xp2bMd7jkx1rfjrb"

--- a/src/packs/spells/effect_Effect__Elemental_Shroud__Bolt__JxkkqwY0eyzqjIXU.json
+++ b/src/packs/spells/effect_Effect__Elemental_Shroud__Bolt__JxkkqwY0eyzqjIXU.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/elementalist/spells/elemental_shroud.png",
   "system": {
-    "fuid": "effect-elemental-shroud",
+    "fuid": "effect-elemental-shroud-bolt",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Elemental Shroud</strong> spell ends, you gain Resistance to <strong>bolt </strong>damage.</p>",
+      "description": "<p>Until this spell ends, you gain Resistance to <strong>bolt </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631580412
+        "modifiedTime": 1771281373212
       },
       "_key": "!items.effects!JxkkqwY0eyzqjIXU.kHcShxkx44ViFsOr"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627829239,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281582359,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Elemental_Shroud__Earth__0gQINms2ddJW2vVr.json
+++ b/src/packs/spells/effect_Effect__Elemental_Shroud__Earth__0gQINms2ddJW2vVr.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/elementalist/spells/elemental_shroud.png",
   "system": {
-    "fuid": "effect-elemental-shroud",
+    "fuid": "effect-elemental-shroud-earth",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Elemental Shroud</strong> spell ends, you gain Resistance to <strong>earth </strong>damage.</p>",
+      "description": "<p>Until the this spell ends, you gain Resistance to <strong>earth </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631593490
+        "modifiedTime": 1771281380935
       },
       "_key": "!items.effects!0gQINms2ddJW2vVr.kHcShxkx44ViFsOr"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627830544,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281584239,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Elemental_Shroud__Fire__jdmbn0LS5Plv2BI2.json
+++ b/src/packs/spells/effect_Effect__Elemental_Shroud__Fire__jdmbn0LS5Plv2BI2.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/elementalist/spells/elemental_shroud.png",
   "system": {
-    "fuid": "effect-elemental-shroud",
+    "fuid": "effect-elemental-shroud-fire",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Elemental Shroud</strong> spell ends, you gain Resistance to <strong>fire </strong>damage.</p>",
+      "description": "<p>Until the this spell ends, you gain Resistance to <strong>fire </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631602391
+        "modifiedTime": 1771281388896
       },
       "_key": "!items.effects!jdmbn0LS5Plv2BI2.kHcShxkx44ViFsOr"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627831763,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281586132,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Elemental_Shroud__Ice__l7FVA1qEtGVhFRne.json
+++ b/src/packs/spells/effect_Effect__Elemental_Shroud__Ice__l7FVA1qEtGVhFRne.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/elementalist/spells/elemental_shroud.png",
   "system": {
-    "fuid": "effect-elemental-shroud",
+    "fuid": "effect-elemental-shroud-ice",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Elemental Shroud</strong> spell ends, you gain Resistance to <strong>ice </strong>damage.</p>",
+      "description": "<p>Until the this spell ends, you gain Resistance to <strong>ice </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631625070
+        "modifiedTime": 1771281396237
       },
       "_key": "!items.effects!l7FVA1qEtGVhFRne.kHcShxkx44ViFsOr"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627832846,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281588064,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Enrage__Restrict_Guard_Spell__AZnLD3nCoMk2GJRe.json
+++ b/src/packs/spells/effect_Effect__Enrage__Restrict_Guard_Spell__AZnLD3nCoMk2GJRe.json
@@ -5,7 +5,7 @@
   "_id": "AZnLD3nCoMk2GJRe",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/enrage.png",
   "system": {
-    "fuid": "effect-enrage",
+    "fuid": "effect-enrage-restrict-guard-spell",
     "cost": {
       "value": 0
     },
@@ -82,7 +82,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770625103639,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281655412,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "_key": "!items!AZnLD3nCoMk2GJRe"

--- a/src/packs/spells/effect_Effect__Mercy_87su2PuI6rSMblmN.json
+++ b/src/packs/spells/effect_Effect__Mercy_87su2PuI6rSMblmN.json
@@ -51,7 +51,7 @@
         }
       },
       "changes": [],
-      "description": "<p>Until the <strong>Mercy</strong> spell ends, if you would be reduced to 0 HP, you are instead left standing with exactly 1 HP. Once that happens, this spell ends.</p>",
+      "description": "<p>Until this spell ends, if you would be reduced to 0 HP, you are instead left standing with exactly 1 HP. Once that happens, this spell ends.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -65,7 +65,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1744722453780,
-        "modifiedTime": 1770627335951,
+        "modifiedTime": 1771281671102,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },

--- a/src/packs/spells/effect_Effect__Mirror_cyA5qMihPTXCsCyD.json
+++ b/src/packs/spells/effect_Effect__Mirror_cyA5qMihPTXCsCyD.json
@@ -47,7 +47,7 @@
         }
       },
       "changes": [],
-      "description": "<p>You twist the laws of magic. Until this spell ends, if an offensive ( @ICON[offensive] ) spell is cast on the target, the creature who cast that offensive spell will be targeted in their stead (any other targets of the offensive spell will be targeted as normal). Once that happens, this spell ends.</p>",
+      "description": "<p>Until this spell ends, if an offensive spell is cast on you, the creature who cast that offensive spell will be targeted in your stead (any other targets of the offensive spell will be targeted as normal). Once that happens, this spell ends.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -61,7 +61,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1744504147205,
-        "modifiedTime": 1770629050540,
+        "modifiedTime": 1771281539728,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },

--- a/src/packs/spells/effect_Effect__Reinforce__Dazed__0SGPkOpasLpl8PuC.json
+++ b/src/packs/spells/effect_Effect__Reinforce__Dazed__0SGPkOpasLpl8PuC.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/reinforce.png",
   "system": {
-    "fuid": "effect-reinforce",
+    "fuid": "effect-reinforce-dazed",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Reinforce</strong> spell ends, you become immune to <strong>dazed</strong>.</p>",
+      "description": "<p>Until this spell ends, you are immune to <strong>dazed</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631813709
+        "modifiedTime": 1771281723839
       },
       "_key": "!items.effects!0SGPkOpasLpl8PuC.sJloIrKsBjrUWGxt"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770626112203,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281675761,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Reinforce__Enraged__fCKSz2LVMBOntokb.json
+++ b/src/packs/spells/effect_Effect__Reinforce__Enraged__fCKSz2LVMBOntokb.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/reinforce.png",
   "system": {
-    "fuid": "effect-reinforce",
+    "fuid": "effect-reinforce-enraged",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Reinforce</strong> spell ends, you become immune to <strong>enraged</strong>.</p>",
+      "description": "<p>Until this spell ends, you are immune to <strong>enraged</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631821358
+        "modifiedTime": 1771281757886
       },
       "_key": "!items.effects!fCKSz2LVMBOntokb.sJloIrKsBjrUWGxt"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770626104590,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281754216,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Reinforce__Poisoned__MTiWeXBaOjy41p9G.json
+++ b/src/packs/spells/effect_Effect__Reinforce__Poisoned__MTiWeXBaOjy41p9G.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/reinforce.png",
   "system": {
-    "fuid": "effect-reinforce",
+    "fuid": "effect-reinforce-poisoned",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Reinforce</strong> spell ends, you become immune to <strong>poisoned</strong>.</p>",
+      "description": "<p>Until this spell ends, you are immune to <strong>poisoned</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631832054
+        "modifiedTime": 1771281767817
       },
       "_key": "!items.effects!MTiWeXBaOjy41p9G.sJloIrKsBjrUWGxt"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770626110750,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281763338,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Reinforce__Shaken__fRj1ONYfLF8Ert18.json
+++ b/src/packs/spells/effect_Effect__Reinforce__Shaken__fRj1ONYfLF8Ert18.json
@@ -5,7 +5,7 @@
   "_id": "fRj1ONYfLF8Ert18",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/reinforce.png",
   "system": {
-    "fuid": "effect-reinforce",
+    "fuid": "effect-reinforce-shaken",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Reinforce</strong> spell ends, you become immune to <strong>shaken</strong>.</p>",
+      "description": "<p>Until this spell ends, you are immune to <strong>shaken</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770625643893,
-        "modifiedTime": 1770631843500,
+        "modifiedTime": 1771281779200,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!fRj1ONYfLF8Ert18.sJloIrKsBjrUWGxt"
@@ -89,7 +89,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770625631426,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281773617,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "_key": "!items!fRj1ONYfLF8Ert18"

--- a/src/packs/spells/effect_Effect__Reinforce__Slow__YPwd8ncv62T8md10.json
+++ b/src/packs/spells/effect_Effect__Reinforce__Slow__YPwd8ncv62T8md10.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/reinforce.png",
   "system": {
-    "fuid": "effect-reinforce",
+    "fuid": "effect-reinforce-slow",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Reinforce</strong> spell ends, you become immune to <strong>slow</strong>.</p>",
+      "description": "<p>Until this spell ends, you are immune to <strong>slow</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631856225
+        "modifiedTime": 1771281787511
       },
       "_key": "!items.effects!YPwd8ncv62T8md10.sJloIrKsBjrUWGxt"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770626107985,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281790477,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Reinforce__Weak__YapKaTVoWMghwB3V.json
+++ b/src/packs/spells/effect_Effect__Reinforce__Weak__YapKaTVoWMghwB3V.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/reinforce.png",
   "system": {
-    "fuid": "effect-reinforce",
+    "fuid": "effect-reinforce-weak",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Reinforce</strong> spell ends, you become immune to <strong>weak</strong>.</p>",
+      "description": "<p>Until this spell ends, you are immune to <strong>weak</strong>.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631865180
+        "modifiedTime": 1771281798991
       },
       "_key": "!items.effects!YapKaTVoWMghwB3V.sJloIrKsBjrUWGxt"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770626106296,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281795067,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Soul_Shroud__Dark__pw3V67Q5TBTnFNXb.json
+++ b/src/packs/spells/effect_Effect__Soul_Shroud__Dark__pw3V67Q5TBTnFNXb.json
@@ -5,7 +5,7 @@
   "_id": "pw3V67Q5TBTnFNXb",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/soul_shroud.png",
   "system": {
-    "fuid": "effect-soul-shroud",
+    "fuid": "effect-soul-shroud-dark",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Soul Shroud</strong> spell ends, you gain Resistance to <strong>dark</strong> damage.</p>",
+      "description": "<p>Until this spell ends, you gain Resistance to <strong>dark</strong> damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770626980865,
-        "modifiedTime": 1770631083402,
+        "modifiedTime": 1771281820853,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!pw3V67Q5TBTnFNXb.dk03CWyervo5sqho"
@@ -89,7 +89,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770626970337,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281813860,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "_key": "!items!pw3V67Q5TBTnFNXb"

--- a/src/packs/spells/effect_Effect__Soul_Shroud__Light__rCmUbGKNsyJPZ70N.json
+++ b/src/packs/spells/effect_Effect__Soul_Shroud__Light__rCmUbGKNsyJPZ70N.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/soul_shroud.png",
   "system": {
-    "fuid": "effect-soul-shroud",
+    "fuid": "effect-soul-shroud-light",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Soul Shroud</strong> spell ends, you gain Resistance to <strong>light </strong>damage.</p>",
+      "description": "<p>Until this spell ends, you gain Resistance to <strong>light </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631097849
+        "modifiedTime": 1771281831958
       },
       "_key": "!items.effects!rCmUbGKNsyJPZ70N.dk03CWyervo5sqho"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627047618,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281826675,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Soul_Shroud__Poison__yOlZYERCLxYMAZq5.json
+++ b/src/packs/spells/effect_Effect__Soul_Shroud__Poison__yOlZYERCLxYMAZq5.json
@@ -4,7 +4,7 @@
   "type": "effect",
   "img": "systems/projectfu/styles/static/compendium/classes/spiritist/spells/soul_shroud.png",
   "system": {
-    "fuid": "effect-soul-shroud",
+    "fuid": "effect-soul-shroud-poison",
     "cost": {
       "value": 0
     },
@@ -54,7 +54,7 @@
           "priority": null
         }
       ],
-      "description": "<p>Until the <strong>Soul Shroud</strong> spell ends, you gain Resistance to <strong>poison </strong>damage.</p>",
+      "description": "<p>Until this spell ends, you gain Resistance to <strong>poison </strong>damage.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -69,7 +69,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "lastModifiedBy": "mA8SNY2rY4X5tOHa",
-        "modifiedTime": 1770631107687
+        "modifiedTime": 1771281848850
       },
       "_key": "!items.effects!yOlZYERCLxYMAZq5.dk03CWyervo5sqho"
     }
@@ -83,7 +83,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770627049284,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281841942,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "ownership": {

--- a/src/packs/spells/effect_Effect__Terra__Reduce_Action__MzygNOJrSay8vRv9.json
+++ b/src/packs/spells/effect_Effect__Terra__Reduce_Action__MzygNOJrSay8vRv9.json
@@ -5,7 +5,7 @@
   "_id": "MzygNOJrSay8vRv9",
   "img": "systems/projectfu/styles/static/compendium/classes/elementalist/spells/terra.png",
   "system": {
-    "fuid": "effect-terra",
+    "fuid": "effect-terra-reduce-action",
     "cost": {
       "value": 0
     },
@@ -82,7 +82,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1770629326141,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281591876,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "_key": "!items!MzygNOJrSay8vRv9"

--- a/src/packs/spells/spell_Comet_Vem0KAbARyK1FtPk.json
+++ b/src/packs/spells/spell_Comet_Vem0KAbARyK1FtPk.json
@@ -80,7 +80,7 @@
       },
       "damage": {
         "hasDamage": {
-          "value": false
+          "value": true
         },
         "value": 40,
         "type": {
@@ -130,64 +130,59 @@
         },
         "rules": {
           "elements": {
-            "CoR1jyfKzPYZu0UK": {
+            "SXh3717drl3PK78W": {
               "type": "ruleElement",
-              "_id": "CoR1jyfKzPYZu0UK",
+              "_id": "SXh3717drl3PK78W",
               "trigger": {
-                "_id": "395fSgy9eYR09Ou2",
-                "type": "initializeCheckRuleTrigger",
+                "_id": "0aRmLO2YsD8scS1X",
+                "type": "calculateDamageRuleTrigger",
                 "eventRelation": "source",
-                "checkTypes": [
-                  "display"
-                ],
-                "itemGroups": [
+                "damageSources": [
                   "spell"
                 ],
-                "local": true
+                "damageTypes": [],
+                "local": true,
+                "identifier": ""
               },
               "predicates": {
-                "VHcYdgzP3G35aWUH": {
+                "AodT2MdkVB5tsQV2": {
                   "type": "targetingRulePredicate",
-                  "_id": "VHcYdgzP3G35aWUH"
+                  "_id": "AodT2MdkVB5tsQV2"
                 }
               },
               "actions": {
-                "5UdRNclWvgXm4XSI": {
-                  "type": "applyDamageRuleAction",
-                  "_id": "5UdRNclWvgXm4XSI",
-                  "damageType": "untyped",
-                  "amount": "&step(60,65,70)"
+                "WyX6PaIobET2yoYb": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "WyX6PaIobET2yoYb",
+                  "amount": "20",
+                  "cost": {
+                    "amount": null
+                  }
                 }
               }
             },
-            "tI4N8LT6RTeRECcB": {
+            "jnuMlX7Qb1nEZMn6": {
               "type": "ruleElement",
-              "_id": "tI4N8LT6RTeRECcB",
+              "_id": "jnuMlX7Qb1nEZMn6",
               "trigger": {
-                "_id": "uuIk2ySmgQwdqeMh",
-                "type": "initializeCheckRuleTrigger",
+                "_id": "0cnbhoYqDGElIX9Y",
+                "type": "calculateDamageRuleTrigger",
                 "eventRelation": "source",
-                "checkTypes": [
-                  "display"
-                ],
-                "itemGroups": [
+                "damageSources": [
                   "spell"
                 ],
-                "local": true
-              },
-              "predicates": {
-                "dhS3ciD0FaimwJHS": {
-                  "type": "targetingRulePredicate",
-                  "_id": "dhS3ciD0FaimwJHS",
-                  "rule": "multiple"
-                }
+                "damageTypes": [],
+                "local": true,
+                "identifier": ""
               },
               "actions": {
-                "M8Z4VifZdLnXFZio": {
-                  "type": "applyDamageRuleAction",
-                  "_id": "M8Z4VifZdLnXFZio",
-                  "damageType": "untyped",
-                  "amount": "&step(40,45,50)"
+                "19CGjOE3D0EP7J0n": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "19CGjOE3D0EP7J0n",
+                  "amount": "&step(0,5,10)",
+                  "cost": {
+                    "amount": null
+                  }
                 }
               }
             }
@@ -213,7 +208,7 @@
       "description": "",
       "origin": null,
       "tint": "#ffffff",
-      "transfer": true,
+      "transfer": false,
       "statuses": [],
       "sort": 0,
       "flags": {},
@@ -221,12 +216,12 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1766925762344,
-        "modifiedTime": 1766925891865,
-        "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+        "modifiedTime": 1771280103688,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!Vem0KAbARyK1FtPk.wscCbuVvN366MDvB"
     }
@@ -248,7 +243,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1710548744272,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771280040168,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/spells/spell_Reinforce_ZxDpmAqbYQqDULxd.json
+++ b/src/packs/spells/spell_Reinforce_ZxDpmAqbYQqDULxd.json
@@ -8,7 +8,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>You protect the targets from attacks that would corrupt their body and spirit. Choose <strong>dazed</strong>, <strong>enraged</strong>, <strong>poisoned</strong>, <strong>shaken</strong>, <strong>slow</strong>, or <strong>weak</strong>. Until this spell ends, each target becomes immune to the chosen status effect.</p><p></p>",
+    "description": "<p>You protect the targets from attacks that would corrupt their body and spirit. Choose <strong>dazed</strong>, <strong>enraged</strong>, <strong>poisoned</strong>, <strong>shaken</strong>, <strong>slow</strong>, or <strong>weak</strong>. Until this spell ends, each target is immune to the chosen status effect.</p>",
     "showTitleCard": {
       "value": false
     },
@@ -138,7 +138,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706573024313,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771281739924,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/spells/spell_Volcano_BfZqKbr38FBxLtmH.json
+++ b/src/packs/spells/spell_Volcano_BfZqKbr38FBxLtmH.json
@@ -81,7 +81,7 @@
       },
       "damage": {
         "hasDamage": {
-          "value": false
+          "value": true
         },
         "value": 30,
         "type": {
@@ -134,95 +134,59 @@
         },
         "rules": {
           "elements": {
-            "LLjAUjm1atiHjNOr": {
+            "bpEHcAozT1dTq7uI": {
               "type": "ruleElement",
-              "_id": "LLjAUjm1atiHjNOr",
+              "_id": "bpEHcAozT1dTq7uI",
               "trigger": {
-                "_id": "hrm2f70g97hm7hai",
-                "type": "initializeCheckRuleTrigger",
+                "_id": "UyoH5dlBTqOYvF3a",
+                "type": "calculateDamageRuleTrigger",
                 "eventRelation": "source",
-                "checkTypes": [
-                  "display"
-                ],
-                "itemGroups": [
+                "damageSources": [
                   "spell"
                 ],
-                "local": true
+                "damageTypes": [],
+                "local": true,
+                "identifier": ""
               },
               "predicates": {
-                "0VQk17DxBEUD6l7f": {
+                "tERBowIlByYXufgz": {
                   "type": "targetingRulePredicate",
-                  "_id": "0VQk17DxBEUD6l7f"
+                  "_id": "tERBowIlByYXufgz"
                 }
               },
               "actions": {
-                "BTcueuJ9Sn7ZSvKt": {
-                  "type": "applyDamageRuleAction",
-                  "_id": "BTcueuJ9Sn7ZSvKt",
-                  "damageType": "fire",
-                  "amount": "&step(50,55,60)"
+                "GVyAF0eRAHeOV4DL": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "GVyAF0eRAHeOV4DL",
+                  "amount": "20",
+                  "cost": {
+                    "amount": null
+                  }
                 }
               }
             },
-            "qTbVxDiyfeahghsE": {
+            "YEgOpVaDNX6JdTIh": {
               "type": "ruleElement",
-              "_id": "qTbVxDiyfeahghsE",
+              "_id": "YEgOpVaDNX6JdTIh",
               "trigger": {
-                "_id": "KWDj8owDZWo9PNor",
-                "type": "initializeCheckRuleTrigger",
+                "_id": "3Bq3iIz8TMscOOAs",
+                "type": "calculateDamageRuleTrigger",
                 "eventRelation": "source",
-                "checkTypes": [
-                  "display"
-                ],
-                "itemGroups": [
+                "damageSources": [
                   "spell"
                 ],
-                "local": true
+                "damageTypes": [],
+                "local": true,
+                "identifier": ""
               },
               "actions": {
-                "wktxan2BwxpdjTOE": {
-                  "type": "applyDamageRuleAction",
-                  "_id": "wktxan2BwxpdjTOE",
-                  "damageType": "fire",
-                  "amount": "&step(30,35,40)"
-                }
-              },
-              "predicates": {
-                "DbL8rFxoEAJVZN9o": {
-                  "type": "targetingRulePredicate",
-                  "_id": "DbL8rFxoEAJVZN9o",
-                  "rule": "multiple"
-                }
-              }
-            },
-            "2BEdovVEUu8UE7y3": {
-              "type": "ruleElement",
-              "_id": "2BEdovVEUu8UE7y3",
-              "trigger": {
-                "_id": "Prkb1QGQj4ecENhh",
-                "type": "initializeCheckRuleTrigger",
-                "eventRelation": "source",
-                "checkTypes": [
-                  "display"
-                ],
-                "itemGroups": [
-                  "spell"
-                ],
-                "local": true
-              },
-              "predicates": {
-                "z0h0MsJJHJhgNylF": {
-                  "type": "targetingRulePredicate",
-                  "_id": "z0h0MsJJHJhgNylF",
-                  "rule": "none"
-                }
-              },
-              "actions": {
-                "s7zxORGGFSKiYJGL": {
-                  "type": "applyDamageRuleAction",
-                  "_id": "s7zxORGGFSKiYJGL",
-                  "damageType": "fire",
-                  "amount": "&step(30,35,40)"
+                "KTcroBv5g7VeP0ev": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "KTcroBv5g7VeP0ev",
+                  "amount": "&step(0,5,10)",
+                  "cost": {
+                    "amount": null
+                  }
                 }
               }
             }
@@ -260,7 +224,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1766869743926,
-        "modifiedTime": 1770621373193,
+        "modifiedTime": 1771279894138,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!BfZqKbr38FBxLtmH.zV3cnqvXYnDpSY9s"
@@ -283,7 +247,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1710548265766,
-    "modifiedTime": 1770872382467,
+    "modifiedTime": 1771279790779,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,


### PR DESCRIPTION
New automation for Heroic Skills and clean up of various Spells.

## General Summary
- Added Shadow Strike damage type changing automation through Rule Elements for Brambleheart and Nether Slash.
- Added Resistance effects for Nether Slash.
- Added automation for Ceaseless Battlefield to halve MP cost for the appropriate Skills.
- Added automation for Paso Doble to remove MP cost for Follow My Lead while in Crisis.
- Altered rule elements for Volcano and Comet. They now have a base damage set up in their Attributes. The Rule Elements add the +20 damage for targeting a single enemy. Also, they handle the scaling damage by level. This allows these spells to detect properly as "damage" spells and gain bonuses from "spell damage bonus" effects.
- Went through the NPC Spells and moved many effects into the Attributes.
- Added effects for the War Cry and Shell spells.
- Added effects for the Weaken spell. Left them as inline effects since a GM will need to easily remove the unneeded effects from the spell when they add it to an NPC. 
- Updated wording on spell effects to not say the name of the spell that will end. That way the effect could potentially be reused for renamed versions of those spells.
- Fixed Spellblade Rule Element to include check for DEX attribute to grant Accuracy bonus.