### PR TITLE
Clean up usage of render data in rule elements

### DIFF
--- a/module/checks/check-hooks.mjs
+++ b/module/checks/check-hooks.mjs
@@ -123,7 +123,7 @@ const processCheck = (check, actor, item, registerCallback) => {};
  */
 
 /**
- * @typedef {(CheckSection | Promise<CheckSection> | (() => CheckSection) | (() => Promise<CheckSection>))[]} CheckRenderData
+ * @typedef {(CheckSection | Promise<CheckSection> | (() => CheckSection) | (() => Promise<CheckSection>))[]} CheckSectionRenderData
  */
 
 /**

--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -444,8 +444,8 @@ async function renderCheck(result, actor, item, flags = {}) {
 	const config = CheckConfiguration.configure(result);
 
 	Hooks.callAll(CheckHooks.renderCheck, renderData, result, actor, item, additionalFlags);
-	await CommonEvents.renderCheck(renderData.sections, config, actor, item);
-	await CommonEvents.renderMessage(renderData.sections, actor, item);
+	await CommonEvents.renderCheck(renderData, config, actor, item);
+	await CommonEvents.renderMessage(renderData, actor, item);
 
 	if (result.critical) {
 		CommonEvents.opportunity(renderData, actor, result.type, item, false);

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -261,13 +261,6 @@ function loss(actor, resource, amount, origin) {
  * @property {FURenderData} renderData
  */
 
