### PR TITLE
Pressure Clock as Trackable Resource

### DIFF
--- a/module/documents/actors/npc/npc-data-model.mjs
+++ b/module/documents/actors/npc/npc-data-model.mjs
@@ -115,7 +115,6 @@ export class NpcDataModel extends BaseCharacterDataModel {
 			pressurePoints: new EmbeddedDataField(TraitsDataModel, {
 				options: TraitUtils.getOptionsFromConfig(FU.weaponCategories),
 			}),
-			clocks: new SchemaField({}),
 		});
 	}
 
@@ -131,7 +130,9 @@ export class NpcDataModel extends BaseCharacterDataModel {
 		this.#prepareReplacedSoldiers();
 		this.#prepareBasicResource();
 		this.derived.prepareData();
-		this.#preparePressureResource();
+
+		this.clocks = {};
+		this.#prepareClockResources();
 	}
 
 	/**
@@ -224,28 +225,40 @@ export class NpcDataModel extends BaseCharacterDataModel {
 		});
 	}
 
-	#preparePressureResource() {
+	/**
+	 * Adds a trackable resource to the clocks property of this DataModel
+	 * @param {string} key - Key name for the clock to be added to the DataModel
+	 * @param {string} fuid - fuid of the progress clock -- will be resolved with {@link FUActor.resolveProgress}
+	 */
+	addClockResource(key, fuid) {
+		this.clocks ??= {};
+		this.clocks[key] ??= {};
+
 		const actor = this.parent;
-		this.clocks.pressure = {};
-		Object.defineProperty(this.clocks.pressure, 'value', {
+
+		Object.defineProperty(this.clocks[key], 'value', {
 			configurable: true,
 			enumerable: true,
 			get() {
-				const clock = actor?.resolveProgress('pressure');
+				const clock = actor?.resolveProgress(fuid);
 				if (!clock) return 0;
 				return clock.current;
 			},
 		});
 
-		Object.defineProperty(this.clocks.pressure, 'max', {
+		Object.defineProperty(this.clocks[key], 'max', {
 			configurable: true,
 			enumerable: true,
 			get() {
-				const clock = actor?.resolveProgress('pressure');
+				const clock = actor?.resolveProgress(fuid);
 				if (!clock) return 0;
 				return clock.max;
 			},
 		});
+	}
+
+	#prepareClockResources() {
+		this.addClockResource('pressure', 'pressure');
 	}
 }
 

--- a/module/documents/actors/npc/npc-data-model.mjs
+++ b/module/documents/actors/npc/npc-data-model.mjs
@@ -115,6 +115,7 @@ export class NpcDataModel extends BaseCharacterDataModel {
 			pressurePoints: new EmbeddedDataField(TraitsDataModel, {
 				options: TraitUtils.getOptionsFromConfig(FU.weaponCategories),
 			}),
+			clocks: new SchemaField({}),
 		});
 	}
 
@@ -130,6 +131,7 @@ export class NpcDataModel extends BaseCharacterDataModel {
 		this.#prepareReplacedSoldiers();
 		this.#prepareBasicResource();
 		this.derived.prepareData();
+		this.#preparePressureResource();
 	}
 
 	/**
@@ -218,6 +220,30 @@ export class NpcDataModel extends BaseCharacterDataModel {
 			set(newValue) {
 				delete this.max;
 				this.max = newValue;
+			},
+		});
+	}
+
+	#preparePressureResource() {
+		const actor = this.parent;
+		this.clocks.pressure = {};
+		Object.defineProperty(this.clocks.pressure, 'value', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				const clock = actor?.resolveProgress('pressure');
+				if (!clock) return 0;
+				return clock.current;
+			},
+		});
+
+		Object.defineProperty(this.clocks.pressure, 'max', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				const clock = actor?.resolveProgress('pressure');
+				if (!clock) return 0;
+				return clock.max;
 			},
 		});
 	}

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -238,7 +238,7 @@ Hooks.once('init', async () => {
 			value: ['resources.fp.value', 'resources.exp.value'],
 		},
 		npc: {
-			bar: ['resources.hp', 'resources.mp'],
+			bar: ['resources.hp', 'resources.mp', 'clocks.pressure'],
 			value: ['resources.fp.value'],
 		},
 	};


### PR DESCRIPTION
This adds the pressure clock as a trackable resource for NPCs under `clocks.pressure`

[Pressure Resource.webm](https://github.com/user-attachments/assets/dbafacdc-6f09-4d10-b5a3-42588735a4ca)

Which also means:  Bar Brawl support.

[Pressure Resource - Bar Brawl.webm](https://github.com/user-attachments/assets/39b96e8f-4a84-4299-96a5-6246702f8f79)
