### PR TITLE
Fix custom effects not interacting with rule elements

### DIFF
--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -76,6 +76,7 @@ function createTemporaryEffect(owner, effectType, name = undefined) {
 			name: name ?? (owner instanceof FUItem ? owner.name : game.i18n.localize('FU.NewEffect')),
 			img: 'icons/svg/aura.svg',
 			source: owner.uuid,
+			origin: owner.uuid,
 			system: system,
 			'duration.rounds': effectType === 'temporary' ? 1 : undefined,
 			disabled: effectType === 'inactive',
@@ -879,3 +880,4 @@ export const Effects = Object.freeze({
 	DAMAGE_TYPES,
 	STATUS_EFFECTS,
 });
+


### PR DESCRIPTION
Rule elements could generally not interact with custom effects. After some extensive debugging, I narrowed it down to the origin field of effects never getting set. This change simply fills a new Active Effect's origin field with the owner's UUID, mimicking the setup of the system compendium effects. This causes rule elements to be able to interact with custom effects.