-/**
- * @param {FUActor} sourceActor
- * @param {FUActor[]} targetActors
- * @param {FUResourceType} resource
- * @param {Number} amount
- * @param {String} origin
- */
 async function resource(sourceActor, targetActors, resource, amount, origin, renderData) {
 	const source = CharacterInfo.fromActor(sourceActor);
 	const targets = CharacterInfo.fromActors(targetActors);
@@ -384,11 +377,6 @@ function spell(actor, item) {
  * @property {CharacterInfo[]} targets
  */
 
-/**
- * @description Dispatches an event to signal a skill event
- * @param {FUActor} actor
- * @param {FUItem} item
- */
 function skill(actor, item, targets = undefined) {
 	/** @type SkillDataModel **/
 	const skill = item.system;
@@ -618,7 +606,7 @@ function resolveCheck(check, actor, item) {
 
 /**
  * @typedef RenderCheckEvent
- * @property {CheckRenderData} renderData
+ * @property {FURenderData} renderData
  * @property {CheckConfigurer} config
  * @property {CheckResultV2} check
  * @property {CharacterInfo} source
@@ -629,13 +617,6 @@ function resolveCheck(check, actor, item) {
  * @remarks Emitted when a check is about to be rendered.
  */
 
-/**
- * @param {CheckRenderData} renderData
- * @param {CheckConfigurer} config
- * @param actor
- * @param item
- * @returns {Promise<[]|*>}
- */
 async function renderCheck(renderData, config, actor, item) {
 	const sourceInfo = InlineSourceInfo.fromInstance(actor, item);
 	const check = config.check;
@@ -699,18 +680,12 @@ function notify(source, id, origin) {
 
 /**
  * @typedef RenderMessageEvent
- * @property {CheckRenderData} renderData
+ * @property {FURenderData} renderData
  * @property {CharacterInfo} source
  * @property {*} document A reference to a document such as an actor or item.
  * @remarks Emitted when a message is about to be rendered.
  */
 
-/**
- * @param {CheckRenderData} renderData
- * @param {FUActor} actor
- * @param {*} document
- * @returns {Promise<[]|*>}
- */
 async function renderMessage(renderData, actor, document = undefined) {
 	const source = CharacterInfo.fromActor(actor);
 
@@ -729,18 +704,18 @@ async function renderMessage(renderData, actor, document = undefined) {
  * @property {CharacterInfo} source
  * @property {FUItem} item
  * @property {String[]} traits
- * @property {FUChatBuilder} builder
+ * @property {FURenderData} renderData
  * @property
  */
 
-async function feature(actor, item, traits, builder) {
+async function feature(actor, item, traits, renderData) {
 	const source = CharacterInfo.fromActor(actor);
 	/** @type FeatureEvent  **/
 	const event = {
 		source: source,
 		item: item,
 		traits: traits,
-		builder: builder,
+		renderData: renderData,
 	};
 	return AsyncHooks.callSequential(FUHooks.FEATURE_EVENT, event);
 }

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -20,7 +20,7 @@ import { ChatAction } from '../helpers/chat-action.mjs';
 import { StringUtils } from '../helpers/string-utils.mjs';
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string | Promise<string>} description
  * @param {string} summary
  * @param {number} [order]
@@ -42,7 +42,7 @@ const description = (sections, description, summary, order = CHECK_DETAILS, open
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string} content
  * @param {number} [order]
  */
@@ -54,7 +54,7 @@ const content = (sections, content, order) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string} template
  * @param {Object} context
  * @param {number} [order]
@@ -70,7 +70,7 @@ const template = (sections, template, context, order) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {ChatAction[]} actions
  * @param {Object} flags
  * @param {number} [order]
@@ -91,7 +91,7 @@ const chatActions = (sections, actions, flags = {}, order) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string, Promise<string>} text
  * @param {number} [order]
  */
@@ -106,7 +106,7 @@ const genericText = (sections, text, order) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string, Promise<string>} text
  * @param {FUActor} actor
  * @param {FUItem} item
@@ -128,7 +128,7 @@ const itemText = (sections, text, actor, item, flags, order) => {
 
 /**
  * A description section with customizable title and without summary.
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string} title
  * @param {string} description
  * @param {number} [order]
@@ -148,7 +148,7 @@ const collapsibleDescription = (sections, title, description, order, open = true
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {ProgressDataModel} clock
  * @param {number} [order]
  */
@@ -175,7 +175,7 @@ const clock = (sections, clock, order) => {
  */
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {Tag[]} tags
  * @param {number} [order]
  */
@@ -193,7 +193,7 @@ const tags = (sections, tags = [], order = CHECK_DETAILS) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string} quality
  * @param {number} [order]
  */
@@ -210,7 +210,7 @@ const quality = (sections, quality, order) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {ProgressDataModel} resource
  * @param {number} [order]
  */
@@ -226,7 +226,7 @@ const resource = (sections, resource, order) => {
 
 /**
  * Sets chat message flavor by default. Specify order for other usecases.
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {{name: string, img: string, id: string, uuid: string}|FUItem} item
  * @param {number} [order]
  */
@@ -242,7 +242,7 @@ const itemFlavor = (sections, item, order = CHECK_FLAVOR) => {
 
 /**
  * Sets chat message flavor by default. Specify order for other usecases.
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string} flavor
  * @param {number} [order]
  */
@@ -257,7 +257,7 @@ const genericFlavor = (sections, flavor, order = CHECK_FLAVOR) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {string} opportunity
  * @param {number} [order]
  */
@@ -571,7 +571,7 @@ const expense = (data, actor, item, targets, flags, expense) => {
 };
 
 /**
- * @param {CheckRenderData} sections
+ * @param {CheckSectionRenderData} sections
  * @param {FUItem[]} slottedTechnospheres
  * @param {number} [order]
  */

--- a/module/documents/effects/actions/message-rule-action.mjs
+++ b/module/documents/effects/actions/message-rule-action.mjs
@@ -63,7 +63,7 @@ export class MessageRuleAction extends RuleActionDataModel {
 		if (context.renderData && context.source) {
 			// TODO: Resolve actor for pseudo-documents too
 			const actor = context.source.actor !== context.character.actor ? context.item?.parent : null;
-			CommonSections.itemText(context.renderData, _message, actor, context.item, flags, ChatSectionOrder.addendum);
+			CommonSections.itemText(context.renderData.sections, _message, actor, context.item, flags, ChatSectionOrder.addendum);
 		} else {
 			const actor = context.character.actor;
 			const content = await FoundryUtils.renderTemplate('chat/partials/chat-item-text', {

--- a/module/documents/effects/active-effect-behaviour-mixin.mjs
+++ b/module/documents/effects/active-effect-behaviour-mixin.mjs
@@ -287,7 +287,7 @@ export function ActiveEffectBehaviourMixin(BaseDocument) {
 				},
 				CHECK_FLAVOR,
 			);
-			await CommonEvents.renderMessage(chatBuilder.sections, actor, item ?? this);
+			await CommonEvents.renderMessage(chatBuilder.renderData, actor, item ?? this);
 			await chatBuilder.withFlags(flags).create();
 		}
 

--- a/module/documents/effects/rule-element-context.mjs
+++ b/module/documents/effects/rule-element-context.mjs
@@ -9,7 +9,7 @@ import { ExpressionContext } from '../../expressions/expressions.mjs';
  * @property {InlineSourceInfo} sourceInfo
  * @property {CheckResultV2|null} check Some events may have check information.
  * @property {CheckConfigurer|null} config Configuration for a check, available in events involving the checks pipeline.
- * @property {CheckRenderData} renderData Used for rendering chat messages.
+ * @property {FURenderData} renderData Used for rendering chat messages.
  * @property {FUItem|null} item The item the rule element could be on.
  * @property {CharacterInfo} source The source character of the event.
  * @property {CharacterInfo[]} targets The targets of the event.

--- a/module/helpers/chat-builder.mjs
+++ b/module/helpers/chat-builder.mjs
@@ -4,7 +4,7 @@ import { ChatSectionOrder } from '../checks/default-section-order.mjs';
 
 /**
  * @typedef FURenderData
- * @property {CheckRenderData} sections
+ * @property {CheckSectionRenderData} sections
  * @property {Promise[]} postRenderActions
  * @property {Tag[]} tags
  */
@@ -64,10 +64,17 @@ export class FUChatBuilder {
 	}
 
 	/**
-	 * @returns {CheckRenderData}
+	 * @returns {CheckSectionRenderData}
 	 */
 	get sections() {
 		return this.#renderData.sections;
+	}
+
+	/**
+	 * @returns {FURenderData}
+	 */
+	get renderData() {
+		return this.#renderData;
 	}
 
 	/**

--- a/module/pipelines/application-pipeline.mjs
+++ b/module/pipelines/application-pipeline.mjs
@@ -39,6 +39,7 @@ async function handleArcanum(actor, item) {
 	const currentArcanumId = actor.system.equipped.arcanum;
 	const currentArcanum = actor.items.get(currentArcanumId);
 
+	// TODO: Pass in render data, check over summon branch
 	// Dismiss
 	if (currentArcanum) {
 		/** @type ArcanumDataModel **/
@@ -61,15 +62,20 @@ async function handleArcanum(actor, item) {
 			await actor.update({
 				'system.equipped.arcanum': null,
 			});
-			const builder = new FUChatBuilder(actor, item);
-			CommonSections.itemFlavor(builder.sections, currentArcanum);
+			/** @type {FURenderData} **/
+			const renderData = {
+				sections: [],
+				postRenderActions: [],
+			};
+			CommonSections.itemFlavor(renderData.sections, currentArcanum);
 			const content = await FoundryUtils.renderTemplate('feature/arcanist/feature-arcanum-chat-message-v2', {
 				item: currentArcanum,
 				message: 'FU.ClassFeatureArcanumDismissMessage',
 				details: currentArcanumData.dismiss,
 			});
-			CommonSections.content(builder.sections, content, CHECK_DETAILS);
-			await CommonEvents.feature(actor, item, [FeatureTraits.ArcanumDismiss], builder);
+			CommonSections.content(renderData.sections, content, CHECK_DETAILS);
+			await CommonEvents.feature(actor, item, [FeatureTraits.ArcanumDismiss], renderData);
+			const builder = new FUChatBuilder(actor, item).withData(renderData);
 			await builder.create();
 		}
 
@@ -113,23 +119,22 @@ async function handleArcanum(actor, item) {
 				console.debug(`Arcanum summon cost: ${expense.amount}`);
 				// Render sections
 				/** @type {FURenderData} **/
-				const data = {
+				const renderData = {
 					sections: [],
 					postRenderActions: [],
 				};
 				let flags = {};
 
-				CommonSections.itemFlavor(data.sections, selectedArcana);
+				CommonSections.itemFlavor(renderData.sections, selectedArcana);
 				const content = await FoundryUtils.renderTemplate('feature/arcanist/feature-arcanum-chat-message-v2', {
 					item: selectedArcana,
 					message: 'FU.ClassFeatureArcanumSummonMessage',
 					details: selectedArcana.system.data.merge,
 				});
-				CommonSections.content(data.sections, content, CHECK_DETAILS);
-				CommonSections.expense(data, actor, item, [], flags, expense);
-				const builder = new FUChatBuilder(actor, item);
-				await CommonEvents.feature(actor, item, expense.traits, builder);
-				builder.withData(data).withFlags(flags);
+				CommonSections.content(renderData.sections, content, CHECK_DETAILS);
+				CommonSections.expense(renderData, actor, item, [], flags, expense);
+				await CommonEvents.feature(actor, item, expense.traits, renderData);
+				const builder = new FUChatBuilder(actor, item).withData(renderData).withFlags(flags);
 				await builder.create();
 			}
 		}

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -880,4 +880,3 @@ export const Effects = Object.freeze({
 	DAMAGE_TYPES,
 	STATUS_EFFECTS,
 });
-

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -130,15 +130,13 @@ async function onAttackEvent(event) {
 	await evaluate(FUHooks.ATTACK_EVENT, event, event.source, event.targets, event.check);
 }
 
-// TODO: Use the full FURenderData object, not just sections
-
 /**
  * @param {DamageEvent} event
  * @returns {Promise<void>}
  */
 async function onDamageEvent(event) {
 	await evaluate(FUHooks.DAMAGE_EVENT, event, event.source, [CharacterInfo.fromActor(event.actor)], {
-		renderData: event.renderData.sections,
+		renderData: event.renderData,
 	});
 }
 
@@ -148,7 +146,7 @@ async function onDamageEvent(event) {
  */
 async function onResourceEvent(event) {
 	await evaluate(FUHooks.RESOURCE_UPDATE, event, event.source, event.targets, {
-		renderData: event.renderData.sections,
+		renderData: event.renderData,
 	});
 }
 
@@ -288,7 +286,7 @@ async function onEffectToggledEvent(event) {
  */
 async function onFeatureEvent(event) {
 	await evaluate(FUHooks.FEATURE_EVENT, event, event.source, [], {
-		renderData: event.builder.sections,
+		renderData: event.renderData,
 	});
 }
 


### PR DESCRIPTION
This pull request refactors the rendering data structures used in the checks and chat pipelines to improve clarity and consistency. The main change is replacing the ambiguous `CheckRenderData` type with more explicit types: `CheckSectionRenderData` and `FURenderData`. This affects function signatures, typedefs, and method calls throughout the codebase, ensuring that rendering operations consistently use the correct data structure. Additionally, related documentation and function parameters have been updated to match these changes.

**Rendering Data Structure Refactor**

* Replaced all instances of `CheckRenderData` with `CheckSectionRenderData` for section arrays, and introduced/standardized `FURenderData` for full render data objects in function signatures, typedefs, and documentation across multiple files (`module/checks/check-hooks.mjs`, `module/helpers/chat-builder.mjs`, `module/checks/common-sections.mjs`). [[1]](diffhunk://#diff-adfdcd8a897d7ef4384ef9b3f5b9480bd921d9d4018c1b0c8039b842651e1752L126-R126) [[2]](diffhunk://#diff-ba37dadb458a157b10218a546ab6c10b703fac5eaae92025d2c5530ddf4a23f6L7-R7) [[3]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL23-R23) [[4]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL45-R45) [[5]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL57-R57) [[6]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL73-R73) [[7]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL94-R94) [[8]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL109-R109) [[9]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL131-R131) [[10]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL151-R151) [[11]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL178-R178) [[12]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL196-R196) [[13]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL213-R213) [[14]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL229-R229) [[15]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL245-R245) [[16]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL260-R260) [[17]](diffhunk://#diff-0b76bd9dc6b5db9532e794dddcaf7df3533ac8bd24c51f684890ecae3d46d91bL574-R574)

* Updated `FUChatBuilder` to provide both `sections` (as `CheckSectionRenderData`) and `renderData` (as `FURenderData`) via new getter methods, and updated usages accordingly.

**Function and Event Signature Updates**

* Changed function signatures and event typedefs in `module/checks/common-events.mjs` and related files to use `FURenderData` instead of `CheckRenderData` for render data, ensuring consistent handling of rendering information. [[1]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L621-R609) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L702-L713) [[3]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L732-R718) [[4]](diffhunk://#diff-a4dd45039af90babd14628a40003e27f206997feb3e7380f82b6d0afef7c1d4cL12-R12)

* Updated function calls throughout the codebase to pass the correct data structure (`sections` or `renderData`) as needed, including in `module/checks/checks.mjs`, `module/documents/effects/actions/message-rule-action.mjs`, `module/documents/effects/active-effect-behaviour-mixin.mjs`, and `module/pipelines/rule-elements.mjs`. [[1]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1L447-R448) [[2]](diffhunk://#diff-bdfa4644499f292b4b5082e88dd58b921879a7f9369952b5236924a1c0bd1297L66-R66) [[3]](diffhunk://#diff-0d9df5c56842856d31083a5ddd709f0be774c1d40d60d2490ddffccdac01a735L290-R290) [[4]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484L133-R139)

**Pipeline and Feature Handling Adjustments**

* Refactored arcanum handling in `module/pipelines/application-pipeline.mjs` to construct and pass `FURenderData` objects instead of just section arrays, improving extensibility and consistency for chat message creation and feature events. [[1]](diffhunk://#diff-759c84e64b8641d259455869e35b1fca50f24aff7b5ae27618a1bbeccb10cc56L64-R78) [[2]](diffhunk://#diff-759c84e64b8641d259455869e35b1fca50f24aff7b5ae27618a1bbeccb10cc56L116-R137)

**Documentation and Typedef Cleanup**

* Removed outdated or redundant JSDoc comments and updated documentation to match new data structures and function signatures, improving code clarity. [[1]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L264-L270) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L387-L391) [[3]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L632-L638)

**Miscellaneous**

* Minor cleanup in `module/pipelines/effects.mjs` (removed trailing newline).