### PR TITLE
Add trait to ignore vulnerability

### DIFF
--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -228,8 +228,9 @@ function resolveAffinity(context) {
 	// Check if affinity should be ignored
 	if (affinity === FU.affValue.vulnerability) {
 		affinityMessage = 'FU.ChatApplyDamageVulnerable';
-		if (context.damageOverride.ignoreVulnerable) {
+		if (context.damageOverride.ignoreVulnerable || context.traits.has(Traits.IgnoreVulnerable)) {
 			affinity = FU.affValue.none;
+			affinityMessage = 'FU.ChatApplyDamageNormal';
 		}
 	}
 	if (affinity === FU.affValue.resistance) {

--- a/module/pipelines/traits.mjs
+++ b/module/pipelines/traits.mjs
@@ -46,6 +46,7 @@ export const DamageTraits = Object.freeze({
 	IgnoreResistances: 'ignore-resistances',
 	IgnoreImmunities: 'ignore-immunities',
 	IgnoreAbsorption: 'ignore-absorption',
+	IgnoreVulnerable: 'ignore-vulnerable',
 	AbsorbHalf: 'absorb-half',
 	Absorb: 'absorb',
 	MindPointLoss: 'mind-point-loss',


### PR DESCRIPTION
This pull request enhances the damage calculation pipeline by introducing a new trait to allow certain effects to bypass vulnerability checks. The main focus is on improving how vulnerabilities are handled when specific traits are present.

Trait system improvements:

* Added a new `IgnoreVulnerable` trait to the `DamageTraits` object in `traits.mjs`, enabling effects or abilities to ignore vulnerability during damage resolution.

Damage calculation logic updates:

* Updated the `resolveAffinity` function in `damage-pipeline.mjs` to check for the `IgnoreVulnerable` trait in addition to the existing `ignoreVulnerable` override. If either is present, vulnerability is ignored and normal damage is applied instead.