### PR TITLE
Add effect option to modify damage rule action

### DIFF
--- a/module/checks/damage-data.mjs
+++ b/module/checks/damage-data.mjs
@@ -12,6 +12,7 @@
  * @property {number} amount
  * @property {DamageType[]} types
  * @property {String[]} traits
+ * @property {String} effect
  * @property {ResourceExpense} expense
  */
 
@@ -75,7 +76,7 @@ export class DamageData {
 	 */
 	get modifiers() {
 		return this._modifiers.filter((m) => {
-			return m.enabled && (m.amount !== 0 || (m.traits && m.traits.length > 0));
+			return m.enabled && (m.amount !== 0 || (m.traits && m.traits.length > 0) || m.effect);
 		});
 	}
 
@@ -141,6 +142,20 @@ export class DamageData {
 			return this.modifierTotal;
 		}
 		return this.modifierTotal + this.hr;
+	}
+
+	/**
+	 * @returns {boolean}
+	 */
+	get hasTraits() {
+		return this._modifiers.some((m) => m.traits && m.traits.length > 0);
+	}
+
+	/**
+	 * @returns {boolean}
+	 */
+	get hasEffects() {
+		return this._modifiers.some((m) => m.effect);
 	}
 
 	/**

--- a/module/documents/effects/actions/modify-damage-rule-action.mjs
+++ b/module/documents/effects/actions/modify-damage-rule-action.mjs
@@ -16,6 +16,7 @@ const fields = foundry.data.fields;
  * @property {TraitsDataModel} traits
  * @property {Set<DamageType>} damageTypes
  * @property {ActionCostDataModel} cost
+ * @property {String} effect Optionally, an effect to be applied.
  * @property {String} variant
  */
 export class ModifyDamageRuleAction extends RuleActionDataModel {
@@ -45,6 +46,7 @@ export class ModifyDamageRuleAction extends RuleActionDataModel {
 				blank: true,
 				choices: Object.keys(FU.modifyDamageVariant),
 			}),
+			effect: new fields.StringField({ blank: true }),
 		});
 	}
 
@@ -86,6 +88,7 @@ export class ModifyDamageRuleAction extends RuleActionDataModel {
 								resource: this.cost.resource,
 							},
 							traits: this.traits.values,
+							effect: this.effect,
 							enabled: false,
 						});
 					}
@@ -101,6 +104,7 @@ export class ModifyDamageRuleAction extends RuleActionDataModel {
 							traits: [FeatureTraits.Gift],
 						},
 						traits: this.traits.values,
+						effect: this.effect,
 						enabled: false,
 					});
 					break;
@@ -111,12 +115,16 @@ export class ModifyDamageRuleAction extends RuleActionDataModel {
 				context.config.getDamage().addModifier(context.label, _amount, types, {
 					expense: this.cost,
 					traits: this.traits.values,
+					effect: this.effect,
 					enabled: !this.cost.assigned,
 				});
 			} else {
 				context.config.addDamageBonus(context.label, _amount);
 				// TODO: Verify...
 				context.config.addTraits(this.traits.values);
+				if (this.effect) {
+					context.config.addEffects(this.effect);
+				}
 			}
 		}
 	}

--- a/module/documents/items/common/effect-application-data-model.mjs
+++ b/module/documents/items/common/effect-application-data-model.mjs
@@ -1,11 +1,11 @@
+import { FU } from '../../../helpers/config.mjs';
+
 /**
  * @typedef ApplyEffectData
  * @property {String[]} entries
  * @property {Boolean} prompt Whether to prompt a selection dialog.
  * @property {FUActiveEffectDuration} duration
  */
