### PR TITLE
Add unit testing framework

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
                   cache: 'npm'
             - name: Install Dependencies
               run: npm ci
-            - name: Run Unit Tests
+            - name: Run Tests
               run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+    push:
+        branches: [main, dev]
+    pull_request:
 
 jobs:
     test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+                  cache: 'npm'
+            - run: npm ci
+            - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,5 +11,7 @@ jobs:
               with:
                   node-version: 22
                   cache: 'npm'
-            - run: npm ci
-            - run: npm test
+            - name: Install Dependencies
+              run: npm ci
+            - name: Run Unit Tests
+              run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,53 @@
 			"version": "#{VERSION}#",
 			"license": "MIT",
 			"dependencies": {
-				"rpg-awesome": "^0.2.0"
+				"rpg-awesome": "0.2.0"
 			},
 			"devDependencies": {
-				"@eslint/js": "^9.38.0",
-				"@foundryvtt/foundryvtt-cli": "^3.0.0",
-				"axios": "^1.13.0",
-				"eslint": "^9.38.0",
-				"eslint-config-prettier": "^10.1.8",
-				"globals": "^16.4.0",
-				"husky": "^9.1.7",
-				"papaparse": "^5.5.3",
-				"prettier": "^3.6.2"
+				"@eslint/js": "9.38.0",
+				"@foundryvtt/foundryvtt-cli": "3.0.0",
+				"axios": "1.13.0",
+				"eslint": "9.38.0",
+				"eslint-config-prettier": "10.1.8",
+				"globals": "16.4.0",
+				"husky": "9.1.7",
+				"papaparse": "5.5.3",
+				"prettier": "3.6.2",
+				"vitest": "^4.1.0"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
+			"integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
+			"integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -307,6 +342,312 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+			"integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1",
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@oxc-project/runtime": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+			"integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+			"integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+			"integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+			"integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+			"integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+			"integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+			"integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+			"integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+			"integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+			"integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+			"integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@seald-io/binary-search-tree": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz",
@@ -324,6 +665,42 @@
 				"util": "^0.12.4"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -337,6 +714,119 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+			"integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.0",
+				"@vitest/utils": "4.1.0",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+			"integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.0",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+			"integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+			"integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.0",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+			"integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.0",
+				"@vitest/utils": "4.1.0",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+			"integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+			"integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.0",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
 		},
 		"node_modules/abstract-level": {
 			"version": "1.0.4",
@@ -448,6 +938,16 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -597,6 +1097,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -668,6 +1178,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -734,6 +1251,16 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -773,6 +1300,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -991,6 +1525,16 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -998,6 +1542,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -1019,6 +1573,24 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
@@ -1112,6 +1684,21 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/function-bind": {
@@ -1534,6 +2121,267 @@
 				"immediate": "~3.0.5"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/localforage": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
@@ -1563,6 +2411,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
 		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
@@ -1641,6 +2499,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/napi-macros": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
@@ -1672,6 +2549,17 @@
 				"node-gyp-build-optional": "optional.js",
 				"node-gyp-build-test": "build-test.js"
 			}
+		},
+		"node_modules/obug": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/sxzz",
+				"https://opencollective.com/debug"
+			],
+			"license": "MIT"
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -1759,6 +2647,33 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -1766,6 +2681,35 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -1849,6 +2793,40 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.9",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+			"integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.115.0",
+				"@rolldown/pluginutils": "1.0.0-rc.9"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"optionalDependencies": {
+				"@rolldown/binding-android-arm64": "1.0.0-rc.9",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+			}
+		},
 		"node_modules/rpg-awesome": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/rpg-awesome/-/rpg-awesome-0.2.0.tgz",
@@ -1893,6 +2871,37 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+			"integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
@@ -1945,6 +2954,58 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1980,6 +3041,167 @@
 				"which-typed-array": "^1.1.2"
 			}
 		},
