### PR TITLE
Robustify DSN Hook

### DIFF
--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -561,6 +561,9 @@ Hooks.once('diceSoNiceReady', (dice3d) => {
 
 		const chatMessage = game.messages.get(_messageId);
 		const checkV2 = chatMessage?.flags?.projectfu?.CheckV2;
+
+		if (!checkV2) return;
+
 		const { critical = false, fumble = false } = checkV2;
 
 		const pfuSfx = { id: SYSTEM, result: null };


### PR DESCRIPTION
- Adds a quick falsy check for CheckV2 data on a roll before attempting to use it to check for critical, fumble, success, and failure Dice So Nice! effects