### PR TITLE
Add an affinity field to the damage rule trigger

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -542,6 +542,7 @@
 		"DamageIce": "Ice",
 		"DamageLight": "Light",
 		"DamagePoison": "Poison",
+		"Affinity": "Affinity",
 		"AffinityNormal": "Normal",
 		"AffinityVulnerable": "Vulnerable",
 		"AffinityVulnerableHint": "Vulnerable Multiplier",

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -75,6 +75,7 @@ function attack(inspector, actor, item) {
  * @typedef DamageEvent
  * @property {CharacterInfo|null} source
  * @property {DamageType} type
+ * @property {FUAffinity} affinity
  * @property {InlineSourceInfo} sourceInfo
  * @property {FUItemGroup} damageSource
  * @property {Number} amount
@@ -87,7 +88,7 @@ function attack(inspector, actor, item) {
  * @property {String} origin An id used to prevent cascading.
  */
 
-async function damage(type, amount, traits, sourceActor, targetActor, sourceInfo, origin, renderData) {
+async function damage(type, affinity, amount, traits, sourceActor, targetActor, sourceInfo, origin, renderData) {
 	const source = CharacterInfo.fromActor(sourceActor);
 	const target = CharacterInfo.fromActor(targetActor);
 	const item = sourceInfo.resolveItem();
@@ -98,6 +99,7 @@ async function damage(type, amount, traits, sourceActor, targetActor, sourceInfo
 		amount: amount,
 		item: item,
 		type: type,
+		affinity: affinity,
 		source: source,
 		sourceActor: sourceInfo,
 		damageSource: damageSource,

--- a/module/documents/effects/triggers/damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/damage-rule-trigger.mjs
@@ -11,6 +11,7 @@ const fields = foundry.data.fields;
  * @property {DamageType} damageTypes
  * @property {Set<FUItemGroup>} damageSource
  * @property {FUThreshold} damageThreshold
+ * @property {FUAffinity} affinity
  * @inheritDoc
  */
 export class DamageRuleTrigger extends RuleTriggerDataModel {
@@ -31,6 +32,11 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 			damageType: new fields.StringField({
 				initial: '',
 				choices: Object.keys(FU.damageTypes),
+				blank: true,
+			}),
+			affinity: new fields.StringField({
+				initial: '',
+				choices: Object.keys(FU.affValue),
 				blank: true,
 			}),
 			damageSources: new fields.SetField(new fields.StringField()),
@@ -85,6 +91,12 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 					break;
 			}
 			return false;
+		}
+
+		if (this.affinity) {
+			if (context.event.affinity !== this.affinity) {
+				return false;
+			}
 		}
 
 		return true;

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -158,6 +158,10 @@ FU.affTypeAbbr = {
 	3: 'FU.AffinityAbsorptionAbbr',
 };
 
+/**
+ * @typedef {'none'|'vulnerability'|'resistance'|'immunity'|'absorption'} FUAffinity
+ */
+
 FU.affValue = {
 	vulnerability: -1,
 	none: 0,
@@ -165,6 +169,19 @@ FU.affValue = {
 	immunity: 2,
 	absorption: 3,
 };
+
+FU.affinities = {
+	vulnerability: 'FU.AffinityVulnerable',
+	none: 'FU.AffinityNormal',
+	resistance: 'FU.AffinityResistance',
+	immunity: 'FU.AffinityImmune',
+	absorption: 'FU.AffinityAbsorption',
+};
+
+/**
+ * @desc For reverse lookups.
+ */
+FU.affinityKeyByValue = Object.fromEntries(Object.entries(FU.affValue).map(([k, v]) => [v, k]));
 
 /**
  * @typedef {"beast" | "construct" | "demon" | "elemental" | "humanoid" | "monster" | "plant" | "undead" | "custom"} FUSpeciesKey

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -516,7 +516,7 @@ async function process(request) {
 					postRenderActions: [],
 				};
 
-				await CommonEvents.damage(request.damageType, damageTaken, context.traits, context.sourceActor, actor, context.sourceInfo, request.origin, renderData);
+				await CommonEvents.damage(request.damageType, FU.affinityKeyByValue[context.affinity], damageTaken, context.traits, context.sourceActor, actor, context.sourceInfo, request.origin, renderData);
 				await CommonEvents.resource(request.sourceActor, request.targets, resource, -damageTaken, request.origin, renderData);
 				TokenUtils.showFloatyText(actor, `${-damageTaken} ${resource.toUpperCase()}`, color);
 

--- a/templates/effects/triggers/damage-rule-trigger.hbs
+++ b/templates/effects/triggers/damage-rule-trigger.hbs
@@ -11,6 +11,14 @@
 	{{formGroup trigger.schema.fields.damageSources value=trigger.damageSources options=options.damageSourceOptions name=(pfuConcat path ".damageSources") classes="fu-rule-element__set stacked"}}
 </div>
 
+<label class="fu-rule-element__property">
+	<span>{{localize 'FU.Affinity'}}</span>
+	<select name="{{pfuConcat path ".affinity"}}">
+		<option value="">-</option>
+		{{selectOptions options.affinities selected=trigger.affinity sort=true localize=true}}
+	</select>
+</label>
+
 <div class="fu-rule-element__property-row">
 	<label class="fu-rule-element__property">
 		<span>{{localize 'FU.ComparisonOperator'}}</span>


### PR DESCRIPTION
This pull request adds support for tracking and filtering by "affinity" (such as vulnerability, resistance, immunity, etc.) in the damage system. It introduces a new `affinity` property throughout the relevant data models, event handlers, and UI, allowing more granular control over how damage rules are triggered and processed.

Key changes include:

**Affinity Support in Damage System:**

* Added a new `affinity` property to the `DamageEvent` typedef and as a parameter to the `damage` function in `common-events.mjs`, ensuring that affinity information is passed and stored with each damage event. [[1]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R78) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L90-R91) [[3]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739R102)
* Updated the damage pipeline to correctly pass the affinity value when invoking the damage event, using a new reverse lookup utility.

**Configuration and Typing:**

* Introduced the `FUAffinity` typedef and added related affinity mappings (`FU.affValue`, `FU.affinities`, `FU.affinityKeyByValue`) in `config.mjs` to standardize affinity handling and enable reverse lookups. [[1]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5R161-R164) [[2]](diffhunk://#diff-86894866dad55eef6711c7776100bdd6f662a69541c3a64bf535dda2252d03e5R173-R185)

**Rule Trigger Enhancements:**

* Extended the `DamageRuleTrigger` data model to include an `affinity` field, with schema validation and UI support for selecting affinity in the rule trigger configuration. [[1]](diffhunk://#diff-ad41e6254bd67b498536a46c49d144b03bfaf9b922b25a8cf941fa836970562aR14) [[2]](diffhunk://#diff-ad41e6254bd67b498536a46c49d144b03bfaf9b922b25a8cf941fa836970562aR37-R41) [[3]](diffhunk://#diff-d0bec737ece4f6bb3c1328f445721c98ba6070df0a6a0f7ca13b8f44ab575550R14-R21)
* Updated the `matches` method in `DamageRuleTrigger` to filter events by affinity, ensuring triggers only activate when the affinity matches the rule's criteria.

**Localization:**

* Added a new localization string for "Affinity" to support UI changes.