+		"node_modules/vite": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+			"integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/runtime": "0.115.0",
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.3",
+				"postcss": "^8.5.8",
+				"rolldown": "1.0.0-rc.9",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.0.0-alpha.31",
+				"esbuild": "^0.27.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+			"integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/expect": "4.1.0",
+				"@vitest/mocker": "4.1.0",
+				"@vitest/pretty-format": "4.1.0",
+				"@vitest/runner": "4.1.0",
+				"@vitest/snapshot": "4.1.0",
+				"@vitest/spy": "4.1.0",
+				"@vitest/utils": "4.1.0",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
+				"magic-string": "^0.30.21",
+				"obug": "^2.1.1",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.3",
+				"std-env": "^4.0.0-rc.1",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^1.0.2",
+				"tinyglobby": "^0.2.15",
+				"tinyrainbow": "^3.0.3",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@opentelemetry/api": "^1.9.0",
+				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+				"@vitest/browser-playwright": "4.1.0",
+				"@vitest/browser-preview": "4.1.0",
+				"@vitest/browser-webdriverio": "4.1.0",
+				"@vitest/ui": "4.1.0",
+				"happy-dom": "*",
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser-playwright": {
+					"optional": true
+				},
+				"@vitest/browser-preview": {
+					"optional": true
+				},
+				"@vitest/browser-webdriverio": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2013,6 +3235,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"c2j": "node ./tools/csvtojson/convert-csv-to-json.mjs && prettier --write .",
 		"j2c": "node ./tools/jsontocsv/convert-json-to-csv.mjs && prettier --write .",
 		"localize": "npm run downloadcsv && npm run c2j",
-		"prepare": "husky"
+		"prepare": "husky",
+		"test": "vitest run"
 	},
 	"browserslist": [
 		"last 3 versions"
@@ -32,6 +33,7 @@
 		"globals": "16.4.0",
 		"husky": "9.1.7",
 		"papaparse": "5.5.3",
-		"prettier": "3.6.2"
+		"prettier": "3.6.2",
+		"vitest": "^4.1.0"
 	}
 }

--- a/tests/object-utils.test.mjs
+++ b/tests/object-utils.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { ObjectUtils } from '../module/helpers/object-utils.mjs';
+
+describe('mergeRecursive', () => {
+	it('merges a flat source into a flat target', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({ a: 1 }, { b: 2 });
+		expect(result).toEqual({ a: 1, b: 2 });
+		expect(changed).toBe(true);
+	});
+
+	it('returns changed=false when source adds nothing new', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({ a: 1 }, { a: 1 });
+		expect(result).toEqual({ a: 1 });
+		expect(changed).toBe(false);
+	});
+
+	it('overwrites a target value when source differs', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({ a: 1 }, { a: 2 });
+		expect(result.a).toBe(2);
+		expect(changed).toBe(true);
+	});
+
+	it('merges nested objects recursively', () => {
+		const target = { a: { x: 1 } };
+		const source = { a: { y: 2 } };
+		const [result, changed] = ObjectUtils.mergeRecursive(target, source);
+		expect(result).toEqual({ a: { x: 1, y: 2 } });
+		expect(changed).toBe(true);
+	});
+
+	it('creates a nested key in target if it does not exist', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({}, { a: { b: 1 } });
+		expect(result).toEqual({ a: { b: 1 } });
+		expect(changed).toBe(true);
+	});
+
+	it('treats arrays as plain values, not objects', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({ a: [1] }, { a: [2, 3] });
+		expect(result.a).toEqual([2, 3]);
+		expect(changed).toBe(true);
+	});
+
+	it('does not mutate source', () => {
+		const source = { a: { b: 1 } };
+		ObjectUtils.mergeRecursive({}, source);
+		expect(source).toEqual({ a: { b: 1 } });
+	});
+
+	it('handles an empty source', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({ a: 1 }, {});
+		expect(result).toEqual({ a: 1 });
+		expect(changed).toBe(false);
+	});
+
+	it('handles an empty target', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({}, { a: 1 });
+		expect(result).toEqual({ a: 1 });
+		expect(changed).toBe(true);
+	});
+
+	it('handles null values in source', () => {
+		const [result, changed] = ObjectUtils.mergeRecursive({ a: 1 }, { a: null });
+		expect(result.a).toBeNull();
+		expect(changed).toBe(true);
+	});
+});
+
+describe('cleanObject', () => {
+	it('removes undefined properties', () => {
+		expect(ObjectUtils.cleanObject({ a: 1, b: undefined })).toEqual({ a: 1 });
+	});
+
+	it('keeps null properties', () => {
+		expect(ObjectUtils.cleanObject({ a: null })).toEqual({ a: null });
+	});
+
+	it('keeps false and zero', () => {
+		expect(ObjectUtils.cleanObject({ a: false, b: 0 })).toEqual({ a: false, b: 0 });
+	});
+
+	it('keeps empty string', () => {
+		expect(ObjectUtils.cleanObject({ a: '' })).toEqual({ a: '' });
+	});
+
+	it('returns empty object when all values are undefined', () => {
+		expect(ObjectUtils.cleanObject({ a: undefined, b: undefined })).toEqual({});
+	});
+
+	it('returns empty object for empty input', () => {
+		expect(ObjectUtils.cleanObject({})).toEqual({});
+	});
+});
+
+describe('pick', () => {
+	it('returns only the specified keys', () => {
+		expect(ObjectUtils.pick({ a: 1, b: 2, c: 3 }, ['a', 'c'])).toEqual({ a: 1, c: 3 });
+	});
+
+	it('ignores keys that do not exist in the record', () => {
+		expect(ObjectUtils.pick({ a: 1 }, ['a', 'b'])).toEqual({ a: 1 });
+	});
+
+	it('returns an empty object when no keys match', () => {
+		expect(ObjectUtils.pick({ a: 1 }, ['b', 'c'])).toEqual({});
+	});
+
+	it('returns an empty object for an empty keys array', () => {
+		expect(ObjectUtils.pick({ a: 1 }, [])).toEqual({});
+	});
+
+	it('returns an empty object for an empty record', () => {
+		expect(ObjectUtils.pick({}, ['a'])).toEqual({});
+	});
+
+	it('preserves falsy values', () => {
+		expect(ObjectUtils.pick({ a: 0, b: false, c: null }, ['a', 'b', 'c'])).toEqual({
+			a: 0,
+			b: false,
+			c: null,
+		});
+	});
+});
+
+describe('deepFreeze', () => {
+	it('freezes a flat object', () => {
+		const obj = ObjectUtils.deepFreeze({ a: 1 });
+		expect(Object.isFrozen(obj)).toBe(true);
+	});
+
+	it('freezes nested objects', () => {
+		const obj = ObjectUtils.deepFreeze({ a: { b: { c: 1 } } });
+		expect(Object.isFrozen(obj.a)).toBe(true);
+		expect(Object.isFrozen(obj.a.b)).toBe(true);
+	});
+
+	it('prevents modification of a frozen object', () => {
+		const obj = ObjectUtils.deepFreeze({ a: 1 });
+		expect(() => {
+			'use strict';
+			obj.a = 2;
+		}).toThrow();
+	});
+
+	it('returns the same object reference', () => {
+		const obj = { a: 1 };
+		expect(ObjectUtils.deepFreeze(obj)).toBe(obj);
+	});
+
+	it('does not re-freeze already frozen nested objects', () => {
+		const inner = Object.freeze({ b: 1 });
+		const obj = ObjectUtils.deepFreeze({ a: inner });
+		expect(Object.isFrozen(obj.a)).toBe(true);
+	});
+
+	it('handles an empty object', () => {
+		const obj = ObjectUtils.deepFreeze({});
+		expect(Object.isFrozen(obj)).toBe(true);
+	});
+});

