### PR TITLE
Refactor the skill hooks and rolls into base skill data model

### DIFF
--- a/module/documents/items/heroic/heroic-skill-data-model.mjs
+++ b/module/documents/items/heroic/heroic-skill-data-model.mjs
@@ -1,86 +1,36 @@
-import { ProgressDataModel } from '../common/progress-data-model.mjs';
-import { CheckHooks } from '../../../checks/check-hooks.mjs';
 import { FU } from '../../../helpers/config.mjs';
-import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
-import { CommonSections } from '../../../checks/common-sections.mjs';
-import { FUSubTypedItemDataModel } from '../item-data-model.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
-
-/** @type RenderCheckHook */
-Hooks.on(CheckHooks.renderCheck, (data, check, actor, item) => {
-	if (item?.system instanceof HeroicSkillDataModel) {
-		CommonSections.tags(data.sections, [
-			{
-				tag: FU.heroicType[item.system.subtype.value],
-			},
-			{
-				tag: 'FU.Class',
-				separator: ':',
-				value: item.system.class.value,
-				show: item.system.class.value,
-			},
-		]);
-
-		if (item.system.requirement.value)
-			data.sections.push({
-				content: `
-                  <div class='chat-desc'>
-                    <p><strong>${game.i18n.localize('FU.Requirements')}: </strong>${item.system.requirement.value}</p>
-                  </div>`,
-			});
-
-		if (item.system.hasResource.value) {
-			CommonSections.resource(data.sections, item.system.rp);
-		}
-
-		CommonSections.description(data.sections, item.system.description, item.system.summary.value);
-	}
-});
+import { TraitUtils } from '../../../pipelines/traits.mjs';
+import { BaseSkillDataModel } from '../skill/base-skill-data-model.mjs';
 
 /**
  * @property {string} subtype.value
- * @property {string} summary.value
- * @property {string} description
- * @property {boolean} showTitleCard.value
  * @property {string} class.value
  * @property {string} requirement.value
- * @property {string} source.value
+ * @property {string} description
+ * @property {string} opportunity
+ * @property {UseWeaponDataModelV2} useWeapon
+ * @property {ItemAttributesDataModelV2} attributes
+ * @property {number} accuracy
+ * @property {Defense} defense
+ * @property {DamageDataModelV2} damage
+ * @property {EffectApplicationDataModel} effects
+ * @property {ActionCostDataModel} cost
+ * @property {TargetingDataModel} targeting
+ * @property {Set<String>} traits
  */