-
-import { FU } from '../../../helpers/config.mjs';
 
 /**
  * @description Used when rolls are performed.

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -826,8 +826,13 @@ const onProcessCheck = (check, actor, item, registerCallback) => {
 				}
 			}
 			for (const modifier of damage.modifiers) {
-				if (modifier.enabled && modifier.traits && modifier.traits.length > 0) {
-					config.addTraits(modifier.traits);
+				if (modifier.enabled) {
+					if (modifier.traits && modifier.traits.length > 0) {
+						config.addTraits(modifier.traits);
+					}
+					if (modifier.effect) {
+						config.addEffects(modifier.effect);
+					}
 				}
 			}
 			if (config.hasTrait(DamageTraits.HighRollZero)) {

--- a/module/ui/damage-customizer-v2.mjs
+++ b/module/ui/damage-customizer-v2.mjs
@@ -1,6 +1,7 @@
 import { FU } from '../helpers/config.mjs';
 import FoundryUtils from '../helpers/foundry-utils.mjs';
 import { StringUtils } from '../helpers/string-utils.mjs';
+import { Effects } from '../pipelines/effects.mjs';
 
 export class DamageCustomizerV2 {
 	/**
@@ -18,6 +19,17 @@ export class DamageCustomizerV2 {
 			initialType: damageData.type,
 			/** @type DamageType **/
 			selectedType: damageData.type,
