### PR TITLE
Add check predicate quantifier

### DIFF
--- a/module/documents/effects/predicates/check-rule-predicate.mjs
+++ b/module/documents/effects/predicates/check-rule-predicate.mjs
@@ -11,6 +11,7 @@ const fields = foundry.data.fields;
  * @property {FUCheckOutcome} outcome
  * @property {ItemAttributesDataModel} attributes
  * @property {Number} result A specific result of the check.
+ * @property {FUPredicateQuantifier} quantifier
  */
 export class CheckRulePredicate extends RulePredicateDataModel {
 	static {
@@ -31,6 +32,11 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 			outcome: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.checkOutcome) }),
 			attributes: new fields.EmbeddedDataField(ItemAttributesDataModel, { initial: { primary: { value: '' }, secondary: { value: '' } } }),
 			result: new fields.NumberField({ integer: true }),
+			quantifier: new fields.StringField({
+				initial: 'any',
+				blank: true,
+				choices: Object.keys(FU.predicateQuantifier),
+			}),
 		});
 	}
 
@@ -82,21 +88,33 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 					break;
 
 				default:
-					if (context.config.isFumble()) {
-						return false;
-					}
-					for (const target of context.config.getTargets()) {
-						switch (target.result) {
-							case 'hit':
-								if (this.outcome !== 'success') {
+					{
+						if (context.config.isFumble()) {
+							return false;
+						}
+
+						const selected = context.config.getTargets();
+						switch (this.quantifier) {
+							case 'all':
+								return selected.every((target) => {
+									if (target.result === 'hit') return this.outcome === 'success';
+									if (target.result === 'miss') return this.outcome === 'failure';
+									return true;
+								});
+
+							case 'any':
+								return selected.some((target) => {
+									if (target.result === 'hit') return this.outcome === 'success';
+									if (target.result === 'miss') return this.outcome === 'failure';
 									return false;
-								}
-								break;
-							case 'miss':
-								if (this.outcome !== 'failure') {
-									return false;
-								}
-								break;
+								});
+
+							case 'none':
+								return selected.every((target) => {
+									if (target.result === 'hit') return this.outcome !== 'success';
+									if (target.result === 'miss') return this.outcome !== 'failure';
+									return true;
+								});
 						}
 					}
 					break;

--- a/templates/effects/active-effect-rules.hbs
+++ b/templates/effects/active-effect-rules.hbs
@@ -81,7 +81,7 @@
 			</span>
 		</legend>
 
-		<div class="rule-element-forms flexcol">
+		<div class="flexcol">
 			{{#each system.rules.elements as |element|}}
 				{{> (lookup (lookup (lookup element "schema") "model") "template") path=(concat "system.rules.elements." element.id) element=element options=../options expanded=(lookup ../expandedRuleElements id)}}
 			{{/each}}

--- a/templates/effects/predicates/check-rule-predicate.hbs
+++ b/templates/effects/predicates/check-rule-predicate.hbs
@@ -8,6 +8,20 @@
 	</label>
 
 	<label class="fu-form__property">
+		<span>{{localize 'FU.Quantifier'}}</span>
+		<select name="{{pfuConcat path ".quantifier"}}" class="">
+			{{selectOptions options.predicateQuantifier selected=predicate.quantifier localize=true}}
+		</select>
+	</label>
+</div>
+
+<div class="fu-form__property-row">
+	<label class="fu-form__property">
+		<span>{{localize 'FU.Result'}}</span>
+		<input type="number" name="{{pfuConcat path ".result"}}" value="{{ predicate.result }}" />
+	</label>
+
+	<label class="fu-form__property">
 		<span>{{localize 'FU.CheckParity'}}</span>
 		<select name="{{pfuConcat path ".parity"}}">
 			<option value="">-</option>
@@ -15,11 +29,6 @@
 		</select>
 	</label>
 </div>
-
-<label class="fu-form__property">
-	<span>{{localize 'FU.Result'}}</span>
-	<input type="number" name="{{pfuConcat path ".result"}}" value="{{ predicate.result }}" />
-</label>
 
 <div class="grid grid-2col">
 	<div class="flexcol flex-group-center">


### PR DESCRIPTION
This pull request introduces support for quantifiers in the `CheckRulePredicate` logic, allowing predicates to specify whether their conditions should apply to "all", "any", or "none" of the selected targets. Additionally, the user interface for editing predicates has been updated to reflect this new option and improve the layout.

Enhancements to predicate logic:

* Added a new `quantifier` property to the `CheckRulePredicate` data model, enabling predicates to specify "all", "any", or "none" as the quantification method. [[1]](diffhunk://#diff-b36cb3e31f36f01335536dc34e4c13d548c5dfdd9375bd1d379840a1df11bc33R14) [[2]](diffhunk://#diff-b36cb3e31f36f01335536dc34e4c13d548c5dfdd9375bd1d379840a1df11bc33R35-R39)
* Updated the predicate evaluation logic to use the `quantifier` property, allowing for more flexible outcome checks across multiple targets.

User interface improvements:

* Replaced the parity selector in the predicate form with a quantifier selector, and reorganized the form layout to accommodate both quantifier and parity options.
* Simplified the rule element forms container class in the active effect rules template for improved styling consistency.