### PR TITLE
Add trait to ignore affinities

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -918,6 +918,7 @@
 		"IgnoreResistances": "Ignore Resistances",
 		"IgnoreImmunities": "Ignore Immunities",
 		"IgnoreAbsorption": "Ignore Absorption",
+		"IgnoreAffinities": "Ignore Affinities",
 		"IgnoreAll": "Ignore All",
 		"IgnoreNone": "Ignore None",
 		"ChatApplyTargeted": "Apply to targeted token",

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -214,8 +214,7 @@ function resolveAffinity(context) {
 	let affinityMessage = 'FU.ChatApplyDamageNormal';
 
 	// Special case (break early)
-	if (context.traits.has(Traits.MindPointLoss)) {
-		context.affinityMessage = 'FU.ChatResourceLoss';
+	if (context.traits.has(Traits.IgnoreAffinities)) {
 		context.affinity = affinity;
 		return true;
 	}
@@ -448,6 +447,7 @@ async function process(request) {
 		let resource = 'hp';
 		if (context.traits.has(Traits.MindPointLoss)) {
 			resource = 'mp';
+			context.affinityMessage = 'FU.ChatResourceLoss';
 		}
 
 		// Damage application

--- a/module/pipelines/traits.mjs
+++ b/module/pipelines/traits.mjs
@@ -47,6 +47,7 @@ export const DamageTraits = Object.freeze({
 	IgnoreImmunities: 'ignore-immunities',
 	IgnoreAbsorption: 'ignore-absorption',
 	IgnoreVulnerable: 'ignore-vulnerable',
+	IgnoreAffinities: 'ignore-affinities',
 	AbsorbHalf: 'absorb-half',
 	Absorb: 'absorb',
 	MindPointLoss: 'mind-point-loss',


### PR DESCRIPTION
This pull request introduces a new damage trait, `IgnoreAffinities`, and updates the damage pipeline to support this trait. The changes add localization for the trait, update trait definitions, and modify affinity resolution logic to handle cases where affinities should be ignored.

Trait system enhancements:

* Added `IgnoreAffinities` to the `DamageTraits` definition in `module/pipelines/traits.mjs`.
* Updated localization by adding the `IgnoreAffinities` entry to `lang/en.json`.

Damage pipeline logic updates:

* Modified `resolveAffinity` in `module/pipelines/damage-pipeline.mjs` to check for the `IgnoreAffinities` trait and break early, bypassing affinity logic when present.
* Updated `process` in `module/pipelines/damage-pipeline.mjs` to set the correct affinity message for Mind Point Loss scenarios.