### PR TITLE
Pressure Gauge and Sprite Scale

### DIFF
--- a/module/ui/pressureGauges/pressure-gauge.mjs
+++ b/module/ui/pressureGauges/pressure-gauge.mjs
@@ -106,7 +106,7 @@ export class FUPressureGauge extends globalThis.PIXI.Container {
 				break;
 			default:
 				if (scaleGauge) {
-					this.y = doc.getSize().height * mesh.anchor.y - doc.getSize().height * doc.texture.scaleY * mesh.anchor.y; // - 4;
+					this.y = doc.getSize().height * mesh.anchor.y - doc.getSize().height * doc.texture.scaleY * mesh.anchor.y - this.height;
 				} else {
 					this.y = -(this.height + 4);
 				}

--- a/module/ui/pressureGauges/pressure-gauge.mjs
+++ b/module/ui/pressureGauges/pressure-gauge.mjs
@@ -81,13 +81,35 @@ export class FUPressureGauge extends globalThis.PIXI.Container {
 	}
 
 	_positionGauge() {
+		const doc = this.token.document;
+		const mesh = this.token.mesh;
+
+		const scaleGauge = (doc.texture.scaleX > 1 || doc.texture.scaleY > 1) && mesh?.anchor;
+
+		if (scaleGauge) {
+			this.width = doc.getSize().width * doc.texture.scaleX;
+			this.x = doc.getSize().width * mesh.anchor.x - doc.getSize().width * doc.texture.scaleX * mesh.anchor.x;
+		} else {
+			this.width = doc.getSize().width;
+			this.x = 0;
+		}
+
 		switch (game.settings.get(SYSTEM, SETTINGS.optionPressureGaugePosition)) {
 			case 'bottom':
-				this.y = this.token.document.getSize().height + 5;
+				if (scaleGauge) {
+					this.y = doc.getSize().height * mesh.anchor.y + doc.getSize().height * doc.texture.scaleY * mesh.anchor.y; // + 4;
+				} else {
+					this.y = this.token.document.getSize().height + 5;
+				}
+
 				if (this.token.nameplate) this.token.nameplate.y = this.y + this.height;
 				break;
 			default:
-				this.y = -(this.height + 5);
+				if (scaleGauge) {
+					this.y = doc.getSize().height * mesh.anchor.y - doc.getSize().height * doc.texture.scaleY * mesh.anchor.y; // - 4;
+				} else {
+					this.y = -(this.height + 4);
+				}
 				if (this.token.tooltip) this.token.tooltip.y = this.y;
 				break;
 		}


### PR DESCRIPTION
Adds handling for sprite scales greater than 1 to ensure pressure gauge remains visible

<img width="581" height="548" alt="image" src="https://github.com/user-attachments/assets/7653c4d0-f35b-4a90-81a7-36102c54fdbb" />

<img width="326" height="314" alt="image" src="https://github.com/user-attachments/assets/7e4a347a-445b-421e-8afa-d5e254c90d33" />

<img width="326" height="314" alt="image" src="https://github.com/user-attachments/assets/32cc8e7e-1c21-4cf8-8802-1a4491b2bfb7" />
