### PR TITLE
Allow inline effects to resolve effects from fuids

### DIFF
--- a/module/helpers/inline-effects.mjs
+++ b/module/helpers/inline-effects.mjs
@@ -3,8 +3,9 @@ import { Effects, disableStatusEffect } from '../pipelines/effects.mjs';
 import { targetHandler } from './target-handler.mjs';
 import { InlineEffectConfiguration } from './inline-effect-configuration.mjs';
 import { InlineHelper } from './inline-helper.mjs';
-import { FUItem } from '../documents/items/item.mjs';
 import { StringUtils } from './string-utils.mjs';
+import { systemId } from './system-utils.mjs';
+import { Flags } from './flags.mjs';
 
 const INLINE_EFFECT = 'InlineEffect';
 const INLINE_EFFECT_CLASS = 'inline-effect';
@@ -51,8 +52,14 @@ function createCompendiumEffectAnchor(effect, config, label) {
 	const anchor = document.createElement('a');
 	anchor.draggable = true;
 	anchor.dataset.effect = StringUtils.toBase64(effect);
-	anchor.dataset.uuid = effect.uuid;
-	anchor.dataset.fuid = effect.parent.system.fuid;
+	if (effect.flags[systemId][Flags.ActiveEffect.Source]) {
+		const sourceInfo = effect.flags[systemId][Flags.ActiveEffect.Source];
+		anchor.dataset.uuid = sourceInfo.effectUuid;
+		anchor.dataset.fuid = sourceInfo.fuid;
+	} else {
+		anchor.dataset.uuid = effect.uuid;
+		anchor.dataset.fuid = effect.parent?.system?.fuid;
+	}
 	anchor.dataset.config = StringUtils.toBase64(config);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
 	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}`);
@@ -137,22 +144,9 @@ async function inlineEffectEnricher(match, options) {
 			return createStatusAnchor(id, status, config);
 		}
 	} else {
-		/** @type ActiveEffect **/
-		if (id.includes('.')) {
-			let instancedEffect = await fromUuid(id);
-			if (!instancedEffect) {
-				return createBrokenAnchor();
-			}
-			if (instancedEffect instanceof FUItem) {
-				const iterator = instancedEffect.effects?.values();
-				const firstEffect = iterator?.next()?.value;
-				if (!firstEffect) {
-					console.warn('FUItem has no effects:', instancedEffect);
-					return null; // or handle appropriately
-				}
-				instancedEffect = firstEffect;
-			}
-			return createCompendiumEffectAnchor(instancedEffect, config, label);
+		const effectData = await Effects.getEffectData(id);
+		if (effectData) {
+			return createCompendiumEffectAnchor(effectData, config, label);
 		}
 
 		// TODO: Deprecate someday

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -95,9 +95,12 @@ function resolveBaseEffect(id) {
 /** *
  * @param {String} id An uuid or fuid
  * @returns {Promise<ActiveEffectData>}
+ * @remarks It makes a safe clone of the data when returning it, thus it will NOT be an ActiveEffect instance.
  */
 async function getEffectData(id) {
 	let effect;
+	let sourceInfo;
+
 	// Resolve by status id
 	if (id in Effects.STATUS_EFFECTS || id in Effects.BOONS_AND_BANES) {
 		effect = statusEffects.find((value) => value.id === id);
@@ -115,6 +118,7 @@ async function getEffectData(id) {
 		}
 		// Get the first AE attached to the item
 		if (effect && effect instanceof FUItem) {
+			sourceInfo = new InlineSourceInfo(effect.name, null, effect.uuid, null, effect.system.fuid);
 			effect = effect.effects.entries().next().value[1];
 		}
 	}
@@ -123,7 +127,20 @@ async function getEffectData(id) {
 	}
 
 	if (effect) {
+		// TODO: Perhaps it be really instanced each time?
+		// effect = await ActiveEffect.create(
+		// 	{
+		// 		...effect,
+		// 		statuses: [statusEffectId],
+		// 		flags: createEffectFlags(statusEffect, sourceInfo, statusEffectId),
+		// 	},
+		// 	{ parent: actor },
+		// );
+
 		effect = FoundryUtils.safeClone(effect);
+		if (sourceInfo) {
+			effect.flags = Pipeline.initializedFlags(Flags.ActiveEffect.Source, sourceInfo);
+		}
 	}
 
 	return effect;


### PR DESCRIPTION
This pull request refactors how inline effects are handled and enriched, focusing on improving the retrieval and anchoring of effect data. The main changes streamline effect data access, ensure more robust handling of source information, and clean up legacy code paths.

**Inline effect data handling and enrichment:**

* Refactored the inline effect enricher to use `Effects.getEffectData(id)` for retrieving effect data, removing legacy code that handled `FUItem` instances directly and simplifying the logic for creating effect anchors.
* Updated `getEffectData` in `effects.mjs` to safely clone effect data and attach source information via flags when the effect originates from a `FUItem`, ensuring returned data is not an `ActiveEffect` instance and is consistently structured. [[1]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fR98-R103) [[2]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fR121) [[3]](diffhunk://#diff-b90e5902466e1e64a812d2df080083a63566e9ef0cbb3a314eb4fd7274ebc19fR130-R143)

**Effect anchor creation improvements:**

* Enhanced `createCompendiumEffectAnchor` to prioritize source information from effect flags when available, falling back to the effect's own UUID and parent FUID if not, and made the code more robust against missing parent data.

**Imports and code organization:**

* Cleaned up and updated imports in `inline-effects.mjs`, removing unused imports and adding necessary ones for system utilities and flags management.