### PR TITLE
Add threshold fields for calculate expense

### DIFF
--- a/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
@@ -14,6 +14,7 @@ const fields = foundry.data.fields;
  * @property {FUExpenseSource} expenseSource
  * @property {String} identifier
  * @property {TraitsPredicateDataModel} traits
+ * @property {FUThreshold} threshold
  * @inheritDoc
  */
 export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
@@ -40,6 +41,10 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 				initial: '',
 				choices: Object.keys(FU.expenseSource),
 				blank: true,
+			}),
+			threshold: new fields.SchemaField({
+				operator: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.comparisonOperator) }),
+				amount: new fields.NumberField({ initial: 0 }),
 			}),
 			identifier: new fields.StringField(),
 			traits: new fields.EmbeddedDataField(TraitsPredicateDataModel, {
@@ -79,6 +84,27 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 		if (this.identifier) {
 			if (!context.matchesItem(this.identifier)) {
 				return false;
+			}
+		}
+		if (this.threshold.operator) {
+			const amount = context.event.expense.amount;
+			if (Number.isInteger(amount)) {
+				switch (this.threshold.operator) {
+					case 'greaterThan':
+						if (amount >= this.threshold.amount) {
+							return true;
+						}
+						break;
+
+					case 'lessThan':
+						if (amount <= this.threshold.amount) {
+							return true;
+						}
+						break;
+				}
+				return false;
+			} else {
+				console.warn(`The given amount in the event was not an integer.`);
 			}
 		}
 		return true;

--- a/module/documents/effects/triggers/damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/damage-rule-trigger.mjs
@@ -10,8 +10,7 @@ const fields = foundry.data.fields;
  * @extends RuleTriggerDataModel
  * @property {DamageType} damageTypes
  * @property {Set<FUItemGroup>} damageSource
- * @property {FUComparisonOperator} damageThreshold.operator
- * @property {Number} damageThreshold.amount
+ * @property {FUThreshold} damageThreshold
  * @inheritDoc
  */
 export class DamageRuleTrigger extends RuleTriggerDataModel {

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -992,6 +992,12 @@ FU.scalarOperation = {
  * @typedef {"greaterThan" | "lessThan"} FUComparisonOperator
  */
 
+/**
+ * @typedef FUThreshold
+ * @property {FUComparisonOperator} operator
+ * @property {Number} amount
+ */
+
 FU.comparisonOperator = {
 	greaterThan: 'FU.GreaterThan',
 	equals: 'FU.Equals',

--- a/templates/effects/triggers/calculate-expense-rule-trigger.hbs
+++ b/templates/effects/triggers/calculate-expense-rule-trigger.hbs
@@ -18,5 +18,19 @@
 	<input type="text" name={{pfuConcat path ".identifier"}} value="{{ trigger.identifier }}" />
 </label>
 
-{{pfuTraits trigger.traits (pfuConcat path ".traits")}}
+<div class="fu-rule-element__property-row">
+	<label class="fu-rule-element__property">
+		<span>{{localize 'FU.ComparisonOperator'}}</span>
+		<select name="{{pfuConcat path ".threshold.operator"}}">
+			<option value="">-</option>
+			{{selectOptions options.comparisonOperator selected=trigger.threshold.operator sort=true localize=true}}
+		</select>
+	</label>
 
+	<label class="fu-rule-element__property">
+		<span>{{localize 'FU.Amount'}}</span>
+		<input type="number" name="{{pfuConcat path ".threshold.amount"}}" value="{{ trigger.threshold.amount }}" />
+	</label>
+</div>
+
+{{pfuTraits trigger.traits (pfuConcat path ".traits")}}


### PR DESCRIPTION
This pull request introduces a threshold property to the `CalculateExpenseRuleTrigger` and `DamageRuleTrigger` data models, allowing for more flexible rule evaluation based on comparison operators and amounts. The changes include both backend logic and frontend template updates to support this new feature.

**Threshold property integration:**

* Added a new `FUThreshold` type definition, encapsulating an `operator` and `amount` for comparison-based rule evaluation.
* Updated the `CalculateExpenseRuleTrigger` and `DamageRuleTrigger` data models to use the new `threshold` and `damageThreshold` properties of type `FUThreshold`, replacing individual operator and amount fields. [[1]](diffhunk://#diff-c8b50dc47133649c16ff0e7d52b0c6fb84d98b643a140fd347d7d1d045c5815cR17) [[2]](diffhunk://#diff-ad41e6254bd67b498536a46c49d144b03bfaf9b922b25a8cf941fa836970562aL13-R13)
* Implemented logic in the `CalculateExpenseRuleTrigger` to evaluate rules based on the selected threshold operator and amount, supporting `greaterThan` and `lessThan` comparisons.

**Frontend updates:**

* Modified the `calculate-expense-rule-trigger.hbs` template to provide UI controls for selecting a threshold operator and entering an amount, reflecting the new backend structure.

**Schema enhancements:**

* Updated the schema definition in `CalculateExpenseRuleTrigger` to include the new `threshold` property with operator and amount fields.