### PR TITLE
Add an universal check bonus

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -508,6 +508,7 @@
 		"MagicCheckBonus": "Magic Check Bonus",
 		"AccuracyBonus": "Accuracy Check Bonus",
 		"CheckBonus": "Check Bonus",
+		"AllCheckBonus": "All Check Bonus",
 		"AccuracyTest": "Accuracy Test",
 		"Accuracy": "Accuracy",
 		"UseWeaponAccuracy": "Use Weapon Accuracy?",

--- a/module/checks/check-prompt.mjs
+++ b/module/checks/check-prompt.mjs
@@ -169,80 +169,6 @@ const areaList = [
 
 /**
  * @template T
- * @param {Actor} actor
- * @param {"attribute", "open", "group", "ritual"} type
- * @param {T} initialConfig
- * @returns {Promise<AttributeCheckConfig | OpenCheckConfig | GroupCheckConfig>}
- */
-async function promptForConfiguration(actor, type, initialConfig = {}) {
-	const recentCheck = retrieveRecentCheck(actor, type);
-
-	Object.keys(recentCheck).forEach((key) => {
-		if (initialConfig[key] != null) {
-			recentCheck[key] = initialConfig[key];
-		}
-	});
-
-	const attributes = actor.system.attributes;
-
-	const attributeValues = Object.entries(attributes).reduce(
-		(previousValue, [attribute, { current }]) => ({
-			...previousValue,
-			[attribute]: current,
-		}),
-		{},
-	);
-
-	let context = {
-		actor: actor,
-		type: type,
-		typeLabel: StringUtils.localize(FU.checkTypes[type]),
-		attributes: FU.attributes,
-		attributeAbbr: FU.attributeAbbreviations,
-		attributeValues: attributeValues,
-		attributeOptions: FoundryUtils.generateConfigIconOptions(Object.keys(FU.attributes), FU.attributes, FU.attributeIcons),
-		attributeIcons: FU.attributeIcons,
-		primary: recentCheck.primary,
-		secondary: recentCheck.secondary,
-		modifier: recentCheck.modifier,
-		difficulty: recentCheck.difficulty,
-		potencyList: potencyList,
-		areaList: areaList,
-		supportDifficulty: recentCheck.supportDifficulty,
-		bonus: actor.system.bonuses.accuracy.openCheck,
-	};
-
-	const title = initialConfig.title ?? FU.checkTypes[type];
-	const result = await foundry.applications.api.DialogV2.input({
-		window: {
-			title: game.i18n.localize(title),
-			icon: 'fa-solid fa-dice',
-		},
-		classes: ['projectfu', 'unique-dialog', 'backgroundstyle'],
-		actions: {
-			setDifficulty: onSetDifficulty,
-		},
-		content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/dialog/dialog-check-prompt-unified.hbs', context),
-		rejectClose: false,
-		ok: {
-			icon: FU.allIcon.roll,
-			label: game.i18n.localize('FU.DialogCheckRoll'),
-		},
-		/** @param {Event} event
-		 *  @param {HTMLElement} dialog **/
-		render: (event, dialog) => {
-			HTMLUtils.initializeIconRadioGroups(dialog.element, context);
-		},
-	});
-	if (result) {
-		saveRecentCheck(actor, type, result);
-		return result;
-	}
-	return null;
-}
-
-/**
- * @template T
  * @param {Document|FUActor} document
  * @param {CheckType} type
  * @param {T} initialConfig
@@ -281,16 +207,16 @@ async function promptForConfigurationV2(document, type, initialConfig = {}) {
 		modifier: recentCheck.modifier,
 		difficulty: recentCheck.difficulty,
 		supportDifficulty: recentCheck.supportDifficulty,
-		bonus: 0,
+		bonus: document.system?.bonuses?.accuracy?.all ?? 0,
 	};
 
 	switch (type) {
 		case 'open': {
-			context.bonus = document.system.bonuses.accuracy.openCheck;
+			context.bonus += document.system.bonuses.accuracy.openCheck;
 			break;
 		}
 		case 'opposed': {
-			context.bonus = document.system.bonuses.accuracy.opposedCheck;
+			context.bonus += document.system.bonuses.accuracy.opposedCheck;
 			break;
 		}
 		case 'ritual':
@@ -381,12 +307,12 @@ async function onUpdateRitual(event, target) {
 }
 
 /**
- * @param {Actor} actor
+ * @param {FUActor} actor
  * @param {CheckPromptOptions<AttributeCheckConfig>} [options]
  * @returns {Promise<void>}
  */
 async function attributeCheck(actor, options = {}) {
-	const promptResult = await promptForConfiguration(actor, 'attribute', options.initialConfig);
+	const promptResult = await promptForConfigurationV2(actor, 'attribute', options.initialConfig);
 	if (promptResult) {
 		return Checks.attributeCheck(
 			actor,
@@ -412,7 +338,7 @@ async function attributeCheck(actor, options = {}) {
 }
 
 /**
- * @param {Actor} actor
+ * @param {FUActor} actor
  * @param {CheckPromptOptions<OpenCheckConfig>} [options]
  * @returns {Promise<void>}
  */
@@ -472,7 +398,7 @@ async function opposedCheck(actor, data = {}, options = {}) {
 }
 
 /**
- * @param {Actor} actor
+ * @param {FUActor} actor
  * @param {CheckPromptOptions<GroupCheckConfig>} [options]
  * @returns {Promise<void>}
  */

--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -239,9 +239,11 @@ async function prepareCheck(check, actor, item, initialConfigCallback) {
 	check.additionalData ??= {};
 	check.critThreshold = CRITICAL_THRESHOLD;
 	Object.seal(check);
+
 	// Set initial targets (actions without rolls can have targeting)
 	const config = CheckConfiguration.configure(check);
 	config.setDefaultTargets();
+
 	// Initial callback
 	await (initialConfigCallback ? initialConfigCallback(check, actor, item) : undefined);
 	Object.defineProperty(check, 'type', {
@@ -260,6 +262,14 @@ async function prepareCheck(check, actor, item, initialConfigCallback) {
 	});
 	if (!check.id) {
 		throw new Error('check id missing');
+	}
+
+	// Universal bonus
+	if (actor.system.bonuses?.accuracy?.all) {
+		check.modifiers.push({
+			label: `FU.AllCheckBonus`,
+			value: actor.system.bonuses.accuracy.all,
+		});
 	}
 
 	await invokeWithCallbacks(CheckHooks.prepareCheck, check, actor, item);

--- a/module/documents/actors/common/accuracy-bonuses-data-model.mjs
+++ b/module/documents/actors/common/accuracy-bonuses-data-model.mjs
@@ -20,6 +20,7 @@ export class AccuracyBonusesDataModel extends foundry.abstract.DataModel {
 	static defineSchema() {
 		const { NumberField } = foundry.data.fields;
 		return {
+			all: new NumberField({ initial: 0, integer: true, nullable: false }),
 			accuracyCheck: new NumberField({ initial: 0, integer: true, nullable: false }),
 			accuracyMelee: new NumberField({ initial: 0, integer: true, nullable: false }),
 			accuracyRanged: new NumberField({ initial: 0, integer: true, nullable: false }),


### PR DESCRIPTION
This pull request introduces a new universal accuracy bonus ("All Check Bonus") that applies to all types of checks, and updates the check prompt and calculation logic to support this feature. It also removes the obsolete `promptForConfiguration` function, standardizes actor typing, and adds the new bonus to the data model and localization files.

**Universal Check Bonus Support:**

* Added a new `all` field to the `AccuracyBonusesDataModel` to store a universal accuracy bonus for all checks.
* Updated check preparation logic in `checks.mjs` to automatically add the universal accuracy bonus as a modifier to any check if present.

**Check Prompt Updates:**

* Modified the check prompt logic in `check-prompt.mjs` (`promptForConfigurationV2`) to include the universal bonus in the displayed bonus value, and to add type-specific bonuses on top of the universal one.

**Code Cleanup and Standardization:**

* Removed the now-obsolete `promptForConfiguration` function, consolidating all prompt logic into `promptForConfigurationV2`.
* Standardized function signatures to use `FUActor` instead of `Actor` for check-related functions. [[1]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aL384-R315) [[2]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aL415-R341) [[3]](diffhunk://#diff-695f82313199c77991235d9372677feddf43211ecc108bae52515528d93c751aL475-R401)

**Localization:**

* Added a new localization string for "All Check Bonus" in `lang/en.json`.