### PR TITLE
Add support for apex attributes

### DIFF
--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -332,6 +332,8 @@ async function prepareCheckDryRun(type, actor, item, initialConfigCallback) {
 }
 
 const CRITICAL_THRESHOLD = 6;
+const ATTRIBUTE_MAXIMUM_DIE = 12;
+const ATTRIBUTE_APEX_DIE = 20;
 
 /**
  * @param {CheckV2} check
@@ -341,10 +343,22 @@ const CRITICAL_THRESHOLD = 6;
  */
 async function rollCheck(check, actor, item) {
 	const { primary, secondary, modifiers } = check;
+
 	/** @type AttributesDataModel */
 	const attributes = actor.system.attributes;
-	const primaryDice = attributes[primary].current;
-	const secondaryDice = attributes[secondary].current;
+	let primaryDice = attributes[primary].current;
+	let secondaryDice = attributes[secondary].current;
+
+	// Optional support for attribute paragon (use D20 instead of D12s during checks)
+	const apexAttribute = actor.getFlag(Flags.Scope, Flags.Toggle.ApexAttribute);
+	if (apexAttribute) {
+		if (primary === apexAttribute && attributes[primary].base >= ATTRIBUTE_MAXIMUM_DIE) {
+			primaryDice = ATTRIBUTE_APEX_DIE;
+		}
+		if (secondary === apexAttribute && attributes[secondary].base >= ATTRIBUTE_MAXIMUM_DIE) {
+			secondaryDice = ATTRIBUTE_APEX_DIE;
+		}
+	}
 
 	const modifierTotal = modifiers.reduce((agg, curr) => (agg += curr.value), 0);
 	let modPart = '';

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -46,6 +46,7 @@ export const Flags = Object.freeze({
 	Scope: 'projectfu',
 	Toggle: Object.freeze({
 		WeaponMagicCheck: 'weaponMagicCheck',
+		ApexAttribute: 'apexAttribute',
 	}),
 	Modifier: Object.freeze({
 		ScaleIncomingDamage: 'scaleIncomingDamage',

--- a/src/packs/actor-effects/effect_Apex_of_Dexterity_AIYVPdyldmKAkiLb.json
+++ b/src/packs/actor-effects/effect_Apex_of_Dexterity_AIYVPdyldmKAkiLb.json
@@ -1,0 +1,116 @@
+{
+  "folder": "423RpDks0B2eewCA",
+  "name": "Apex of Dexterity",
+  "type": "effect",
+  "_id": "AIYVPdyldmKAkiLb",
+  "img": "systems/projectfu/styles/static/statuses/DexUp.webp",
+  "system": {
+    "fuid": "apex-of-dexterity",
+    "cost": {
+      "value": 0
+    },
+    "source": ""
+  },
+  "effects": [
+    {
+      "name": "Apex of Dexterity",
+      "img": "systems/projectfu/styles/static/statuses/DexUp.webp",
+      "origin": "Compendium.projectfu.actor-effects.Item.AIYVPdyldmKAkiLb",
+      "system": {
+        "duration": {
+          "event": "none",
+          "interval": 1,
+          "tracking": "self",
+          "remaining": 1
+        },
+        "type": "default",
+        "predicate": {
+          "crisisInteraction": "none"
+        },
+        "rules": {
+          "elements": {},
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "bar"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
+          }
+        }
+      },
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "disabled": false,
+      "_id": "WPFaLxJqwtwseHIs",
+      "type": "base",
+      "changes": [
+        {
+          "key": "system.attributes.dex",
+          "mode": 0,
+          "value": "upgrade",
+          "priority": null
+        },
+        {
+          "key": "flags.projectfu.apexAttribute",
+          "mode": 5,
+          "value": "dex",
+          "priority": null
+        }
+      ],
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "projectfu": {
+          "Source": {
+            "name": "Apex of Dexterity",
+            "actorUuid": null,
+            "itemUuid": "Compendium.projectfu.actor-effects.Item.AIYVPdyldmKAkiLb",
+            "effectUuid": null,
+            "fuid": "apex-of-dexterity"
+          }
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "projectfu",
+        "systemVersion": "#{VERSION}#",
+        "createdTime": 1773072400712,
+        "modifiedTime": 1773072460348,
+        "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+      },
+      "_key": "!items.effects!AIYVPdyldmKAkiLb.WPFaLxJqwtwseHIs"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "J5B4HfVqUaCPvzGg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "createdTime": 1773072320779,
+    "modifiedTime": 1773072399130,
+    "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+  },
+  "_key": "!items!AIYVPdyldmKAkiLb"
+}

--- a/src/packs/actor-effects/effect_Apex_of_Insight_PzBzHR0xsT4jXqys.json
+++ b/src/packs/actor-effects/effect_Apex_of_Insight_PzBzHR0xsT4jXqys.json
@@ -1,0 +1,116 @@
+{
+  "folder": "423RpDks0B2eewCA",
+  "name": "Apex of Insight",
+  "type": "effect",
+  "_id": "PzBzHR0xsT4jXqys",
+  "img": "systems/projectfu/styles/static/statuses/InsUp.webp",
+  "system": {
+    "fuid": "apex-of-insight",
+    "cost": {
+      "value": 0
+    },
+    "source": ""
+  },
+  "effects": [
+    {
+      "name": "Apex of Insight",
+      "img": "systems/projectfu/styles/static/statuses/InsUp.webp",
+      "origin": "Compendium.projectfu.actor-effects.Item.PzBzHR0xsT4jXqys",
+      "system": {
+        "duration": {
+          "event": "none",
+          "interval": 1,
+          "tracking": "self",
+          "remaining": 1
+        },
+        "type": "default",
+        "predicate": {
+          "crisisInteraction": "none"
+        },
+        "rules": {
+          "elements": {},
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "bar"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
+          }
+        }
+      },
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "disabled": false,
+      "_id": "SWPWY8IYX4N9A21v",
+      "type": "base",
+      "changes": [
+        {
+          "key": "system.attributes.ins",
+          "mode": 0,
+          "value": "upgrade",
+          "priority": null
+        },
+        {
+          "key": "flags.projectfu.apexAttribute",
+          "mode": 5,
+          "value": "ins",
+          "priority": null
+        }
+      ],
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "projectfu": {
+          "Source": {
+            "name": "Apex of Insight",
+            "actorUuid": null,
+            "itemUuid": "Compendium.projectfu.actor-effects.Item.PzBzHR0xsT4jXqys",
+            "effectUuid": null,
+            "fuid": "apex-of-insight"
+          }
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "projectfu",
+        "systemVersion": "#{VERSION}#",
+        "createdTime": 1773072491242,
+        "modifiedTime": 1773072518331,
+        "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+      },
+      "_key": "!items.effects!PzBzHR0xsT4jXqys.SWPWY8IYX4N9A21v"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "J5B4HfVqUaCPvzGg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "createdTime": 1773072477202,
+    "modifiedTime": 1773072490116,
+    "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+  },
+  "_key": "!items!PzBzHR0xsT4jXqys"
+}

--- a/src/packs/actor-effects/effect_Apex_of_Might_UshRKaPJW2yet0qI.json
+++ b/src/packs/actor-effects/effect_Apex_of_Might_UshRKaPJW2yet0qI.json
@@ -1,0 +1,116 @@
+{
+  "folder": "423RpDks0B2eewCA",
+  "name": "Apex of Might",
+  "type": "effect",
+  "_id": "UshRKaPJW2yet0qI",
+  "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+  "system": {
+    "fuid": "might-paragon",
+    "cost": {
+      "value": 0
+    },
+    "source": ""
+  },
+  "effects": [
+    {
+      "name": "Apex of Might",
+      "img": "systems/projectfu/styles/static/statuses/MigUp.webp",
+      "origin": "Compendium.projectfu.actor-effects.Item.UshRKaPJW2yet0qI",
+      "system": {
+        "duration": {
+          "event": "none",
+          "interval": 1,
+          "tracking": "self",
+          "remaining": 1
+        },
+        "type": "default",
+        "predicate": {
+          "crisisInteraction": "none"
+        },
+        "rules": {
+          "elements": {},
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "bar"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
+          }
+        }
+      },
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "disabled": false,
+      "_id": "CJptAkNpo0jBYqYr",
+      "type": "base",
+      "changes": [
+        {
+          "key": "system.attributes.mig",
+          "mode": 0,
+          "value": "upgrade",
+          "priority": null
+        },
+        {
+          "key": "flags.projectfu.apexAttribute",
+          "mode": 5,
+          "value": "mig",
+          "priority": null
+        }
+      ],
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "projectfu": {
+          "Source": {
+            "name": "Might Paragon",
+            "actorUuid": null,
+            "itemUuid": "Compendium.projectfu.actor-effects.Item.UshRKaPJW2yet0qI",
+            "effectUuid": null,
+            "fuid": "might-paragon"
+          }
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "projectfu",
+        "systemVersion": "#{VERSION}#",
+        "createdTime": 1773070167344,
+        "modifiedTime": 1773072463403,
+        "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+      },
+      "_key": "!items.effects!UshRKaPJW2yet0qI.CJptAkNpo0jBYqYr"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "J5B4HfVqUaCPvzGg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "createdTime": 1773070155174,
+    "modifiedTime": 1773072336254,
+    "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+  },
+  "_key": "!items!UshRKaPJW2yet0qI"
+}

--- a/src/packs/actor-effects/effect_Apex_of_Willpower_3bSDigs6OycCOBop.json
+++ b/src/packs/actor-effects/effect_Apex_of_Willpower_3bSDigs6OycCOBop.json
@@ -1,0 +1,116 @@
+{
+  "folder": "423RpDks0B2eewCA",
+  "name": "Apex of Willpower",
+  "type": "effect",
+  "_id": "3bSDigs6OycCOBop",
+  "img": "systems/projectfu/styles/static/statuses/WlpUp.webp",
+  "system": {
+    "fuid": "apex-of-willpower",
+    "cost": {
+      "value": 0
+    },
+    "source": ""
+  },
+  "effects": [
+    {
+      "name": "Apex of Willpower",
+      "img": "systems/projectfu/styles/static/statuses/WlpUp.webp",
+      "origin": "Compendium.projectfu.actor-effects.Item.3bSDigs6OycCOBop",
+      "system": {
+        "duration": {
+          "event": "none",
+          "interval": 1,
+          "tracking": "self",
+          "remaining": 1
+        },
+        "type": "default",
+        "predicate": {
+          "crisisInteraction": "none"
+        },
+        "rules": {
+          "elements": {},
+          "progress": {
+            "enabled": false,
+            "id": "",
+            "name": "",
+            "current": 0,
+            "max": 6,
+            "style": "bar"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
+          }
+        }
+      },
+      "duration": {
+        "startTime": null,
+        "combat": null
+      },
+      "disabled": false,
+      "_id": "jW4nxSExG4gSqqFP",
+      "type": "base",
+      "changes": [
+        {
+          "key": "system.attributes.wlp",
+          "mode": 0,
+          "value": "upgrade",
+          "priority": null
+        },
+        {
+          "key": "flags.projectfu.apexAttribute",
+          "mode": 5,
+          "value": "wlp",
+          "priority": null
+        }
+      ],
+      "description": "",
+      "tint": "#ffffff",
+      "transfer": true,
+      "statuses": [],
+      "sort": 0,
+      "flags": {
+        "projectfu": {
+          "Source": {
+            "name": "Apex of Willpower",
+            "actorUuid": null,
+            "itemUuid": "Compendium.projectfu.actor-effects.Item.3bSDigs6OycCOBop",
+            "effectUuid": null,
+            "fuid": "apex-of-willpower"
+          }
+        }
+      },
+      "_stats": {
+        "compendiumSource": null,
+        "duplicateSource": null,
+        "exportSource": null,
+        "coreVersion": "13.351",
+        "systemId": "projectfu",
+        "systemVersion": "#{VERSION}#",
+        "createdTime": 1773072548325,
+        "modifiedTime": 1773072576298,
+        "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+      },
+      "_key": "!items.effects!3bSDigs6OycCOBop.jW4nxSExG4gSqqFP"
+    }
+  ],
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "J5B4HfVqUaCPvzGg": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "exportSource": null,
+    "coreVersion": "13.351",
+    "systemId": "projectfu",
+    "systemVersion": "#{VERSION}#",
+    "createdTime": 1773072537428,
+    "modifiedTime": 1773072545655,
+    "lastModifiedBy": "J5B4HfVqUaCPvzGg"
+  },
+  "_key": "!items!3bSDigs6OycCOBop"
+}


### PR DESCRIPTION
This pull request introduces a new "Apex Attribute" system for actor checks, allowing certain attributes to be upgraded to a d20 die when specific conditions are met. It also adds supporting flags and four new actor effects for Dexterity, Insight, Might, and Willpower, each granting apex status to their respective attributes.

Enhancements to attribute checks:

* Added new constants `ATTRIBUTE_MAXIMUM_DIE` and `ATTRIBUTE_APEX_DIE` to `module/checks/checks.mjs`, enabling the use of a d20 die for apex attributes during checks.
* Updated the `rollCheck` function logic to check for the apex attribute flag and upgrade the die to d20 if the attribute's base value meets the threshold.

System flag additions:

* Introduced the `ApexAttribute` flag in `module/helpers/flags.mjs` to support marking an attribute as apex on an actor.

New actor effects for apex attributes:

* Added four new actor effects in the `src/packs/actor-effects` directory: `effect_Apex_of_Dexterity_AIYVPdyldmKAkiLb.json`, `effect_Apex_of_Insight_PzBzHR0xsT4jXqys.json`, `effect_Apex_of_Might_UshRKaPJW2yet0qI.json`, and `effect_Apex_of_Willpower_3bSDigs6OycCOBop.json`. Each effect upgrades its respective attribute and sets the apex flag. [[1]](diffhunk://#diff-64f5489f6c79e59568825690667010ffd949272519b3af24bcc5b14f907e6996R1-R116) [[2]](diffhunk://#diff-de84e6ea5117640fb1200605ec47235abd428ff8570ebff16b8a74d15c59078bR1-R116) [[3]](diffhunk://#diff-aa602ab8fa164ab45ebdb653c21c2666482fee674ba6d9e6f84ed78ff4c8facaR1-R116) [[4]](diffhunk://#diff-5e16ca41f22e49cec5c9437eb8c21f238ebbbbe2619445926d94076eaee2e2b6R1-R116)