-export class HeroicSkillDataModel extends FUSubTypedItemDataModel {
-	static {
-		deprecationNotice(this, 'level.min');
-		deprecationNotice(this, 'level.value');
-		deprecationNotice(this, 'level.max');
-		deprecationNotice(this, 'useWeapon.accuracy.value');
-		deprecationNotice(this, 'useWeapon.damage.value');
-		deprecationNotice(this, 'useWeapon.hrZero.value');
-		deprecationNotice(this, 'attributes.primary.value');
-		deprecationNotice(this, 'attributes.secondary.value');
-		deprecationNotice(this, 'accuracy.value');
-		deprecationNotice(this, 'damage.hasDamage.value');
-		deprecationNotice(this, 'damage.value');
-		deprecationNotice(this, 'damage.type.value');
-		deprecationNotice(this, 'impdamage.hasImpDamage.value');
-		deprecationNotice(this, 'impdamage.value');
-		deprecationNotice(this, 'impdamage.impType.value');
-		deprecationNotice(this, 'impdamage.type.value');
-		deprecationNotice(this, 'benefits.resources.hp.value');
-		deprecationNotice(this, 'benefits.resources.mp.value');
-		deprecationNotice(this, 'benefits.resources.ip.value');
-	}
-
+export class HeroicSkillDataModel extends BaseSkillDataModel {
 	static defineSchema() {
-		const { SchemaField, StringField, BooleanField, EmbeddedDataField } = foundry.data.fields;
+		const { SchemaField, StringField } = foundry.data.fields;
 		return Object.assign(super.defineSchema(), {
+			subtype: new SchemaField({ value: new StringField() }),
 			class: new SchemaField({ value: new StringField() }),
-			hasResource: new SchemaField({ value: new BooleanField() }),
-			rp: new EmbeddedDataField(ProgressDataModel, {}),
 			requirement: new SchemaField({ value: new StringField() }),
 		});
 	}
 
 	get attributePartials() {
-		return [ItemPartialTemplates.standard, ItemPartialTemplates.classField, ItemPartialTemplates.heroicSkill, ItemPartialTemplates.resourcePoints];
+		return [...this.commonPartials, ItemPartialTemplates.classField, ItemPartialTemplates.heroicSkill];
 	}
 
 	/**
@@ -92,5 +42,12 @@ export class HeroicSkillDataModel extends FUSubTypedItemDataModel {
 		return this.parent.update({
 			'system.rp': this.rp.getProgressUpdate(event, target, { indirect: { dataAttribute: 'data-resource-action', attributeValueIncrement: 'increment', attributeValueDecrement: 'decrement' } }),
 		});
+	}
+
+	/**
+	 * @override
+	 */
+	getTags() {
+		return [{ tag: 'FU.Class', separator: ':', value: this.class.value, show: this.class.value }, { tag: FU.heroicType[this.subtype.value] }, ...TraitUtils.toTags(this.traits)];
 	}
 }

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -1,86 +1,8 @@
 import { ProgressDataModel } from '../common/progress-data-model.mjs';
 import { MiscAbilityMigrations } from './misc-ability-migrations.mjs';
-import { CheckHooks } from '../../../checks/check-hooks.mjs';
 import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
-import { Checks } from '../../../checks/checks.mjs';
-import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
-import { ChooseWeaponDialog } from '../skill/choose-weapon-dialog.mjs';
-import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
-import { CommonSections } from '../../../checks/common-sections.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
-import { TraitUtils } from '../../../pipelines/traits.mjs';
 import { BaseSkillDataModel } from '../skill/base-skill-data-model.mjs';
-import { CommonEvents } from '../../../checks/common-events.mjs';
-
-const skillForAttributeCheck = 'skillForAttributeCheck';
-
-/**
- * @type RenderCheckHook
- */
-let onRenderAccuracyCheck = async (data, check, actor, item, flags) => {
-	if (check.type === 'accuracy' && item?.system instanceof MiscAbilityDataModel) {
-		const inspector = CheckConfiguration.inspect(check);
-		const weapon = await fromUuid(inspector.getWeaponReference());
-		if (check.critical) {
-			CommonSections.opportunity(data.sections, item.system.opportunity, CHECK_DETAILS);
-		}
-		CommonSections.description(data.sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
-		if (item.system.hasClock.value) {
-			CommonSections.clock(data.sections, item.system.progress, CHECK_DETAILS);
-		}
-
-		// Tag info
-		let tags = [];
-		tags.push(...TraitUtils.toTags(item.system.traits));
-		if (weapon) {
-			if (weapon.system.getTags instanceof Function) {
-				tags.push(...weapon.system.getTags(item.system.useWeapon.traits));
-			}
-		}
-		CommonSections.tags(data.sections, tags, CHECK_DETAILS);
-	}
-};
-Hooks.on(CheckHooks.renderCheck, onRenderAccuracyCheck);
-
-/**
- * @type RenderCheckHook
- */
-let onRenderAttributeCheck = async (data, check, actor, item, flags) => {
-	if (check.type === 'attribute' && item?.system instanceof MiscAbilityDataModel && check.additionalData[skillForAttributeCheck]) {
-		const inspector = CheckConfiguration.inspect(check);
-		const ability = await fromUuid(inspector.getWeaponReference());
-		CommonSections.itemFlavor(data.sections, ability);
-		if (check.critical) {
-			CommonSections.opportunity(data.sections, ability.system.opportunity, CHECK_DETAILS);
-		}
-		CommonSections.description(data.sections, ability.system.description, ability.system.summary.value, CHECK_DETAILS, true);
-		if (ability.system.hasClock.value) {
-			CommonSections.clock(data.sections, item.system.progress, CHECK_DETAILS);
-		}
-	}
-};
-
-Hooks.on(CheckHooks.renderCheck, onRenderAttributeCheck);
-
-/**
- * @type RenderCheckHook
- */
-const onRenderDisplay = (data, check, actor, item, flags) => {
-	if (check.type === 'display' && item?.system instanceof MiscAbilityDataModel) {
-		const skill = item.system;
-		CommonSections.tags(data.sections, skill.getCommonTags(), CHECK_DETAILS);
-		if (item.system.hasResource.value) {
-			CommonSections.resource(data.sections, item.system.rp, CHECK_DETAILS);
-		}
-		CommonSections.description(data.sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
-		const inspector = CheckConfiguration.inspect(check);
-		const targets = inspector.getTargetsOrDefault();
-		CommonSections.actions(data, actor, item, targets, flags, inspector);
-		CommonEvents.skill(actor, item);
-	}
-};
-
-Hooks.on(CheckHooks.renderCheck, onRenderDisplay);
 
 /**
  * @property {string} subtype.value
@@ -140,75 +62,8 @@ export class MiscAbilityDataModel extends BaseSkillDataModel {
 		return source;
 	}
 
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @return {Promise<void>}
-	 */
-	async roll(modifiers) {
-		if (this.hasRoll.value) {
-			if (this.useWeapon.accuracy) {
-				return Checks.accuracyCheck(this.parent.actor, this.parent, this.#initializeAccuracyCheck(modifiers));
-			} else {
-				return Checks.attributeCheck(
-					this.parent.actor,
-					{
-						primary: this.attributes.primary,
-						secondary: this.attributes.secondary,
-					},
-					this.parent,
-					this.#initializeAttributeCheck(modifiers),
-				);
-			}
-		}
-		return Checks.display(this.parent.actor, this.parent, this.#initializeSkillDisplay(modifiers));
-	}
-
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @return {CheckCallback}
-	 * @remarks Expects a weapon
-	 */
-	#initializeSkillDisplay(modifiers) {
-		return async (check, actor, item) => {
-			const config = CheckConfiguration.configure(check);
-			await this.configureDisplayCheck(config, actor, item);
-		};
-	}
-
-	/**
-	 * @return {CheckCallback}
-	 */
-	#initializeAttributeCheck(modifiers) {
-		return async (check, actor, item) => {
-			await this.configureAttributeCheck(modifiers, check, actor, item);
-		};
-	}
-
-	/**
-	 * @param modifiers
-	 * @return {CheckCallback}
-	 */
-	#initializeAccuracyCheck(modifiers) {
-		return async (check, actor, item) => {
-			const weapon = await ChooseWeaponDialog.prompt(actor, true);
-			if (weapon === false) {
-				let message = game.i18n.localize('FU.AbilityNoWeaponEquipped');
-				ui.notifications.error(message);
-				throw new Error(message);
-			}
-			if (weapon == null) {
-				throw new Error('no selection');
-			}
-			const { check: weaponCheck, error } = await Checks.prepareCheckDryRun('accuracy', actor, weapon);
-			if (error) {
-				throw error;
-			}
-
-			check.primary = weaponCheck.primary;
-			check.secondary = weaponCheck.secondary;
-
-			return this.configureAccuracyCheck(modifiers, check, actor, item, weapon);
-		};
+	getTags() {
+		return super.getTags();
 	}
 
 	get attributePartials() {

--- a/module/documents/items/misc/misc-ability-data-model.mjs
+++ b/module/documents/items/misc/misc-ability-data-model.mjs
@@ -1,6 +1,5 @@
 import { ProgressDataModel } from '../common/progress-data-model.mjs';
 import { MiscAbilityMigrations } from './misc-ability-migrations.mjs';
-import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
 import { BaseSkillDataModel } from '../skill/base-skill-data-model.mjs';
 
@@ -29,22 +28,6 @@ import { BaseSkillDataModel } from '../skill/base-skill-data-model.mjs';
  * @property {Set<String>} traits
  */
 export class MiscAbilityDataModel extends BaseSkillDataModel {
-	static {
-		deprecationNotice(this, 'rollInfo.useWeapon.accuracy.value', 'useWeapon.accuracy');
-		deprecationNotice(this, 'rollInfo.useWeapon.damage.value', 'useWeapon.damage');
-		deprecationNotice(this, 'rollInfo.useWeapon.hrZero.value', 'damage.hrZero');
-		deprecationNotice(this, 'rollInfo.attributes.primary.value', 'attributes.primary');
-		deprecationNotice(this, 'rollInfo.attributes.secondary.value', 'attributes.secondary');
-		deprecationNotice(this, 'rollInfo.accuracy.value', 'accuracy');
-		deprecationNotice(this, 'rollInfo.damage.hasDamage.value', 'damage.hasDamage');
-		deprecationNotice(this, 'rollInfo.damage.value', 'damage.value');
-		deprecationNotice(this, 'rollInfo.damage.type.value', 'damage.type');
-		deprecationNotice(this, 'impdamage.hasImpDamage.value');
-		deprecationNotice(this, 'impdamage.value');
-		deprecationNotice(this, 'impdamage.impType.value');
-		deprecationNotice(this, 'impdamage.type.value');
-	}
-
 	static defineSchema() {
 		const { SchemaField, StringField, BooleanField, NumberField, EmbeddedDataField } = foundry.data.fields;
 		return Object.assign(super.defineSchema(), {

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -153,6 +153,13 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	}
 
 	/**
+	 * @return Tag[]
+	 */
+	getTags() {
+		return TraitUtils.toTags(this.traits);
+	}
+
+	/**
 	 * @param {KeyboardModifiers} modifiers
 	 * @return {Promise<void>}
 	 */
@@ -191,7 +198,15 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 			check.primary = weaponCheck.primary;
 			check.secondary = weaponCheck.secondary;
 
-			return this.configureAccuracyCheck(modifiers, check, actor, item, weapon);
+			const config = CheckConfiguration.configure(check);
+			const targets = config.getTargets();
+			const context = ExpressionContext.fromTargetData(actor, item, targets);
+
+			config.setWeaponReference(weapon);
+			config.setHrZero(this.damage.hrZero || modifiers.shift);
+			await this.configureCheck(config, actor, item);
+			await this.addSkillDamage(config, item, context, weapon.system);
+			await this.addSkillAccuracy(config, actor, item, context);
 		};
 	}
 
@@ -201,7 +216,29 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	 */
 	#initializeAttributeCheck(modifiers) {
 		return async (check, actor, item) => {
-			await this.configureAttributeCheck(modifiers, check, actor, item);
+			const config = CheckConfiguration.configure(check);
+			const targets = config.getTargets();
+			const context = ExpressionContext.fromTargetData(actor, item, targets);
+
+			config.setWeaponReference(this.parent);
+			config.check.additionalData[skillForAttributeCheck] = this.parent.uuid;
+			config.setHrZero(this.damage.hrZero || modifiers.shift);
+			await this.configureCheck(config, actor, item);
+			await this.addSkillAccuracy(config, actor, item, context);
+			await this.addSkillDamage(config, item, context);
+			if (this.defense && targets.length === 1) {
+				let dl;
+				switch (this.defense) {
+					case 'def':
+						dl = targets[0].def;
+						break;
+
+					case 'mdef':
+						dl = targets[0].mdef;
+						break;
+				}
+				config.setDifficulty(dl);
+			}
 		};
 	}
 
@@ -213,7 +250,19 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	#initializeSkillDisplay(modifiers) {
 		return async (check, actor, item) => {
 			const config = CheckConfiguration.configure(check);
-			await this.configureDisplayCheck(config, actor, item);
+			const targets = config.getTargets();
+			const context = ExpressionContext.fromTargetData(actor, item, targets);
+			await this.configureCheck(config, actor, item);
+			if (this.damage.hasDamage) {
+				if (this.useWeapon.damage) {
+					const weapon = await this.getWeapon(actor);
+					config.setWeaponReference(weapon);
+					/** @type WeaponDataModel **/
+					const weaponData = weapon.system;
+					config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);
+				}
+				await this.addSkillDamage(config, item, context);
+			}
 		};
 	}
 
@@ -232,86 +281,6 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 			config.setResource(this.resource.type, this.resource.amount);
 		}
 		await ResourcePipeline.configureExpense(config, actor, item, this.cost);
-	}
-
-	/**
-	 * @return Tag[]
-	 */
-	getTags() {
-		return TraitUtils.toTags(this.traits);
-	}
-
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @param {CheckV2|CheckResultV2} check
-	 * @param {FUActor} actor
-	 * @param {FUItem} item
-	 */
-	async configureAttributeCheck(modifiers, check, actor, item) {
-		const config = CheckConfiguration.configure(check);
-		const targets = config.getTargets();
-		const context = ExpressionContext.fromTargetData(actor, item, targets);
-
-		config.setWeaponReference(this.parent);
-		config.check.additionalData[skillForAttributeCheck] = this.parent.uuid;
-		config.setHrZero(this.damage.hrZero || modifiers.shift);
-		await this.configureCheck(config, actor, item);
-		await this.addSkillAccuracy(config, actor, item, context);
-		await this.addSkillDamage(config, item, context);
-		if (this.defense && targets.length === 1) {
-			let dl;
-			switch (this.defense) {
-				case 'def':
-					dl = targets[0].def;
-					break;
-
-				case 'mdef':
-					dl = targets[0].mdef;
-					break;
-			}
-			config.setDifficulty(dl);
-		}
-	}
-
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @param {CheckV2|CheckResultV2} check
-	 * @param {FUActor} actor
-	 * @param {FUItem} item
-	 * @param {FUItem} weapon
-	 */
-	async configureAccuracyCheck(modifiers, check, actor, item, weapon) {
-		const config = CheckConfiguration.configure(check);
-		const targets = config.getTargets();
-		const context = ExpressionContext.fromTargetData(actor, item, targets);
-
-		config.setWeaponReference(weapon);
-		config.setHrZero(this.damage.hrZero || modifiers.shift);
-		await this.configureCheck(config, actor, item);
-		await this.addSkillDamage(config, item, context, weapon.system);
-		await this.addSkillAccuracy(config, actor, item, context);
-	}
-
-	/**
-	 * @desc Common configuration for display checks.
-	 * @param {CheckConfigurer} config
-	 * @param {FUActor} actor
-	 * @param {FUItem} item
-	 */
-	async configureDisplayCheck(config, actor, item) {
-		const targets = config.getTargets();
-		const context = ExpressionContext.fromTargetData(actor, item, targets);
-		await this.configureCheck(config, actor, item);
-		if (this.damage.hasDamage) {
-			if (this.useWeapon.damage) {
-				const weapon = await this.getWeapon(actor);
-				config.setWeaponReference(weapon);
-				/** @type WeaponDataModel **/
-				const weaponData = weapon.system;
-				config.setDamage(this.damage.type || weaponData.damageType.value, weaponData.damage.value);
-			}
-			await this.addSkillDamage(config, item, context);
-		}
 	}
 
 	/**

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -16,8 +16,89 @@ import { WeaponDataModel } from '../weapon/weapon-data-model.mjs';
 import { ResourcePipeline } from '../../../pipelines/resource-pipeline.mjs';
 import { BasicItemDataModel } from '../basic/basic-item-data-model.mjs';
 import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
+import { Checks } from '../../../checks/checks.mjs';
+import { CommonSections } from '../../../checks/common-sections.mjs';
+import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
+import { CheckHooks } from '../../../checks/check-hooks.mjs';
+import { CommonEvents } from '../../../checks/common-events.mjs';
 
 const skillForAttributeCheck = 'skillForAttributeCheck';
+
+/**
+ * @type RenderCheckHook
+ */
+let onRenderAccuracyCheck = async (data, check, actor, item, flags) => {
+	if (check.type === 'accuracy' && item?.system instanceof BaseSkillDataModel) {
+		const inspector = CheckConfiguration.inspect(check);
+		const weapon = await fromUuid(inspector.getWeaponReference());
+
+		if (check.critical) {
+			CommonSections.opportunity(data.sections, item.system.opportunity, CHECK_DETAILS);
+		}
+
+		let tags = item.system.getTags();
+		if (weapon) {
+			if (weapon.system.getTags instanceof Function) {
+				tags.push(...weapon.system.getTags(item.system.useWeapon.traits));
+			}
+		}
+		CommonSections.tags(data.sections, tags, CHECK_DETAILS);
+		CommonSections.description(data.sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
+
+		if (item.system.hasClock?.value) {
+			CommonSections.clock(data.sections, item.system.progress, CHECK_DETAILS);
+		}
+	}
+};
+Hooks.on(CheckHooks.renderCheck, onRenderAccuracyCheck);
+
+/**
+ * @type RenderCheckHook
+ */
+let onRenderAttributeCheck = async (data, check, actor, item, flags) => {
+	if (check.type === 'attribute' && item?.system instanceof BaseSkillDataModel && check.additionalData[skillForAttributeCheck]) {
+		const skill = await fromUuid(check.additionalData[skillForAttributeCheck]);
+		const inspector = CheckConfiguration.inspect(check);
+		CommonSections.itemFlavor(data.sections, skill);
+		CommonSections.tags(data.sections, skill.system.getTags(), CHECK_DETAILS);
+		CommonSections.description(data.sections, skill.system.description, skill.system.summary.value, CHECK_DETAILS);
+		CommonSections.actions(data, actor, item, [], flags, inspector);
+
+		if (check.critical) {
+			CommonSections.opportunity(data.sections, skill.system.opportunity, CHECK_DETAILS);
+		}
+
+		if (skill.system.hasResource?.value) {
+			CommonSections.resource(data.sections, skill.system.rp, CHECK_DETAILS);
+		}
+		if (skill.system.hasClock?.value) {
+			CommonSections.clock(data.sections, item.system.progress, CHECK_DETAILS);
+		}
+	}
+};
+
+Hooks.on(CheckHooks.renderCheck, onRenderAttributeCheck);
+
+/**
+ * @type RenderCheckHook
+ */
+const onRenderDisplay = (data, check, actor, item, flags) => {
+	if (check.type === 'display' && item?.system instanceof BaseSkillDataModel) {
+		CommonSections.tags(data.sections, item.system.getTags(), CHECK_DETAILS);
+		CommonSections.description(data.sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
+		const inspector = CheckConfiguration.inspect(check);
+		const targets = inspector.getTargetsOrDefault();
+		// TODO: Find a better way to handle this, as it's needed when using a spell without accuracy
+		if (!item.system.hasRoll.value) {
+			CommonSections.actions(data, actor, item, targets, flags, inspector);
+		}
+		if (item.system.hasResource?.value) {
+			CommonSections.resource(data.sections, item.system.rp, CHECK_DETAILS);
+		}
+		CommonEvents.skill(actor, item);
+	}
+};
+Hooks.on(CheckHooks.renderCheck, onRenderDisplay);
 
 /**
  * @property {string} description
@@ -72,6 +153,71 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	}
 
 	/**
+	 * @param {KeyboardModifiers} modifiers
+	 * @return {Promise<void>}
+	 */
+	async roll(modifiers) {
+		if (this.hasRoll.value) {
+			if (this.useWeapon.accuracy) {
+				return Checks.accuracyCheck(this.parent.actor, this.parent, this.#initializeAccuracyCheck(modifiers));
+			} else {
+				return Checks.attributeCheck(
+					this.parent.actor,
+					{
+						primary: this.attributes.primary,
+						secondary: this.attributes.secondary,
+					},
+					this.parent,
+					this.#initializeAttributeCheck(modifiers),
+				);
+			}
+		}
+		return Checks.display(this.parent.actor, this.parent, this.#initializeSkillDisplay(modifiers));
+	}
+
+	/**
+	 * @param modifiers
+	 * @return {CheckCallback}
+	 * @override
+	 */
+	#initializeAccuracyCheck(modifiers) {
+		return async (check, actor, item) => {
+			const weapon = await this.getWeapon(actor);
+			const { check: weaponCheck, error } = await Checks.prepareCheckDryRun('accuracy', actor, weapon);
+			if (error) {
+				throw error;
+			}
+
+			check.primary = weaponCheck.primary;
+			check.secondary = weaponCheck.secondary;
+
+			return this.configureAccuracyCheck(modifiers, check, actor, item, weapon);
+		};
+	}
+
+	/**
+	 * @param {KeyboardModifiers} modifiers
+	 * @return {CheckCallback}
+	 */
+	#initializeAttributeCheck(modifiers) {
+		return async (check, actor, item) => {
+			await this.configureAttributeCheck(modifiers, check, actor, item);
+		};
+	}
+
+	/**
+	 * @param {KeyboardModifiers} modifiers
+	 * @return {CheckCallback}
+	 * @remarks Expects a weapon
+	 */
+	#initializeSkillDisplay(modifiers) {
+		return async (check, actor, item) => {
+			const config = CheckConfiguration.configure(check);
+			await this.configureDisplayCheck(config, actor, item);
+		};
+	}
+
+	/**
 	 * @desc Common configuration for attribute checks.
 	 * @param {CheckConfigurer} config
 	 * @param {FUActor} actor
@@ -91,7 +237,7 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	/**
 	 * @return Tag[]
 	 */
-	getCommonTags() {
+	getTags() {
 		return TraitUtils.toTags(this.traits);
 	}
 

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -1,87 +1,8 @@
-import { CheckHooks } from '../../../checks/check-hooks.mjs';
-import { Checks } from '../../../checks/checks.mjs';
-import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
-import { CommonSections } from '../../../checks/common-sections.mjs';
-import { CHECK_DETAILS } from '../../../checks/default-section-order.mjs';
 import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
 import { SkillMigrations } from './skill-migrations.mjs';
-import { CommonEvents } from '../../../checks/common-events.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
 import { TraitUtils } from '../../../pipelines/traits.mjs';
 import { BaseSkillDataModel } from './base-skill-data-model.mjs';
-
-const skillForAttributeCheck = 'skillForAttributeCheck';
-
-/**
- * @type RenderCheckHook
- */
-let onRenderAccuracyCheck = async (data, check, actor, item, flags) => {
-	if (check.type === 'accuracy' && item?.system instanceof SkillDataModel) {
-		const inspector = CheckConfiguration.inspect(check);
-		const weapon = await fromUuid(inspector.getWeaponReference());
-
-		if (check.critical) {
-			CommonSections.opportunity(data.sections, item.system.opportunity, CHECK_DETAILS);
-		}
-
-		let tags = getTags(item);
-		if (weapon) {
-			if (weapon.system.getTags instanceof Function) {
-				tags.push(...weapon.system.getTags(item.system.useWeapon.traits));
-			}
-		}
-		CommonSections.tags(data.sections, tags, CHECK_DETAILS);
-		CommonSections.description(data.sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
-	}
-};
-Hooks.on(CheckHooks.renderCheck, onRenderAccuracyCheck);
-
-/**
- * @type RenderCheckHook
- */
-let onRenderAttributeCheck = async (data, check, actor, item, flags) => {
-	if (check.type === 'attribute' && item?.system instanceof SkillDataModel && check.additionalData[skillForAttributeCheck]) {
-		const skill = await fromUuid(check.additionalData[skillForAttributeCheck]);
-		const inspector = CheckConfiguration.inspect(check);
-		CommonSections.itemFlavor(data.sections, skill);
-		CommonSections.tags(data.sections, getTags(skill), CHECK_DETAILS);
-		if (skill.system.hasResource.value) {
-			CommonSections.resource(data.sections, skill.system.rp, CHECK_DETAILS);
-		}
-		CommonSections.description(data.sections, skill.system.description, skill.system.summary.value, CHECK_DETAILS);
-		CommonSections.actions(data, actor, item, [], flags, inspector);
-	}
-};
-Hooks.on(CheckHooks.renderCheck, onRenderAttributeCheck);
-
-/**
- * @type RenderCheckHook
- */
-const onRenderDisplay = (data, check, actor, item, flags) => {
-	if (check.type === 'display' && item?.system instanceof SkillDataModel) {
-		CommonSections.tags(data.sections, getTags(item), CHECK_DETAILS);
-		if (item.system.hasResource.value) {
-			CommonSections.resource(data.sections, item.system.rp, CHECK_DETAILS);
-		}
-		CommonSections.description(data.sections, item.system.description, item.system.summary.value, CHECK_DETAILS);
-		const inspector = CheckConfiguration.inspect(check);
-		const targets = inspector.getTargetsOrDefault();
-		// TODO: Find a better way to handle this, as it's needed when using a spell without accuracy
-		if (!item.system.hasRoll.value) {
-			CommonSections.actions(data, actor, item, targets, flags, inspector);
-		}
-		CommonEvents.skill(actor, item);
-	}
-};
-Hooks.on(CheckHooks.renderCheck, onRenderDisplay);
-
-/**
- * @param {FUItem} skill
- * @return Tag[]
- */
-function getTags(skill) {
-	return [{ tag: 'FU.Class', separator: ':', value: skill.system.class.value, show: skill.system.class.value }, { tag: 'FU.SkillLevelAbbr', separator: ' ', value: skill.system.level.value }, ...TraitUtils.toTags(skill.system.traits)];
-}
 
 /**
  * @property {string} subtype.value
@@ -141,71 +62,6 @@ export class SkillDataModel extends BaseSkillDataModel {
 		return source;
 	}
 
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @return {Promise<void>}
-	 */
-	async roll(modifiers) {
-		if (this.hasRoll.value) {
-			if (this.useWeapon.accuracy) {
-				return Checks.accuracyCheck(this.parent.actor, this.parent, this.#initializeAccuracyCheck(modifiers));
-			} else {
-				return Checks.attributeCheck(
-					this.parent.actor,
-					{
-						primary: this.attributes.primary,
-						secondary: this.attributes.secondary,
-					},
-					this.parent,
-					this.#initializeAttributeCheck(modifiers),
-				);
-			}
-		}
-		return Checks.display(this.parent.actor, this.parent, this.#initializeSkillDisplay(modifiers));
-	}
-
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @return {CheckCallback}
-	 * @remarks Expects a weapon
-	 */
-	#initializeSkillDisplay(modifiers) {
-		return async (check, actor, item) => {
-			const config = CheckConfiguration.configure(check);
-			await this.configureDisplayCheck(config, actor, item);
-		};
-	}
-
-	/**
-	 * @return {CheckCallback}
-	 */
-	#initializeAttributeCheck(modifiers) {
-		return async (check, actor, item) => {
-			const config = CheckConfiguration.configure(check);
-			await this.configureAttributeCheck(modifiers, config, actor, item);
-		};
-	}
-
-	/**
-	 * @param {KeyboardModifiers} modifiers
-	 * @return {CheckCallback}
-	 * @remarks Expects a weapon
-	 */
-	#initializeAccuracyCheck(modifiers) {
-		return async (check, actor, item) => {
-			const weapon = await this.getWeapon(actor);
-			const { check: weaponCheck, error } = await Checks.prepareCheckDryRun('accuracy', actor, weapon);
-			if (error) {
-				throw error;
-			}
-
-			check.primary = weaponCheck.primary;
-			check.secondary = weaponCheck.secondary;
-
-			return this.configureAccuracyCheck(modifiers, check, actor, item, weapon);
-		};
-	}
-
 	shouldApplyEffect(effect) {
 		return this.level.value > 0;
 	}
@@ -216,6 +72,13 @@ export class SkillDataModel extends BaseSkillDataModel {
 
 	get retainedFieldPaths() {
 		return ['level.value'];
+	}
+
+	/**
+	 * @override
+	 */
+	getTags() {
+		return [{ tag: 'FU.Class', separator: ':', value: this.class.value, show: this.class.value }, { tag: 'FU.SkillLevelAbbr', separator: ' ', value: this.level.value }, ...TraitUtils.toTags(this.traits)];
 	}
 
 	/**

--- a/module/documents/items/skill/skill-data-model.mjs
+++ b/module/documents/items/skill/skill-data-model.mjs
@@ -1,4 +1,3 @@
-import { deprecationNotice } from '../../../helpers/deprecation-helper.mjs';
 import { SkillMigrations } from './skill-migrations.mjs';
 import { ItemPartialTemplates } from '../item-partial-templates.mjs';
 import { TraitUtils } from '../../../pipelines/traits.mjs';
@@ -28,22 +27,6 @@ import { BaseSkillDataModel } from './base-skill-data-model.mjs';
  * @property {Set<String>} traits
  */
 export class SkillDataModel extends BaseSkillDataModel {
-	static {
-		deprecationNotice(this, 'rollInfo.useWeapon.accuracy.value', 'useWeapon.accuracy');
-		deprecationNotice(this, 'rollInfo.useWeapon.damage.value', 'useWeapon.damage');
-		deprecationNotice(this, 'rollInfo.useWeapon.hrZero.value', 'damage.hrZero');
-		deprecationNotice(this, 'rollInfo.attributes.primary.value', 'attributes.primary');
-		deprecationNotice(this, 'rollInfo.attributes.secondary.value', 'attributes.secondary');
-		deprecationNotice(this, 'rollInfo.accuracy.value', 'accuracy');
-		deprecationNotice(this, 'rollInfo.damage.hasDamage.value', 'damage.hasDamage');
-		deprecationNotice(this, 'rollInfo.damage.value', 'damage.value');
-		deprecationNotice(this, 'rollInfo.damage.type.value', 'damage.type');
-		deprecationNotice(this, 'impdamage.hasImpDamage.value');
-		deprecationNotice(this, 'impdamage.value');
-		deprecationNotice(this, 'impdamage.impType.value');
-		deprecationNotice(this, 'impdamage.type.value');
-	}
-
 	static defineSchema() {
 		const { SchemaField, StringField, NumberField } = foundry.data.fields;
 		return Object.assign(super.defineSchema(), {


### PR DESCRIPTION
This pull request refactors the skill and ability data model system, centralizing and simplifying check rendering logic and related hooks. The most significant changes are the migration of check rendering hooks from individual item data models to the shared `BaseSkillDataModel`, the removal of duplicated and deprecated code, and the standardization of tag generation and roll logic across skills and abilities.

**Centralization and Standardization of Check Rendering:**

* Moved all check rendering hooks (`renderCheck` for accuracy, attribute, and display) from `heroic-skill-data-model.mjs` and `misc-ability-data-model.mjs` into `base-skill-data-model.mjs`, ensuring consistent behavior and reducing duplication. [[1]](diffhunk://#diff-8d1271ee402fb31d427194a16b5d1d06d9b488e50454d41d8dcd6008f80726edL1-R33) [[2]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L3-L83) [[3]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R19-R102)

**Code Cleanup and Refactoring:**

* Removed deprecated methods, legacy hooks, and duplicated roll logic from `MiscAbilityDataModel` and `HeroicSkillDataModel`, delegating these responsibilities to the base class. [[1]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L3-L83) [[2]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L110-L125) [[3]](diffhunk://#diff-8d1271ee402fb31d427194a16b5d1d06d9b488e50454d41d8dcd6008f80726edL1-R33) [[4]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0L75-R218) [[5]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R242-L157) [[6]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R266-R283)
* Updated method implementations in `BaseSkillDataModel` to handle all roll, tag, and check configuration logic, including new private methods for initializing checks and displays. [[1]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0L75-R218) [[2]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R242-L157) [[3]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0R266-R283)

**Tag Generation Improvements:**

* Standardized the `getTags()` method in `BaseSkillDataModel` and its children, allowing for consistent tag rendering and easier extension by subclasses. [[1]](diffhunk://#diff-8d1271ee402fb31d427194a16b5d1d06d9b488e50454d41d8dcd6008f80726edR46-R52) [[2]](diffhunk://#diff-c8a2c1b6d2c48b5037b5ffcf4a6c95f736528a29007a9156009094bb274dc9b0L75-R218) [[3]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L143-R49)

**Schema and Partial Templates Updates:**

* Simplified the schema definitions in `HeroicSkillDataModel` and `MiscAbilityDataModel`, removing unused fields and updating `attributePartials` to use shared partials from the base class. [[1]](diffhunk://#diff-8d1271ee402fb31d427194a16b5d1d06d9b488e50454d41d8dcd6008f80726edL1-R33) [[2]](diffhunk://#diff-759a432f9097fd70fcf3c2d3b36a0f4127612565e62968287b2cc9e70e50cf93L110-L125)

These changes will make it easier to maintain and extend the skill and ability system, while ensuring that rendering and rolling logic is consistent across all skill types.