+			effectIcons: await Promise.all(
+				damageData.rawModifiers.map(async (m) => {
+					if (m.effect) {
+						const effectData = await Effects.getEffectData(m.effect);
+						if (effectData) {
+							return effectData.img;
+						}
+					}
+					return '';
+				}),
+			),
 		};
 
 		const result = await foundry.applications.api.DialogV2.input({
@@ -26,7 +38,7 @@ export class DamageCustomizerV2 {
 				icon: 'fas fa-heartbeat',
 			},
 			position: {
-				width: 480,
+				width: 600,
 			},
 			actions: {
 				/** @param {Event} event

--- a/src/packs/skills/classFeature_Gadget___Infusion_1tfYFkiXLuTOUmre.json
+++ b/src/packs/skills/classFeature_Gadget___Infusion_1tfYFkiXLuTOUmre.json
@@ -376,7 +376,8 @@
                 "eventRelation": "source",
                 "damageSources": [
                   "attack"
-                ]
+                ],
+                "identifier": ""
               },
               "actions": {
                 "lJMbxGComOsR053y": {
@@ -389,11 +390,7 @@
                   "cost": {
                     "resource": "ip",
                     "amount": "2"
-                  }
-                },
-                "enEX2W9hjJyvRYFc": {
-                  "type": "applyEffectRuleAction",
-                  "_id": "enEX2W9hjJyvRYFc",
+                  },
                   "effect": "poisoned"
                 }
               },
@@ -414,6 +411,11 @@
             "current": 0,
             "max": 6,
             "style": "basic"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
           }
         }
       },
@@ -436,11 +438,11 @@
         "compendiumSource": null,
         "duplicateSource": null,
         "exportSource": null,
-        "coreVersion": "13.348",
+        "coreVersion": "13.351",
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1767645170601,
-        "modifiedTime": 1767890390974,
+        "modifiedTime": 1772720016338,
         "lastModifiedBy": "J5B4HfVqUaCPvzGg"
       },
       "_key": "!items.effects!1tfYFkiXLuTOUmre.mZBX5ATHRQquUFEN"

--- a/src/packs/skills/effect_Effect__Charging_Cavalry_X4L3sibcGEi8LPvd.json
+++ b/src/packs/skills/effect_Effect__Charging_Cavalry_X4L3sibcGEi8LPvd.json
@@ -27,7 +27,38 @@
           "crisisInteraction": "none"
         },
         "rules": {
-          "elements": {},
+          "elements": {
+            "xv58stjBNv1FM6gq": {
+              "type": "ruleElement",
+              "trigger": {
+                "_id": "Fxwp6KV9YQlO5YP2",
+                "type": "calculateDamageRuleTrigger",
+                "eventRelation": "source",
+                "damageSources": [
+                  "attack"
+                ],
+                "damageTypes": [],
+                "local": false,
+                "identifier": ""
+              },
+              "_id": "xv58stjBNv1FM6gq",
+              "actions": {
+                "2bCWGBIbBYIXuvLE": {
+                  "type": "modifyDamageRuleAction",
+                  "_id": "2bCWGBIbBYIXuvLE",
+                  "traits": {
+                    "entries": [
+                      "high-roll-zero"
+                    ]
+                  },
+                  "amount": "",
+                  "cost": {
+                    "amount": null
+                  }
+                }
+              }
+            }
+          },
           "progress": {
             "enabled": false,
             "id": "",
@@ -35,6 +66,11 @@
             "current": 0,
             "max": 6,
             "style": "basic"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
           }
         }
       },
@@ -69,8 +105,8 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770273473908,
-        "modifiedTime": 1770632170336,
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
+        "modifiedTime": 1772306823909,
+        "lastModifiedBy": "J5B4HfVqUaCPvzGg"
       },
       "_key": "!items.effects!X4L3sibcGEi8LPvd.6FbGNzBSHKFc7umq"
     }

--- a/templates/dialog/dialog-damage-customizer-v2.hbs
+++ b/templates/dialog/dialog-damage-customizer-v2.hbs
@@ -20,6 +20,7 @@
 				<th>{{localize 'FU.Types'}}</th>
 				<th>{{localize 'FU.Amount'}}</th>
 				<th>{{localize 'FU.Traits'}}</th>
+				<th>{{localize 'FU.Effect'}}</th>
 				<th>{{localize 'FU.Expense'}}</th>
 				<th>{{localize 'FU.Enabled'}}</th>
 			</tr>
@@ -31,7 +32,7 @@
 						<th>{{localize this.label}}</th>
 						<td>
 							{{#each this.types as |type| }}
-								<i class="icon {{lookup @root.FU.affIcon type}}" style="flex: 0 1 auto;"></i>
+								<i data-tooltip="{{type}}" class="icon {{lookup @root.FU.affIcon type}}" style="flex: 0 1 auto;"></i>
 							{{/each}}
 						</td>
 						<td>
@@ -43,6 +44,11 @@
 							{{#each this.traits as |trait|}}
 								<span>{{pfuLocalizeTrait trait}} </span>
 							{{/each}}
+						</td>
+						<td class="fu-icon__container" data-tooltip="{{this.effect}}">
+							{{#if this.effect}}
+								<img class="fu-icon--s" alt="{{this.effect}}" src="{{lookup @root.context.effectIcons index}}">
+							{{/if}}
 						</td>
 						<td>
 							{{#if (and this.expense this.expense.amount)}}
@@ -69,6 +75,7 @@
 					<td>
 						?
 					</td>
+					<td></td>
 					<td></td>
 					<td></td>
 					<td>

--- a/templates/effects/actions/apply-effect-rule-action.hbs
+++ b/templates/effects/actions/apply-effect-rule-action.hbs
@@ -4,6 +4,6 @@
 	 type="text"
 	 name="{{pfuConcat path ".effect"}}"
 	 value="{{action.effect}}"
-	 placeholder="e.g. Item.XYZ123.ActiveEffect.ABC123"
+	 placeholder="e.g. status|fuid|uuid"
 	/>
 </label>

--- a/templates/effects/actions/modify-damage-rule-action.hbs
+++ b/templates/effects/actions/modify-damage-rule-action.hbs
@@ -18,6 +18,16 @@
 	</select>
 </label>
 
+<label class="fu-form__property">
+	<span>{{localize 'FU.Effect'}}</span>
+	<input
+	 type="text"
+	 name="{{pfuConcat path ".effect"}}"
+	 value="{{action.effect}}"
+	 placeholder="e.g. Item.XYZ123.ActiveEffect.ABC123"
+	/>
+</label>
+
 <div class="fu-form__group">
 	<label class="fu-form__group__header flex-group-center">
 		<i class="ra ra-wrench"></i>{{localize 'FU.Cost'}}


### PR DESCRIPTION
This pull request introduces support for associating effects with damage modifiers throughout the damage calculation and customization workflow. The changes ensure that effects can be specified, processed, and visually represented alongside traits and other damage properties, improving both data modeling and user interface clarity.

**Damage Modifier Effect Support**

* Added an `effect` property to the `DamageData` class and its modifiers, updated filtering logic to include modifiers with effects, and introduced `hasEffects` and `hasTraits` getters for easier checks. [[1]](diffhunk://#diff-681449d0fb0156047f9679ed931b17ea61915b61f0b5b3c00055664b3c8149fdR15) [[2]](diffhunk://#diff-681449d0fb0156047f9679ed931b17ea61915b61f0b5b3c00055664b3c8149fdL78-R79) [[3]](diffhunk://#diff-681449d0fb0156047f9679ed931b17ea61915b61f0b5b3c00055664b3c8149fdR147-R160)
* Updated `ModifyDamageRuleAction` to support an optional `effect` field, ensuring it is properly serialized and passed through all relevant rule action logic. [[1]](diffhunk://#diff-f38be338c7b9430dab8e29f1d7f323104a3f28a6e2871f7b1dbc71b7c43dac72R19) [[2]](diffhunk://#diff-f38be338c7b9430dab8e29f1d7f323104a3f28a6e2871f7b1dbc71b7c43dac72R49) [[3]](diffhunk://#diff-f38be338c7b9430dab8e29f1d7f323104a3f28a6e2871f7b1dbc71b7c43dac72R91) [[4]](diffhunk://#diff-f38be338c7b9430dab8e29f1d7f323104a3f28a6e2871f7b1dbc71b7c43dac72R107) [[5]](diffhunk://#diff-f38be338c7b9430dab8e29f1d7f323104a3f28a6e2871f7b1dbc71b7c43dac72R118-R127)

**Damage Pipeline and UI Enhancements**

* Modified the damage pipeline to process and apply effects from enabled modifiers, and updated the damage customizer UI to display effect icons and tooltips for each modifier. [[1]](diffhunk://#diff-bcb665426bff421e59d50cdeeff55311484599463936329d39a86acff172e60bL829-R836) [[2]](diffhunk://#diff-844912234aec1eeaee11e4f12b1a203700e24af879b490db345c1ac8ec09a5b2R4) [[3]](diffhunk://#diff-844912234aec1eeaee11e4f12b1a203700e24af879b490db345c1ac8ec09a5b2R22-R32) [[4]](diffhunk://#diff-844912234aec1eeaee11e4f12b1a203700e24af879b490db345c1ac8ec09a5b2L29-R41) [[5]](diffhunk://#diff-5c4bd4e9f1a8afeafd3535bc85b48b10a7f0dd4308c5a763a4326f1e4b013c70R23) [[6]](diffhunk://#diff-5c4bd4e9f1a8afeafd3535bc85b48b10a7f0dd4308c5a763a4326f1e4b013c70R48-R52) [[7]](diffhunk://#diff-5c4bd4e9f1a8afeafd3535bc85b48b10a7f0dd4308c5a763a4326f1e4b013c70R80)

**Template and Form Improvements**

* Added effect fields and improved placeholders in HBS templates for both damage customizer and rule action forms, ensuring users can input and view effect information clearly. [[1]](diffhunk://#diff-5350803fca792f6b71313d199c152cf93142dad9eefb91ac3f30dd2894edf7a8L7-R7) [[2]](diffhunk://#diff-3f4ba4e64de11ef993a5f9aa6ce75363a49639f82f23622ab2be31ff94b95882R21-R30) [[3]](diffhunk://#diff-5c4bd4e9f1a8afeafd3535bc85b48b10a7f0dd4308c5a763a4326f1e4b013c70L34-R35)

**Data Model and Pack Updates**

* Updated relevant JSON skill and effect packs to include new effect properties, stacking configuration, and metadata reflecting the new version and modification times. [[1]](diffhunk://#diff-2eb2b0f352731d632112b44b348b1b950b598026f40dfd746ecd13f8690dadf9L379-R380) [[2]](diffhunk://#diff-2eb2b0f352731d632112b44b348b1b950b598026f40dfd746ecd13f8690dadf9L392-L396) [[3]](diffhunk://#diff-2eb2b0f352731d632112b44b348b1b950b598026f40dfd746ecd13f8690dadf9R414-R418) [[4]](diffhunk://#diff-2eb2b0f352731d632112b44b348b1b950b598026f40dfd746ecd13f8690dadf9L439-R445) [[5]](diffhunk://#diff-c138b8eeea143c8eeed863be8076b5b86ca6f4818a77b25f2769fd9eb97812e2L30-R73) [[6]](diffhunk://#diff-c138b8eeea143c8eeed863be8076b5b86ca6f4818a77b25f2769fd9eb97812e2L72-R109)