### PR TITLE
Fix negative damage modifiers being ignored

### DIFF
--- a/module/checks/damage-data.mjs
+++ b/module/checks/damage-data.mjs
@@ -75,7 +75,7 @@ export class DamageData {
 	 */
 	get modifiers() {
 		return this._modifiers.filter((m) => {
-			return m.enabled && (m.amount > 0 || (m.traits && m.traits.length > 0));
+			return m.enabled && (m.amount !== 0 || (m.traits && m.traits.length > 0));
 		});
 	}
 

--- a/module/ui/damage-customizer-v2.mjs
+++ b/module/ui/damage-customizer-v2.mjs
@@ -91,7 +91,7 @@ export class DamageCustomizerV2 {
 					}
 					// Modifiers
 					context.damage.modifiers.forEach((modifier) => {
-						if (modifier.amount > 0) {
+						if (modifier.amount !== 0) {
 							components.push(`${modifier.amount} (${StringUtils.localize(modifier.label)})`);
 						}
 					});


### PR DESCRIPTION
This pull request introduces a minor logic update to how damage modifiers are filtered and displayed. The key change is that modifiers with non-zero amounts (both positive and negative) are now included, instead of only those with positive amounts.

* **Damage Modifier Filtering and Display:**
  * Updated the `modifiers` getter in `DamageData` to include modifiers with any non-zero amount, rather than only positive amounts.
  * Modified the display logic in `DamageCustomizerV2` to show modifiers with non-zero amounts, ensuring negative modifiers are also represented.