### PR TITLE
Add arcanum pulse option

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -856,9 +856,11 @@
 		"ClassFeatureArcanumHint": "Arcanum",
 		"ClassFeatureArcanumDomains": "Domains",
 		"ClassFeatureArcanumMerge": "Merge Benefits",
+		"ClassFeatureArcanumPulse": "Pulse Effect",
 		"ClassFeatureArcanumDismiss": "Dismiss Effect",
 		"ClassFeatureArcanumSummonMessage": "The arcanum has been <strong>merged with.</strong>",
 		"ClassFeatureArcanumDismissMessage": "The arcanum has been <strong>dismissed.</strong>",
+		"ClassFeatureArcanumPulseMessage": "The arcanum's <strong>pulse effect</strong> has been unleashed.",
 		"ClassFeatureKey": "Key",
 		"ClassFeatureKeyDamageType": "Damage type",
 		"ClassFeatureKeyStatus": "Status Effect",
@@ -1924,6 +1926,8 @@
 		"Used": "Used",
 		"Points": "Points",
 		"NPCSkills": "NPC Skills",
-		"SpecialAttacks": "Special Attacks"
+		"SpecialAttacks": "Special Attacks",
+		"OptionArcanumPulse": "Arcanum Pulse",
+		"OptionArcanumPulseHint": "Whether to add pulses to arcanums as per the playtest materials."
 	}
 }

--- a/module/documents/items/classFeature/arcanist/arcanum-data-model.mjs
+++ b/module/documents/items/classFeature/arcanist/arcanum-data-model.mjs
@@ -9,6 +9,7 @@ import FoundryUtils from '../../../../helpers/foundry-utils.mjs';
  * @extends ClassFeatureDataModel
  * @property {string} domains
  * @property {string} merge