--- a/tests/string-utils.test.mjs
+++ b/tests/string-utils.test.mjs
@@ -1,29 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { StringUtils } from '../module/helpers/string-utils.mjs'; // adjust path as needed
-
-// ============================================================================
-// Minimal mocks for localize / hasLocalization only
-// ============================================================================
-
-beforeEach(() => {
-	globalThis.game = {
-		i18n: {
-			localize: vi.fn((key) => `localized:${key}`),
-			format: vi.fn((key, data) => `formatted:${key}`),
-			translations: { 'FU.ExistingKey': 'Existing' },
-			_fallback: { 'FU.FallbackKey': 'Fallback' },
-		},
-	};
-	globalThis.foundry = {
-		utils: {
-			hasProperty: vi.fn((obj, key) => key.split('.').reduce((o, k) => o?.[k], obj) !== undefined),
-		},
-	};
-});
-
-// ============================================================================
-// kebabToPascal
-// ============================================================================
+import { describe, it, expect } from 'vitest';
+import { StringUtils } from '../module/helpers/string-utils.mjs';
 
 describe('kebabToPascal', () => {
 	it('converts a single word', () => {
@@ -42,10 +18,6 @@ describe('kebabToPascal', () => {
 		expect(StringUtils.kebabToPascal('')).toBe('');
 	});
 });
-
-// ============================================================================
-// camelToKebab
-// ============================================================================
 
 describe('camelToKebab', () => {
 	it('converts camelCase to kebab-case', () => {
@@ -69,10 +41,6 @@ describe('camelToKebab', () => {
 	});
 });
 
-// ============================================================================
-// titleToKebab
-// ============================================================================
-
 describe('titleToKebab', () => {
 	it('converts Title Case to kebab-case', () => {
 		expect(StringUtils.titleToKebab('Hello World')).toBe('hello-world');
@@ -94,10 +62,6 @@ describe('titleToKebab', () => {
 		expect(StringUtils.titleToKebab('')).toBe('');
 	});
 });
-
-// ============================================================================
-// capitalize
-// ============================================================================
 
 describe('capitalize', () => {
 	it('capitalizes first letter and lowercases rest', () => {
@@ -121,10 +85,6 @@ describe('capitalize', () => {
 		expect(StringUtils.capitalize('')).toBe('');
 	});
 });
-
-// ============================================================================
-// truncate
-// ============================================================================
 
 describe('truncate', () => {
 	it('returns the string unchanged if within maxLength', () => {
@@ -152,10 +112,6 @@ describe('truncate', () => {
 		expect(StringUtils.truncate('', 5)).toBe('');
 	});
 });
-
-// ============================================================================
-// toBase64 / fromBase64
-// ============================================================================
 
 describe('toBase64 / fromBase64', () => {
 	it('encodes and decodes a plain object', () => {

--- a/tests/string-utils.test.mjs
+++ b/tests/string-utils.test.mjs
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { StringUtils } from '../module/helpers/string-utils.mjs'; // adjust path as needed
+
+// ============================================================================
+// Minimal mocks for localize / hasLocalization only
+// ============================================================================
+
+beforeEach(() => {
+	globalThis.game = {
+		i18n: {
+			localize: vi.fn((key) => `localized:${key}`),
+			format: vi.fn((key, data) => `formatted:${key}`),
+			translations: { 'FU.ExistingKey': 'Existing' },
+			_fallback: { 'FU.FallbackKey': 'Fallback' },
+		},
+	};
+	globalThis.foundry = {
+		utils: {
+			hasProperty: vi.fn((obj, key) => key.split('.').reduce((o, k) => o?.[k], obj) !== undefined),
+		},
+	};
+});
+
+// ============================================================================
+// kebabToPascal
+// ============================================================================
+
+describe('kebabToPascal', () => {
+	it('converts a single word', () => {
+		expect(StringUtils.kebabToPascal('hello')).toBe('Hello');
+	});
+
+	it('converts multiple kebab segments', () => {
+		expect(StringUtils.kebabToPascal('hello-world')).toBe('HelloWorld');
+	});
+
+	it('handles three segments', () => {
+		expect(StringUtils.kebabToPascal('my-data-model')).toBe('MyDataModel');
+	});
+
+	it('returns empty string unchanged', () => {
+		expect(StringUtils.kebabToPascal('')).toBe('');
+	});
+});
+
+// ============================================================================
+// camelToKebab
+// ============================================================================
+
+describe('camelToKebab', () => {
+	it('converts camelCase to kebab-case', () => {
+		expect(StringUtils.camelToKebab('helloWorld')).toBe('hello-world');
+	});
+
+	it('handles multiple uppercase letters', () => {
+		expect(StringUtils.camelToKebab('myDataModel')).toBe('my-data-model');
+	});
+
+	it('adds a hyphen before numbers', () => {
+		expect(StringUtils.camelToKebab('level2Attack')).toBe('level-2-attack');
+	});
+
+	it('returns lowercase string unchanged', () => {
+		expect(StringUtils.camelToKebab('hello')).toBe('hello');
+	});
+
+	it('returns empty string unchanged', () => {
+		expect(StringUtils.camelToKebab('')).toBe('');
+	});
+});
+
+// ============================================================================
+// titleToKebab
+// ============================================================================
+
+describe('titleToKebab', () => {
+	it('converts Title Case to kebab-case', () => {
+		expect(StringUtils.titleToKebab('Hello World')).toBe('hello-world');
+	});
+
+	it('converts camelCase boundaries', () => {
+		expect(StringUtils.titleToKebab('helloWorld')).toBe('hello-world');
+	});
+
+	it('collapses multiple spaces', () => {
+		expect(StringUtils.titleToKebab('Hello   World')).toBe('hello-world');
+	});
+
+	it('lowercases the result', () => {
+		expect(StringUtils.titleToKebab('HELLO')).toBe('hello');
+	});
+
+	it('returns empty string unchanged', () => {
+		expect(StringUtils.titleToKebab('')).toBe('');
+	});
+});
+
+// ============================================================================
+// capitalize
+// ============================================================================
+
+describe('capitalize', () => {
+	it('capitalizes first letter and lowercases rest', () => {
+		expect(StringUtils.capitalize('hello')).toBe('Hello');
+	});
+
+	it('lowercases subsequent letters', () => {
+		expect(StringUtils.capitalize('hELLO')).toBe('Hello');
+	});
+
+	it('handles a single character', () => {
+		expect(StringUtils.capitalize('a')).toBe('A');
+	});
+
+	it('returns non-string input as-is', () => {
+		expect(StringUtils.capitalize(42)).toBe(42);
+		expect(StringUtils.capitalize(null)).toBe(null);
+	});
+
+	it('returns empty string unchanged', () => {
+		expect(StringUtils.capitalize('')).toBe('');
+	});
+});
+
+// ============================================================================
+// truncate
+// ============================================================================
+
+describe('truncate', () => {
+	it('returns the string unchanged if within maxLength', () => {
+		expect(StringUtils.truncate('hello', 10)).toBe('hello');
+	});
+
+	it('returns the string unchanged if exactly maxLength', () => {
+		expect(StringUtils.truncate('hello', 5)).toBe('hello');
+	});
+
+	it('truncates at the last whole word and appends ellipsis', () => {
+		expect(StringUtils.truncate('hello world foo', 13)).toBe('hello world…');
+	});
+
+	it('truncates mid-word if no space is available', () => {
+		expect(StringUtils.truncate('helloworld', 5)).toBe('hello…');
+	});
+
+	it('returns empty string for non-string input', () => {
+		expect(StringUtils.truncate(123, 5)).toBe('');
+		expect(StringUtils.truncate(null, 5)).toBe('');
+	});
+
+	it('returns empty string for empty input', () => {
+		expect(StringUtils.truncate('', 5)).toBe('');
+	});
+});
+
+// ============================================================================
+// toBase64 / fromBase64
+// ============================================================================
+
+describe('toBase64 / fromBase64', () => {
+	it('encodes and decodes a plain object', () => {
+		const original = { name: 'Test Actor', level: 5 };
+		const encoded = StringUtils.toBase64(original);
+		expect(typeof encoded).toBe('string');
+		expect(StringUtils.fromBase64(encoded)).toEqual(original);
+	});
+
+	it('encodes and decodes a nested object', () => {
+		const original = { a: { b: { c: 42 } } };
+		expect(StringUtils.fromBase64(StringUtils.toBase64(original))).toEqual(original);
+	});
+
+	it('encodes and decodes an array', () => {
+		const original = [1, 2, 3];
+		expect(StringUtils.fromBase64(StringUtils.toBase64(original))).toEqual(original);
+	});
+
+	it('returns null from toBase64 on non-serializable input', () => {
+		const circular = {};
+		circular.self = circular;
+		expect(StringUtils.toBase64(circular)).toBeNull();
+	});
+
+	it('returns null from fromBase64 on invalid input', () => {
+		expect(StringUtils.fromBase64('not-valid-base64!!!')).toBeNull();
+	});
+
+	it('returns null from fromBase64 on valid base64 that is not JSON', () => {
+		expect(StringUtils.fromBase64(btoa('not json'))).toBeNull();
+	});
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+	test: {
+		root: '.',
+		environment: 'node',
+		include: ['tests/**/*.{test,spec}.{js,mjs}', 'tests/**/*-test.{js,mjs}'],
+		globals: true,
+	},
+});


### PR DESCRIPTION
This pull request introduces a testing framework to the project and adds initial unit tests for utility functions. The main changes include configuring Vitest for testing, updating dependencies, and adding comprehensive test suites for object and string utilities.

Testing infrastructure:

* Added a new GitHub Actions workflow (`.github/workflows/test.yml`) to automatically run tests on pushes and pull requests, using Node.js 22 and caching npm dependencies.
* Introduced Vitest configuration (`vitest.config.js`) to define test environment, file patterns, and global settings.
* Updated `package.json` to add a `test` script for running Vitest and included Vitest as a development dependency. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L15-R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R37)

Unit tests for utilities:

* Added `tests/object-utils.test.mjs` with thorough tests for `mergeRecursive`, `cleanObject`, `pick`, and `deepFreeze` methods in `ObjectUtils`.
* Added `tests/string-utils.test.mjs` with tests for string transformation and encoding methods in `StringUtils`, including `kebabToPascal`, `camelToKebab`, `titleToKebab`, `capitalize`, `truncate`, `toBase64`, and `fromBase64`.