### PR TITLE
Fix the start/end combat event not triggering REs

### DIFF
--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -49,7 +49,7 @@ export class MessageRuleAction extends RuleActionDataModel {
 		// Flag information
 		let sourceInfo;
 		if (context.item) {
-			sourceInfo = new InlineSourceInfo(context.item.name, context.source.actor.uuid, context.item.uuid);
+			sourceInfo = new InlineSourceInfo(context.item.name, context.source ? context.source.actor.uuid : null, context.item.uuid);
 		} else {
 			sourceInfo = context.sourceInfo;
 		}

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -311,9 +311,6 @@ function getSceneCharacters(targets) {
 	return [...new Map(sceneCharacters.filter((ci) => ci.actor?.uuid).map((ci) => [ci.actor.uuid, ci])).values()];
 }
 
-/** @type {FUItem | null} */
-//let temporaryItem = null;
-
 /**
  * @param {FUActiveEffect} effect
  * @returns {Promise<game.projectfu.FUItem|null>}
@@ -332,7 +329,7 @@ async function getTemporaryItem(effect) {
 }
 
 /**
- * @param {FUActiveEffect} effect
+ * @param {ActiveEffect|FUActiveEffect} effect
  * @returns {boolean}
  */
 function canProcessEffect(effect) {
@@ -342,6 +339,11 @@ function canProcessEffect(effect) {
 	}
 	return true;
 }
+
+/**
+ * @type {Set<string>} Events that can possibly have no source character.
+ */
+const eventsWithoutSourceCharacter = new Set([FUHooks.COMBAT_EVENT]);
 
 /**
  * @param {String} type
@@ -354,10 +356,13 @@ function canProcessEffect(effect) {
 async function evaluate(type, event, source, targets, data = undefined) {
 	// This can happen when sending items to chat.
 	if (!source) {
-		return;
+		// But some events
+		if (!eventsWithoutSourceCharacter.has(type)) {
+			return;
+		}
 	}
 	// Always include the source as part of the scene character pool; useful for when they are not part of the encounter
-	const sceneCharacters = getSceneCharacters([source, ...targets]);
+	const sceneCharacters = getSceneCharacters(source ? [source, ...targets] : targets);
 	for (const character of sceneCharacters) {
 		for (const effect of character.actor.allApplicableEffects()) {
 			if (!canProcessEffect(effect)) {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to handling events and sources in the rule elements pipeline and message rule actions. The main focus is on correctly managing cases where an event may not have a source character, particularly for combat events, and ensuring robust handling of source information.

**Event and Source Handling Improvements:**

* Added a constant `eventsWithoutSourceCharacter` to explicitly list event types (such as `FUHooks.COMBAT_EVENT`) that may not have a source character, improving clarity and maintainability.
* Updated the `evaluate` function to allow processing of events without a source character only if their type is included in `eventsWithoutSourceCharacter`, preventing errors for other event types. Also adjusted the construction of the `sceneCharacters` array to handle cases where `source` is null.

**Bug Fixes and Type Improvements:**

* Fixed a potential error in `MessageRuleAction` by checking if `context.source` exists before accessing `context.source.actor.uuid` when creating `InlineSourceInfo`.
* Improved the documentation and type signature of `canProcessEffect` to indicate it can accept both `ActiveEffect` and `FUActiveEffect` types.

**Code Cleanup:**

* Removed commented-out code related to `temporaryItem` in `rule-elements.mjs` for better code clarity.