+ * @property {string} pulse
  * @property {string} dismiss
  */
 export class ArcanumDataModel extends RollableClassFeatureDataModel {
@@ -17,6 +18,7 @@ export class ArcanumDataModel extends RollableClassFeatureDataModel {
 		return {
 			domains: new StringField(),
 			merge: new HTMLField(),
+			pulse: new HTMLField(),
 			dismiss: new HTMLField(),
 		};
 	}
@@ -48,6 +50,7 @@ export class ArcanumDataModel extends RollableClassFeatureDataModel {
 		return {
 			enrichedMerge: await TextEditor.enrichHTML(model.merge),
 			enrichedDismiss: await TextEditor.enrichHTML(model.dismiss),
+			enrichedPulse: await TextEditor.enrichHTML(model.pulse),
 			active: itemId === actorArcanumId,
 		};
 	}
@@ -60,6 +63,7 @@ export class ArcanumDataModel extends RollableClassFeatureDataModel {
 		const data = {
 			domains: model.domains,
 			merge: await TextEditor.enrichHTML(model.merge),
+			pulse: await TextEditor.enrichHTML(model.pulse),
 			dismiss: await TextEditor.enrichHTML(model.dismiss),
 		};
 

--- a/module/documents/items/classFeature/chanter/verses-application.mjs
+++ b/module/documents/items/classFeature/chanter/verses-application.mjs
@@ -11,6 +11,7 @@ import { ActionCostDataModel } from '../../common/action-cost-data-model.mjs';
 import { ClassFeatureTypeDataModel } from '../class-feature-type-data-model.mjs';
 import { FUChatBuilder } from '../../../../helpers/chat-builder.mjs';
 import { ResourcePipeline } from '../../../../pipelines/resource-pipeline.mjs';
+import { FeatureTraits } from '../../../../pipelines/traits.mjs';
 
 /**
  * @param {VerseDataModel} model
@@ -327,12 +328,13 @@ export class VersesApplication extends FUApplication {
 		CommonSections.genericText(renderData.sections, enriched);
 		CommonSections.expense(renderData, actor, item, targets, flags, expense);
 
+		await CommonEvents.feature(actor, item, [FeatureTraits.Verse], renderData);
+
 		const builder = new FUChatBuilder(actor, item);
 		builder.withFlags(flags);
 		builder.withData(renderData);
 		await builder.create();
 
 		CommonEvents.skill(actor, item);
-		this.close();
 	}
 }

--- a/module/helpers/chat-builder.mjs
+++ b/module/helpers/chat-builder.mjs
@@ -207,13 +207,7 @@ export class FUChatBuilder {
 		}
 
 		// Resolve speaker
-		let speaker = ChatMessage.getSpeaker({ actor });
-		if (speaker.scene && speaker.token) {
-			const token = game.scenes.get(speaker.scene)?.tokens?.get(speaker.token);
-			if (token) {
-				speaker = ChatMessage.getSpeaker({ token });
-			}
-		}
+		let speaker = FoundryUtils.resolveSpeaker(actor);
 
 		// Prepare data
 		const chatMessage = {

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -66,6 +66,12 @@ const { api, fields, handlebars } = foundry.applications;
  */
 
 /**
+ * @typedef FUDialogContentSection
+ * @property {String} title
+ * @property {String} text
+ */
+
+/**
  * @remarks Helper usage examples can also be found here: https://foundryvtt.wiki/en/development/api/helpers
  */
 export default class FoundryUtils {

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -287,6 +287,45 @@ export default class FoundryUtils {
 	}
 
 	/**
+	 * @param {Object} options
+	 * @param {string} options.title
+	 * @param {FUDialogContentSection[]} options.sections
+	 * @param {DialogV2Button[]} options.buttons
+	 * @returns {Promise<string|null>}
+	 */
+	static async promptChoiceSections({ title, sections, buttons }) {
+		const result = await foundry.applications.api.DialogV2.wait({
+			window: {
+				title,
+				icon: 'fas fa-square-up-right',
+				resizable: true,
+			},
+			position: {
+				width: 225 * sections.length,
+			},
+			classes: ['projectfu', 'sheet', 'backgroundstyle', 'fu-dialog'],
+			content: await FoundryUtils.renderTemplate('dialog/dialog-layout', {
+				sections: sections,
+			}),
+			buttons,
+			actions: {
+				sendToChat: async (event, dialog) => {
+					const text = dialog.dataset.text;
+					const title = dialog.dataset.title;
+					const chatMessage = {
+						content: await FoundryUtils.renderTemplate('chat/chat-description', {
+							flavor: StringUtils.localize(title),
+							description: text,
+						}),
+					};
+					return ChatMessage.create(chatMessage);
+				},
+			},
+		});
+		return result ?? null;
+	}
+
+	/**
 	 * @param {String} title
 	 * @param {FUActor} actor
 	 * @param {FUItem} item

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -291,9 +291,10 @@ export default class FoundryUtils {
 	 * @param {string} options.title
 	 * @param {FUDialogContentSection[]} options.sections
 	 * @param {DialogV2Button[]} options.buttons
+	 * @param {FUItem} options.item
 	 * @returns {Promise<string|null>}
 	 */
-	static async promptChoiceSections({ title, sections, buttons }) {
+	static async promptChoiceSections({ title, sections, buttons, item }) {
 		const result = await foundry.applications.api.DialogV2.wait({
 			window: {
 				title,
@@ -312,9 +313,13 @@ export default class FoundryUtils {
 				sendToChat: async (event, dialog) => {
 					const text = dialog.dataset.text;
 					const title = dialog.dataset.title;
+					const flavor = await FoundryUtils.renderTemplate('chat/chat-check-flavor-item-v2', {
+						subtitle: title,
+						item: item,
+					});
 					const chatMessage = {
-						content: await FoundryUtils.renderTemplate('chat/chat-description', {
-							flavor: StringUtils.localize(title),
+						flavor: flavor,
+						content: await FoundryUtils.renderTemplate('chat/chat-description-v2', {
 							description: text,
 						}),
 					};

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -318,7 +318,7 @@ export default class FoundryUtils {
 						subtitle: title,
 						item: item,
 					});
-					const speaker = ChatMessage.getSpeaker({ actor });
+					const speaker = FoundryUtils.resolveSpeaker(actor);
 					const chatMessage = {
 						speaker: speaker,
 						flavor: flavor,
@@ -483,6 +483,21 @@ export default class FoundryUtils {
 	static safeClone(data) {
 		if (data?.toObject instanceof Function) return data.toObject();
 		return foundry.utils.deepClone(data);
+	}
+
+	/**
+	 * @param {FUActor} actor
+	 * @returns {*}
+	 */
+	static resolveSpeaker(actor) {
+		let speaker = ChatMessage.getSpeaker({ actor });
+		if (speaker.scene && speaker.token) {
+			const token = game.scenes.get(speaker.scene)?.tokens?.get(speaker.token);
+			if (token) {
+				speaker = ChatMessage.getSpeaker({ token });
+			}
+		}
+		return speaker;
 	}
 
 	/**

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -291,10 +291,11 @@ export default class FoundryUtils {
 	 * @param {string} options.title
 	 * @param {FUDialogContentSection[]} options.sections
 	 * @param {DialogV2Button[]} options.buttons
+	 * @param {FUActor} options.actor
 	 * @param {FUItem} options.item
 	 * @returns {Promise<string|null>}
 	 */
-	static async promptChoiceSections({ title, sections, buttons, item }) {
+	static async promptChoiceSections({ title, sections, buttons, actor, item }) {
 		const result = await foundry.applications.api.DialogV2.wait({
 			window: {
 				title,
@@ -317,7 +318,9 @@ export default class FoundryUtils {
 						subtitle: title,
 						item: item,
 					});
+					const speaker = ChatMessage.getSpeaker({ actor });
 					const chatMessage = {
+						speaker: speaker,
 						flavor: flavor,
 						content: await FoundryUtils.renderTemplate('chat/chat-description-v2', {
 							description: text,

--- a/module/pipelines/application-pipeline.mjs
+++ b/module/pipelines/application-pipeline.mjs
@@ -44,26 +44,18 @@ async function handleArcanum(actor, item) {
 	if (currentArcanum) {
 		/** @type ArcanumDataModel **/
 		const currentArcanumData = currentArcanum.system.data;
+
 		/** @type FUDialogContentSection[] **/
-		let sections = [
-			{
-				title: `FU.ClassFeatureArcanumDismiss`,
-				text: await FoundryUtils.enrichText(currentArcanumData.dismiss, {
-					relativeTo: actor,
-				}),
-			},
-		];
-		const dialogData = {
-			title: title,
-			buttons: [
-				{
-					action: 'dismiss',
-					label: `FU.ClassFeatureArcanumDismiss`,
-					icon: 'fas fa-bolt',
-					primary: true,
-				},
-			],
-		};
+		let sections = [];
+		let buttons = [];
+
+		// FOR REFERENCE: Merge
+		sections.push({
+			title: `FU.ClassFeatureArcanumMerge`,
+			text: await FoundryUtils.enrichText(currentArcanumData.merge, {
+				relativeTo: actor,
+			}),
+		});
 
 		// OPTIONAL: Pulse
 		if (getSystemSetting(SETTINGS.optionArcanumPulse) && currentArcanumData.pulse) {
@@ -73,7 +65,7 @@ async function handleArcanum(actor, item) {
 					relativeTo: actor,
 				}),
 			});
-			dialogData.buttons.push({
+			buttons.push({
 				action: 'pulse',
 				label: `FU.ClassFeatureArcanumPulse`,
 				icon: 'fas fa-burst',
@@ -81,10 +73,27 @@ async function handleArcanum(actor, item) {
 			});
 		}
 
-		dialogData.content = await FoundryUtils.renderTemplate('dialog/dialog-layout', {
-			sections: sections,
+		// ALWAYS: DISMISS
+		buttons.push({
+			action: 'dismiss',
+			label: `FU.ClassFeatureArcanumDismiss`,
+			icon: 'fas fa-bolt',
+			primary: true,
 		});
-		const choice = await FoundryUtils.promptActionChoice(dialogData);
+		sections.push({
+			title: `FU.ClassFeatureArcanumDismiss`,
+			text: await FoundryUtils.enrichText(currentArcanumData.dismiss, {
+				relativeTo: actor,
+			}),
+		});
+
+		const dialogData = {
+			title: `${title} - ${currentArcanum.name}`,
+			buttons: buttons,
+			sections: sections,
+		};
+
+		const choice = await FoundryUtils.promptChoiceSections(dialogData);
 
 		if (choice === 'dismiss') {
 			await actor.update({

--- a/module/pipelines/application-pipeline.mjs
+++ b/module/pipelines/application-pipeline.mjs
@@ -14,6 +14,7 @@ import { FeatureTraits } from './traits.mjs';
 import { CommonSections } from '../checks/common-sections.mjs';
 import { FUChatBuilder } from '../helpers/chat-builder.mjs';
 import { CHECK_DETAILS } from '../checks/default-section-order.mjs';
+import { getSystemSetting, SETTINGS } from '../settings.js';
 
 /**
  * @desc An application used for specific class features.
@@ -39,16 +40,21 @@ async function handleArcanum(actor, item) {
 	const currentArcanumId = actor.system.equipped.arcanum;
 	const currentArcanum = actor.items.get(currentArcanumId);
 
-	// TODO: Pass in render data, check over summon branch
-	// Dismiss
+	// Dismiss/Pulse
 	if (currentArcanum) {
 		/** @type ArcanumDataModel **/
 		const currentArcanumData = currentArcanum.system.data;
-		const choice = await FoundryUtils.promptItemChoice({
-			title: `${title}: ${StringUtils.localize('FU.ClassFeatureArcanumDismiss')}`,
-			actor: actor,
-			item: currentArcanum,
-			description: currentArcanumData.dismiss,
+		/** @type FUDialogContentSection[] **/
+		let sections = [
+			{
+				title: `FU.ClassFeatureArcanumDismiss`,
+				text: await FoundryUtils.enrichText(currentArcanumData.dismiss, {
+					relativeTo: actor,
+				}),
+			},
+		];
+		const dialogData = {
+			title: title,
 			buttons: [
 				{
 					action: 'dismiss',
@@ -57,7 +63,29 @@ async function handleArcanum(actor, item) {
 					primary: true,
 				},
 			],
+		};
+
+		// OPTIONAL: Pulse
+		if (getSystemSetting(SETTINGS.optionArcanumPulse) && currentArcanumData.pulse) {
+			sections.push({
+				title: `FU.ClassFeatureArcanumPulse`,
+				text: await FoundryUtils.enrichText(currentArcanumData.pulse, {
+					relativeTo: actor,
+				}),
+			});
+			dialogData.buttons.push({
+				action: 'pulse',
+				label: `FU.ClassFeatureArcanumPulse`,
+				icon: 'fas fa-burst',
+				primary: false,
+			});
+		}
+
+		dialogData.content = await FoundryUtils.renderTemplate('dialog/dialog-layout', {
+			sections: sections,
 		});
+		const choice = await FoundryUtils.promptActionChoice(dialogData);
+
 		if (choice === 'dismiss') {
 			await actor.update({
 				'system.equipped.arcanum': null,
@@ -75,6 +103,22 @@ async function handleArcanum(actor, item) {
 			});
 			CommonSections.content(renderData.sections, content, CHECK_DETAILS);
 			await CommonEvents.feature(actor, item, [FeatureTraits.ArcanumDismiss], renderData);
+			const builder = new FUChatBuilder(actor, item).withData(renderData);
+			await builder.create();
+		} else if (choice === 'pulse') {
+			/** @type {FURenderData} **/
+			const renderData = {
+				sections: [],
+				postRenderActions: [],
+			};
+			CommonSections.itemFlavor(renderData.sections, currentArcanum);
+			const content = await FoundryUtils.renderTemplate('feature/arcanist/feature-arcanum-chat-message-v2', {
+				item: currentArcanum,
+				message: 'FU.ClassFeatureArcanumPulseMessage',
+				details: currentArcanumData.pulse,
+			});
+			CommonSections.content(renderData.sections, content, CHECK_DETAILS);
+			await CommonEvents.feature(actor, item, [FeatureTraits.ArcanumPulse], renderData);
 			const builder = new FUChatBuilder(actor, item).withData(renderData);
 			await builder.create();
 		}

--- a/module/pipelines/application-pipeline.mjs
+++ b/module/pipelines/application-pipeline.mjs
@@ -89,6 +89,7 @@ async function handleArcanum(actor, item) {
 
 		const dialogData = {
 			title: `${title} - ${currentArcanum.name}`,
+			actor: actor,
 			buttons: buttons,
 			item: currentArcanum,
 			sections: sections,
@@ -156,8 +157,8 @@ async function handleArcanum(actor, item) {
 		if (result && result.length > 0) {
 			/** @type FUItem **/
 			const selectedArcana = result[0];
-			const selectedArcanaEffect = selectedArcana.effects.size === 1 ? Array.from(selectedArcana.effects.values())[0] : null;
-			if (selectedArcanaEffect) {
+			//const selectedArcanaEffect = selectedArcana.effects.size === 1 ? Array.from(selectedArcana.effects.values())[0] : null;
+			if (selectedArcana) {
 				// Equip the arcana
 				await actor.update({
 					'system.equipped.arcanum': selectedArcana.id,
@@ -190,6 +191,8 @@ async function handleArcanum(actor, item) {
 				await CommonEvents.feature(actor, item, expense.traits, renderData);
 				const builder = new FUChatBuilder(actor, item).withData(renderData).withFlags(flags);
 				await builder.create();
+			} else {
+				ui.notifications.error(`Failed to resolve the arcana from the selection.`);
 			}
 		}
 	}

--- a/module/pipelines/application-pipeline.mjs
+++ b/module/pipelines/application-pipeline.mjs
@@ -90,6 +90,7 @@ async function handleArcanum(actor, item) {
 		const dialogData = {
 			title: `${title} - ${currentArcanum.name}`,
 			buttons: buttons,
+			item: currentArcanum,
 			sections: sections,
 		};
 

--- a/module/pipelines/traits.mjs
+++ b/module/pipelines/traits.mjs
@@ -67,6 +67,7 @@ export const FeatureTraits = Object.freeze({
 	Dance: 'dance',
 	ArcanumSummon: 'arcanum-summon',
 	ArcanumDismiss: 'arcanum-dismiss',
+	ArcanumPulse: 'arcanum-pulse',
 });
 
 /**

--- a/module/settings.js
+++ b/module/settings.js
@@ -70,6 +70,7 @@ export const SETTINGS = Object.freeze({
 	optionCampingRules: 'optionCampingRules',
 	optionQuirks: 'optionQuirks',
 	optionZeroPower: 'optionZeroPower',
+	optionArcanumPulse: 'optionArcanumPulse',
 	useRevisedStudyRule: 'useRevisedStudyRule',
 	technospheres: 'useTechnospheres',
 	pressureSystem: 'pressureSystem',
@@ -308,6 +309,7 @@ export const registerSystemSettings = async function () {
 		type: createConfigurationApp('FU.OptionalRules', [
 			SETTINGS.optionQuirks,
 			SETTINGS.optionZeroPower,
+			SETTINGS.optionArcanumPulse,
 			SETTINGS.optionCampingRules,
 			SETTINGS.useRevisedStudyRule,
 			SETTINGS.technospheres,
@@ -371,6 +373,16 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.pressureSystem, {
 		name: game.i18n.localize('FU.OptionPressureSystem'),
 		hint: game.i18n.localize('FU.OptionPressureSystemHint'),
+		scope: 'world',
+		config: false,
+		type: Boolean,
+		default: false,
+		requiresReload: true,
+	});
+
+	game.settings.register(SYSTEM, SETTINGS.optionArcanumPulse, {
+		name: game.i18n.localize('FU.OptionArcanumPulse'),
+		hint: game.i18n.localize('FU.OptionArcanumPulseHint'),
 		scope: 'world',
 		config: false,
 		type: Boolean,

--- a/styles/css/global/grid.css
+++ b/styles/css/global/grid.css
@@ -1,4 +1,11 @@
 /* Grid System */
+.grid {
+	/* if only one child, make it full width */
+	> *:only-child {
+		grid-column: 1 / -1;
+	}
+}
+
 .grid,
 .grid-2col {
 	display: grid;

--- a/templates/chat/chat-check-flavor-item-v2.hbs
+++ b/templates/chat/chat-check-flavor-item-v2.hbs
@@ -11,3 +11,8 @@
 			</span>
 	</a>
 </header>
+{{#if subtitle}}
+	<div class="chat-header" style="padding: 0;">
+		<h3>{{localize subtitle}}</h3>
+	</div>
+{{/if}}

--- a/templates/chat/chat-description-v2.hbs
+++ b/templates/chat/chat-description-v2.hbs
@@ -1,0 +1,7 @@
+<div>
+	{{#if description}}
+		<div class='chat-desc'>
+			{{{description}}}
+		</div>
+	{{/if}}
+</div>

--- a/templates/chat/chat-description.hbs
+++ b/templates/chat/chat-description.hbs
@@ -1,5 +1,5 @@
 <header class="title-desc chat-header flexrow">
-    <h2>{{flavor}}</h2>
+    <h2>{{{flavor}}}</h2>
 </header>
 <div>
     {{#if description}}

--- a/templates/dialog/dialog-layout.hbs
+++ b/templates/dialog/dialog-layout.hbs
@@ -1,8 +1,13 @@
-<div class="grid">
+<div class="flexrow">
 	{{#each sections as |section|}}
 		{{#if section.text}}
 			<fieldset class="title-fieldset section-container desc resource-content">
-				<legend class="resource-label-m">{{localize section.title}}</legend>
+				<legend class="resource-label-m" style="gap: 4px;">
+					{{localize section.title}}
+					<a data-action="sendToChat" data-title="{{section.title}}" data-text="{{section.text}}">
+						<i class="fas fas fa-comment"></i>
+					</a>
+				</legend>
 				{{{section.text}}}
 			</fieldset>
 		{{/if}}

--- a/templates/dialog/dialog-layout.hbs
+++ b/templates/dialog/dialog-layout.hbs
@@ -1,0 +1,10 @@
+<div class="grid">
+	{{#each sections as |section|}}
+		{{#if section.text}}
+			<fieldset class="title-fieldset section-container desc resource-content">
+				<legend class="resource-label-m">{{localize section.title}}</legend>
+				{{{section.text}}}
+			</fieldset>
+		{{/if}}
+	{{/each}}
+</div>

--- a/templates/feature/arcanist/feature-arcanum-chat-message.hbs
+++ b/templates/feature/arcanist/feature-arcanum-chat-message.hbs
@@ -9,6 +9,14 @@
         {{{merge}}}
     </details>
 </div>
+{{#if (pfuGetSetting 'optionArcanumPulse')}}
+	<div class='chat-desc'>
+		<details {{#unless collapseDescriptions}}open{{/unless}}>
+			<summary class="collapsible-description align-center">{{localize 'FU-PT.arcanum2.pulse'}}</summary>
+			{{{pulse}}}
+		</details>
+	</div>
+{{/if}}
 <div class='chat-desc'>
     <details {{#unless (pfuGetSetting 'optionChatMessageCollapseDescription')}}open{{/unless}}>
         <summary class="collapsible-description align-center">{{localize 'FU.ClassFeatureArcanumDismiss'}}</summary>

--- a/templates/feature/arcanist/feature-arcanum-chat-message.hbs
+++ b/templates/feature/arcanist/feature-arcanum-chat-message.hbs
@@ -12,7 +12,7 @@
 {{#if (pfuGetSetting 'optionArcanumPulse')}}
 	<div class='chat-desc'>
 		<details {{#unless collapseDescriptions}}open{{/unless}}>
-			<summary class="collapsible-description align-center">{{localize 'FU-PT.arcanum2.pulse'}}</summary>
+			<summary class="collapsible-description align-center">{{localize 'FU.ClassFeatureArcanumPulse'}}</summary>
 			{{{pulse}}}
 		</details>
 	</div>

--- a/templates/feature/arcanist/feature-arcanum-description.hbs
+++ b/templates/feature/arcanist/feature-arcanum-description.hbs
@@ -2,7 +2,12 @@
 <div class="flexcol resource-content gap-2 mb-3">
     <label class="resource-label-m">{{localize 'FU.ClassFeatureArcanumMerge'}}</label>
     <div class="description-effect">{{{additionalData.enrichedMerge}}}</div>
-    
+
+	{{#if (pfuGetSetting 'optionArcanumPulse')}}
+		<label class="resource-label-m">{{localize 'FU.ClassFeatureArcanumPulse'}}</label>
+		<div class="description-effect">{{{additionalData.enrichedPulse}}}</div>
+	{{/if}}
+
     <label class="resource-label-m">{{localize 'FU.ClassFeatureArcanumDismiss'}}</label>
     <div class="description-effect">{{{additionalData.enrichedDismiss}}}</div>
 </div>

--- a/templates/feature/arcanist/feature-arcanum-sheet.hbs
+++ b/templates/feature/arcanist/feature-arcanum-sheet.hbs
@@ -4,7 +4,7 @@
 		<input type='text' name='system.data.domains' value='{{system.data.domains}}'
 			   class="resource-inputs select-dropdown-full resource-text-m" />
 	</fieldset>
-	<div class="grid grid-3col gap-5 border-rc flexgrow-1">
+	<div class="grid {{#if (pfuGetSetting 'optionArcanumPulse')}}grid-3col{{else}}grid-2col{{/if}} gap-5 border-rc flexgrow-1">
 		<fieldset class="title-fieldset section-container desc resource-content">
 			<legend class="resource-label-m">{{localize 'FU.ClassFeatureArcanumMerge'}}</legend>
 			<prose-mirror name="system.data.merge" value="{{system.data.merge}}" toggled>

--- a/templates/feature/arcanist/feature-arcanum-sheet.hbs
+++ b/templates/feature/arcanist/feature-arcanum-sheet.hbs
@@ -4,13 +4,23 @@
 		<input type='text' name='system.data.domains' value='{{system.data.domains}}'
 			   class="resource-inputs select-dropdown-full resource-text-m" />
 	</fieldset>
-	<div class="grid grid-2col gap-5 border-rc flexgrow-1">
+	<div class="grid grid-3col gap-5 border-rc flexgrow-1">
 		<fieldset class="title-fieldset section-container desc resource-content">
 			<legend class="resource-label-m">{{localize 'FU.ClassFeatureArcanumMerge'}}</legend>
 			<prose-mirror name="system.data.merge" value="{{system.data.merge}}" toggled>
 				{{{enrichedHtml.merge}}}
 			</prose-mirror>
 		</fieldset>
+
+		{{#if (pfuGetSetting 'optionArcanumPulse')}}
+			<fieldset class="title-fieldset section-container desc resource-content">
+				<legend class="resource-label-m">{{localize 'FU.ClassFeatureArcanumPulse'}}</legend>
+				<prose-mirror name="system.data.pulse" value="{{system.data.pulse}}" toggled>
+					{{{enrichedHtml.pulse}}}
+				</prose-mirror>
+			</fieldset>
+		{{/if}}
+
 		<fieldset class="title-fieldset section-container desc resource-content">
 			<legend class="resource-label-m">{{localize 'FU.ClassFeatureArcanumDismiss'}}</legend>
 			<prose-mirror name="system.data.dismiss" value="{{system.data.dismiss}}" toggled>


### PR DESCRIPTION
This pull request introduces support for an optional "Pulse" effect for Arcanum class features, controlled by a new system setting. It adds the ability to configure, display, and trigger the Pulse effect alongside existing Merge and Dismiss effects, including UI and chat message updates. The changes are grouped below by theme:

**Feature: Arcanum Pulse Effect**

* Added a new `pulse` property to the `ArcanumDataModel`, including enrichment and rendering logic for Pulse text. [[1]](diffhunk://#diff-91891d2bd08c94bef124d39657d314fb81873534286a05563c9a9f11f0b15a62R12) [[2]](diffhunk://#diff-91891d2bd08c94bef124d39657d314fb81873534286a05563c9a9f11f0b15a62R21) [[3]](diffhunk://#diff-91891d2bd08c94bef124d39657d314fb81873534286a05563c9a9f11f0b15a62R53) [[4]](diffhunk://#diff-91891d2bd08c94bef124d39657d314fb81873534286a05563c9a9f11f0b15a62R66)
* Updated UI templates (`feature-arcanum-sheet.hbs`, `feature-arcanum-description.hbs`, `feature-arcanum-chat-message.hbs`) to display Pulse effect when enabled via system setting. [[1]](diffhunk://#diff-f1d06cd8f98a168a9e57cad761d3e17041411a957fd881b47d27c39e35e7f59eL7-R23) [[2]](diffhunk://#diff-15d96c0afbef7b417382182e1122d157c7525fa55b6e4200924c8068abe370b2R6-R10) [[3]](diffhunk://#diff-01522858e840d9deb496442cc9601c94467e778fb8246a9ed0f961ba6e70e7ffR12-R19)

**System Setting Integration**

* Introduced a new system setting `optionArcanumPulse` to enable or disable Pulse effects, including registration and localization strings. [[1]](diffhunk://#diff-5a64af73e981d8c32be81d0711891c209b3a29261c686bae39b132a67fc41d62R73) [[2]](diffhunk://#diff-5a64af73e981d8c32be81d0711891c209b3a29261c686bae39b132a67fc41d62R312) [[3]](diffhunk://#diff-5a64af73e981d8c32be81d0711891c209b3a29261c686bae39b132a67fc41d62R383-R392) [[4]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1L1927-R1931) [[5]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R859-R863)

**Dialog and Interaction Enhancements**

* Refactored Arcanum handling logic to present Merge, Pulse (if enabled), and Dismiss effects in a multi-section dialog, allowing users to trigger Pulse or Dismiss actions. [[1]](diffhunk://#diff-759c84e64b8641d259455869e35b1fca50f24aff7b5ae27618a1bbeccb10cc56L42-R98) [[2]](diffhunk://#diff-759c84e64b8641d259455869e35b1fca50f24aff7b5ae27618a1bbeccb10cc56R118-R133)
* Added a generic dialog layout template and helper for sectioned dialogs, supporting send-to-chat actions for each section. [[1]](diffhunk://#diff-b549f7be4b5dfeea6e4f311131f043a2a04bb5b3604b67da7a69c0d804fa23edR1-R15) [[2]](diffhunk://#diff-fb71a9d83613063884136e5cf74522ce04c5b9ad4cc0b77dc7e06fe8e2061658R68-R73) [[3]](diffhunk://#diff-fb71a9d83613063884136e5cf74522ce04c5b9ad4cc0b77dc7e06fe8e2061658R289-R332)

**Chat and Trait Updates**

* Added localized chat message for Pulse effect and ensured chat flavor/description templates support new Pulse section. [[1]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R859-R863) [[2]](diffhunk://#diff-a59ebf1186b685cafdf13a9393cedadd850f7bd657c4522cfb11d2eb9fda1885R14-R18) [[3]](diffhunk://#diff-b9896d1c689b086de399092338586e86d2cd0d661a7ff0879537fea589a3a1d8R1-R7) [[4]](diffhunk://#diff-942108f9db9ba8432d9d16a377ed259e111fb5251b6c2c6441465bbd95deac7dL2-R2)
* Introduced a new trait `ArcanumPulse` for event tracking and feature processing.

**UI Improvements**

* Improved grid layout to support dynamic column counts based on enabled features, ensuring proper display of Merge, Pulse, and Dismiss sections. [[1]](diffhunk://#diff-99a2d2be3ccaf181ca83c265153f86ac6bfc4af6036e7b0d4dd6ec3207a514d2R2-R8) [[2]](diffhunk://#diff-f1d06cd8f98a168a9e57cad761d3e17041411a957fd881b47d27c39e35e7f59eL7-R23)

These changes collectively provide optional Pulse functionality for Arcanum features, enhance user interaction, and maintain flexibility via system settings.