### PR TITLE
Add support for calculate damage rule trigger for inline damage

### DIFF
--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -571,10 +571,9 @@ const performCheck = async (check, actor, item, prepareCheckCallback = undefined
 /**
  * @param {FUActor} actor
  * @param {FUItem} item
- * @param {CheckCallback} [initialConfigCallback]
- * @return {Promise<void>}
+ * @returns {CheckResultV2}
  */
-const display = async (actor, item, initialConfigCallback = undefined) => {
+const constructDisplayCheck = (actor, item) => {
 	/** @type CheckResultV2 */
 	const check = Object.freeze({
 		type: 'display',
@@ -593,13 +592,22 @@ const display = async (actor, item, initialConfigCallback = undefined) => {
 		critical: null,
 		additionalData: {},
 	});
+	return check;
+};
+
+/**
+ * @param {FUActor} actor
+ * @param {FUItem} item
+ * @param {CheckCallback} [initialConfigCallback]
+ * @return {Promise<void>}
+ */
+const display = async (actor, item, initialConfigCallback = undefined) => {
+	const check = constructDisplayCheck(actor, item);
 	// Set initial targets (actions without rolls can have targeting)
 	const config = CheckConfiguration.configure(check);
 	config.setDefaultTargets();
 	await CommonEvents.initializeCheck(config, actor, item);
 	await (initialConfigCallback ? initialConfigCallback(check, actor, item) : undefined);
-
-	//Hooks.callAll(CheckHooks.processCheck, check, actor, item);
 	await invokeWithCallbacks(CheckHooks.processCheck, check, actor, item);
 	await renderCheck(check, actor, item);
 };
@@ -689,6 +697,7 @@ export const Checks = Object.freeze({
 	modifyCheck,
 	isCheck,
 	prepareCheckDryRun,
+	constructDisplayCheck,
 });
 
 CheckRetarget.initialize();

--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -135,7 +135,6 @@ function calculateDamage(actor, item, config) {
 		type: config.getDamage()?.type,
 	};
 	Hooks.call(FUHooks.CALCULATE_DAMAGE_EVENT, event);
-	//await AsyncHooks.callSequential(FUHooks.CALCULATE_DAMAGE_EVENT, event);
 }
 
 /**

--- a/module/helpers/inline-damage.mjs
+++ b/module/helpers/inline-damage.mjs
@@ -4,11 +4,13 @@ import { InlineHelper, InlineSourceInfo } from './inline-helper.mjs';
 import { ExpressionContext, Expressions } from '../expressions/expressions.mjs';
 import { DamagePipeline, DamageRequest } from '../pipelines/damage-pipeline.mjs';
 import { Flags } from './flags.mjs';
-import { DamageData } from '../checks/damage-data.mjs';
 import { StringUtils } from './string-utils.mjs';
 import { HTMLUtils } from './html-utils.mjs';
 import { DamageCustomizerV2 } from '../ui/damage-customizer-v2.mjs';
 import { DamageTraits } from '../pipelines/traits.mjs';
+import { CommonEvents } from '../checks/common-events.mjs';
+import { CheckConfiguration } from '../checks/check-configuration.mjs';
+import { Checks } from '../checks/checks.mjs';
 
 const INLINE_DAMAGE = 'InlineDamage';
 
@@ -86,7 +88,22 @@ async function onRender(element) {
 				context = context.withCheck(check);
 			}
 			let amount = await Expressions.evaluateAsync(renderContext.dataset.amount, context);
-			const damageData = DamageData.construct(type, amount);
+
+			// TODO: Can the source check be used?
+			const eventCheck = Checks.constructDisplayCheck(context.actor, context.item);
+			const config = CheckConfiguration.configure(eventCheck);
+			config.setDefaultTargets();
+			config.setDamage(type, amount);
+			const damageData = config.getDamage();
+
+			// Check source actor for outgoing damage bonuses
+			if (context.actor) {
+				DamagePipeline.collectOutgoingBonuses(context.actor, damageData);
+				CommonEvents.calculateDamage(context.actor, context.item, config);
+				// TODO: Better solution
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+
 			let traits = [];
 			// SHIFT: Ignore resistances
 			if (keyboardModifiers.shift) {
@@ -101,10 +118,7 @@ async function onRender(element) {
 					traits.push(DamageTraits.IgnoreImmunities);
 				}
 			}
-			// Check source actor for outgoing damage bonuses
-			if (context.actor) {
-				DamagePipeline.collectOutgoingBonuses(context.actor, damageData);
-			}
+
 			const request = new DamageRequest(renderContext.sourceInfo, targets, damageData);
 			request.addTraits(traits);
 			if (renderContext.dataset.traits) {


### PR DESCRIPTION
This pull request refactors how display checks are constructed and integrates them into the inline damage calculation flow. The main improvements include extracting display check construction to a standalone function, updating the inline damage helper to leverage this function for more consistent damage configuration, and cleaning up unused code and imports.

**Refactoring and API Consistency**

* Extracted display check construction logic into a new `constructDisplayCheck` function in `module/checks/checks.mjs`, replacing the previous inline construction in the `display` function. This function is now exported as part of the `Checks` API for reuse. [[1]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1L574-R576) [[2]](diffhunk://#diff-319dbb38da41fa57e356a644957876ab687d43fa87a4b23a36c6948fae1441c1R700)
* Updated the `display` function to use `constructDisplayCheck`, improving separation of concerns and code clarity.

**Inline Damage Calculation Improvements**

* Refactored the inline damage helper (`module/helpers/inline-damage.mjs`) to use `constructDisplayCheck` and `CheckConfiguration` for setting up damage data, ensuring outgoing bonuses and damage events are processed consistently. Added a workaround with a short delay to ensure event processing.

**Code Cleanup**

* Removed the unused import of `DamageData` from `module/helpers/inline-damage.mjs`, as damage data is now configured via `CheckConfiguration`.
* Removed commented-out code and streamlined bonus collection in the inline damage helper for clarity. [[1]](diffhunk://#diff-1bf6261519c2f4d68da27dcabf120a17e937b83fcea044e9dc869eb1c2eaded9L104-R121) [[2]](diffhunk://#diff-131a49edbe188864fe037fc3d203d730b2a49f0d9447dfc58c2a349d52c70739L138)