### PR TITLE
Sidebar Tab

### DIFF
--- a/module/documents/items/classFeature/invoker/invoker-integration.mjs
+++ b/module/documents/items/classFeature/invoker/invoker-integration.mjs
@@ -76,8 +76,24 @@ function onGetSystemTools(tools) {
 	});
 }
 
+/**
+ * @param {import('../../../../ui/sidebar.mjs').SidebarToolGroup[]} tools
+ */
+function onGetSidebarTools(tools) {
+	const group = tools.find((group) => group.id === 'utilities');
+	if (group) {
+		group.tools.wellspring = {
+			icon: 'fa-solid fa-earth-asia',
+			label: 'FU.ClassFeatureInvocationsWellspringManagerTitle',
+			condition: () => game.user.isGM,
+			click: () => renderApp(),
+		};
+	}
+}
+
 function initialize() {
 	Hooks.on(SystemControls.HOOK_GET_SYSTEM_TOOLS, onGetSystemTools);
+	Hooks.on(FUHooks.GET_SIDEBAR_TOOLS, onGetSidebarTools);
 
 	Hooks.on('projectfu.actor.dataPrepared', ActorWellspringManager.onActorPrepared);
 

--- a/module/hooks.mjs
+++ b/module/hooks.mjs
@@ -248,4 +248,6 @@ export const FUHooks = {
 	 * @remarks Uses {@link FeatureEvent}
 	 */
 	FEATURE_EVENT: `projectfu.events.feature`,
+
+	GET_SIDEBAR_TOOLS: `projectfu.getSidebarTools`,
 };

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -114,6 +114,7 @@ import { FUPressureGauge, FUModernPressureGauge, FUPixelPressureGauge } from './
 import { FUChatLog } from './ui/chat-log.mjs';
 import { AutomationPipeline } from './pipelines/automation.mjs';
 import { Themes } from './ui/themes/theme-options.mjs';
+import { FUSidebar, FUSidebarApplication } from './ui/sidebar.mjs';
 
 globalThis.projectfu = {
 	ClassFeatureDataModel,
@@ -288,6 +289,8 @@ Hooks.once('init', async () => {
 	Object.assign(CONFIG.ui, {
 		combat: FUCombatTracker,
 		chat: FUChatLog,
+		sidebar: FUSidebar,
+		pfuTools: FUSidebarApplication,
 	});
 
 	// Register status effects

--- a/module/settings.js
+++ b/module/settings.js
@@ -1111,3 +1111,25 @@ function createConfigurationApp(name, settings) {
 		}
 	};
 }
+
+function createMenuTool(key) {
+	const menuSetting = game.settings.menus.get(key);
+	if (!menuSetting) return;
+
+	return {
+		id: menuSetting.key,
+		label: menuSetting.label,
+		icon: menuSetting.icon,
+		click: () => {
+			new menuSetting.type().render({ force: true });
+		},
+	};
+}
+
+Hooks.on(FUHooks.GET_SIDEBAR_TOOLS, (tools) => {
+	tools.push({
+		id: 'settings',
+		label: 'FU.Settings',
+		tools: [createMenuTool(`${SYSTEM}.${SETTINGS.sheetOptions}`), createMenuTool(`${SYSTEM}.myOptionalRules`), createMenuTool(`${SYSTEM}.combatHudSettings`)],
+	});
+});

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -744,6 +744,7 @@ export class FUPartySheet extends FUActorSheet {
 
 // Set up sidebar menu option
 Hooks.on(SystemControls.HOOK_GET_SYSTEM_TOOLS, onGetSystemTools);
+Hooks.on(FUHooks.GET_SIDEBAR_TOOLS, onGetSidebarTools);
 
 /**
  * @param {SystemControlTool[]} tools
@@ -756,6 +757,22 @@ function onGetSystemTools(tools) {
 			FUPartySheet.toggleActive();
 		},
 	});
+}
+
+/**
+ * @param {import('../ui/sidebar.mjs').SidebarToolGroup[]} tools
+ */
+function onGetSidebarTools(tools) {
+	const group = tools.find((group) => group.id === 'utilities');
+	if (group) {
+		group.tools.party = {
+			icon: 'fa-solid fa fa-users',
+			label: 'FU.Party',
+			click: () => {
+				FUPartySheet.toggleActive();
+			},
+		};
+	}
 }
 
 /**

--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -65,6 +65,42 @@ Hooks.once('setup', () => {
 	});
 });
 
+Hooks.once(FUHooks.GET_SIDEBAR_TOOLS, (tools) => {
+	tools.push({
+		id: 'combathud',
+		label: 'FU.ExperimentalCombatHudSettings',
+		icon: 'fa-solid fa-book',
+		tools: {
+			toggleHud: {
+				label: 'FU.CombatHudControlButtonTitle',
+				icon: 'fa-solid fa-thumbtack',
+				click: () => {
+					if (game.settings.get(SYSTEM, SETTINGS.optionCombatHudMinimized)) {
+						CombatHUD.restore();
+					} else {
+						CombatHUD.minimize();
+					}
+				},
+			},
+			savePos: {
+				label: 'FU.CombatHudSaveButtonTitle',
+				icon: 'fa-solid fa-lock',
+				click: () => {
+					const isSaved = game.settings.get(SYSTEM, SETTINGS.optionCombatHudSaved);
+					game.settings.set(SYSTEM, SETTINGS.optionCombatHudSaved, !isSaved);
+				},
+			},
+			resetHud: {
+				label: 'FU.CombatHudResetButtonTitle',
+				icon: 'fa-solid fa-undo',
+				click: () => {
+					CombatHUD.reset();
+				},
+			},
+		},
+	});
+});
+
 export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2) {
 	#hooks = [];
 

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -8,6 +8,7 @@ import { FU } from '../../helpers/config.mjs';
 import { CompendiumFilter } from './compendium-filter.mjs';
 import { HTMLUtils } from '../../helpers/html-utils.mjs';
 import FoundryUtils from '../../helpers/foundry-utils.mjs';
+import { FUHooks } from '../../hooks.mjs';
 
 /**
  * @typedef {"classes"|"skills"|"equipment"|"spells"|"adversaries"|"abilities"|"effects"} CompendiumBrowserTab
@@ -855,7 +856,25 @@ export class CompendiumBrowser extends FUApplication {
 				},
 			});
 		};
+
+		/**
+		 *
+		 * @param {import('../sidebar.mjs').SidebarToolGroup[]} tools
+		 */
+		const onGetSidebarTools = (tools) => {
+			const group = tools.find((group) => group.id === 'utilities');
+			if (group) {
+				group.tools.compendium = {
+					icon: 'fa-solid fa-book',
+					label: 'FU.CompendiumBrowser',
+					click: () => {
+						CompendiumBrowser.instance.render({ force: true });
+					},
+				};
+			}
+		};
 		Hooks.on(SystemControls.HOOK_GET_SYSTEM_TOOLS, onGetSystemTools);
+		Hooks.on(FUHooks.GET_SIDEBAR_TOOLS, onGetSidebarTools);
 	}
 
 	/**

--- a/module/ui/metacurrency/MetaCurrencyTrackerApplication.mjs
+++ b/module/ui/metacurrency/MetaCurrencyTrackerApplication.mjs
@@ -6,6 +6,7 @@ import { Flags } from '../../helpers/flags.mjs';
 import { CharacterDataModel } from '../../documents/actors/character/character-data-model.mjs';
 import { NpcDataModel } from '../../documents/actors/npc/npc-data-model.mjs';
 import FUApplication from '../application.mjs';
+import { FUHooks } from '../../hooks.mjs';
 
 /**
  * @param {SystemControlTool[]} tools
@@ -17,7 +18,24 @@ function onGetSystemTools(tools) {
 		onClick: () => renderApp(),
 	});
 }
+
+/**
+ *
+ * @param {import('../sidebar.mjs').SidebarToolGroup[]} tools
+ */
+function onGetSidebarTools(tools) {
+	const group = tools.find((group) => group.id === 'utilities');
+	if (group) {
+		group.tools.metaCurrency = {
+			icon: 'fa-solid fa-chart-line',
+			label: 'FU.AppMetaCurrencyTrackerTitle',
+			click: () => renderApp(),
+		};
+	}
+}
+
 Hooks.on(SystemControls.HOOK_GET_SYSTEM_TOOLS, onGetSystemTools);
+Hooks.on(FUHooks.GET_SIDEBAR_TOOLS, onGetSidebarTools);
 
 let app;
 const renderApp = () => (app ??= new MetaCurrencyTrackerApplication()).render(true);

--- a/module/ui/sidebar.mjs
+++ b/module/ui/sidebar.mjs
@@ -1,0 +1,133 @@
+import { GameWellspringManager } from '../documents/items/classFeature/invoker/game-wellspring-manager.mjs';
+import { systemAssetPath, systemTemplatePath } from '../helpers/system-utils.mjs';
+import { FUHooks } from '../hooks.mjs';
+import { FUPartySheet } from '../sheets/actor-party-sheet.mjs';
+import { CompendiumBrowser } from './compendium/compendium-browser.mjs';
+import { MetaCurrencyTrackerApplication } from './metacurrency/MetaCurrencyTrackerApplication.mjs';
+
+const { api, sidebar } = foundry.applications;
+
+/**
+ * @typedef {Function} SidebarToolCondition
+ * @returns {boolean}
+ */
+
+/**
+ * @typedef SidebarTool
+ * @property {string} label
+ * @property {string} [icon]
+ * @property {Function} click
+ * @property {string[]} [classes]
+ * @property {SidebarToolCondition} [condition]
+ */
+
+/**
+ * @typedef SidebarToolGroup
+ * @property {string} id
+ * @property {string} label
+ * @property {string[]} [classes]
+ * @property {Record<string, SidebarTool>} tools
+ */
+
+export class FUSidebar extends sidebar.Sidebar {
+	static TABS = {
+		...foundry.applications.sidebar.Sidebar.TABS,
+		pfuTools: {
+			tooltip: 'FU.UiControlTitle',
+			img: systemAssetPath('icons/fus-star2.svg'),
+		},
+	};
+}
+
+export class FUSidebarApplication extends api.HandlebarsApplicationMixin(sidebar.AbstractSidebarTab) {
+	static DEFAULT_OPTIONS = {
+		classes: ['directory', 'projectfu'],
+		window: {
+			title: 'SIDEBAR.TabSettings',
+		},
+		actions: {
+			clickToolButton: FUSidebarApplication.clickToolButton,
+		},
+	};
+
+	static PARTS = {
+		main: {
+			template: systemTemplatePath(`ui/sidebar-menu`),
+			root: true,
+		},
+	};
+
+	static tabName = 'pfuTools';
+
+	static clickToolButton(event, button) {
+		const groupId = button.dataset.group;
+		const toolId = button.dataset.tool;
+
+		const tools = this._prepareTools();
+		const group = tools.find((group) => group.id === groupId);
+		if (!group) throw new Error(`Group ${groupId} not found.`);
+		const tool = group.tools[toolId];
+		if (!tool) throw new Error(`Tool ${toolId} not found.`);
+
+		if (typeof tool.click === 'function') tool.click.call(undefined);
+	}
+
+	onOpenPartySheet() {
+		FUPartySheet.toggleActive();
+	}
+	onOpenMetaCurrencyTracker() {
+		new MetaCurrencyTrackerApplication().render({ force: true });
+	}
+	onOpenWellspringManager() {
+		new GameWellspringManager().render({ force: true });
+	}
+	onOpenCompendiumBrowser() {
+		CompendiumBrowser.instance.render({ force: true });
+	}
+
+	/** @type SidebarToolGroup  */
+	#tools = [
+		{
+			id: 'utilities',
+			label: 'FU.SidebarUtilities',
+			tools: {},
+		},
+	];
+
+	_prepareTools() {
+		const tools = foundry.utils.deepClone(this.#tools);
+		for (const group of Object.values(tools)) {
+			if (group.classes?.length) group.expandedClasses = group.classes.join(' ');
+			for (const tool of Object.values(group.tools)) {
+				switch (typeof tool.condition) {
+					case 'function':
+						tool.visible = tool.condition();
+						break;
+					case 'boolean':
+						tool.visible = tool.condition;
+						break;
+					default:
+						tool.visible = true;
+				}
+				if (tool.visible) group.visible = true;
+				if (tool.classes?.length) tool.expandedClasses = tool.classes.join(' ');
+			}
+		}
+		return tools;
+	}
+
+	async _prepareContext(options) {
+		const context = await super._prepareContext(options);
+
+		context.tools = this._prepareTools();
+
+		return context;
+	}
+
+	constructor(options) {
+		super(options);
+		const tools = this.#tools;
+		Hooks.callAll(FUHooks.GET_SIDEBAR_TOOLS, tools);
+		this.#tools = tools;
+	}
+}

--- a/module/ui/sidebar.mjs
+++ b/module/ui/sidebar.mjs
@@ -37,6 +37,32 @@ export class FUSidebar extends sidebar.Sidebar {
 			img: systemAssetPath('icons/fus-star2.svg'),
 		},
 	};
+
+	static PARTS = {
+		tabs: {
+			id: 'tabs',
+			template: systemTemplatePath('ui/sidebar-tabs'),
+		},
+	};
+
+	/**
+	 * @override
+	 * Overridden to allow for specifying an image
+	 */
+	async _prepareTabContext(context, options) {
+		context.tabs = Object.entries(FUSidebar.TABS).reduce((obj, [key, value]) => {
+			let { documentName, gmOnly, tooltip, icon, img } = value;
+			if (gmOnly && !game.user.isGM) return obj;
+			if (documentName) {
+				tooltip ??= getDocumentClass(documentName).metadata.labelPlural;
+				icon ??= CONFIG[documentName]?.sidebarIcon;
+			}
+
+			obj[key] = { tooltip, icon, img };
+			obj[key].active = this.tabGroups.primary === key;
+			return obj;
+		}, {});
+	}
 }
 
 export class FUSidebarApplication extends api.HandlebarsApplicationMixin(sidebar.AbstractSidebarTab) {
@@ -89,7 +115,7 @@ export class FUSidebarApplication extends api.HandlebarsApplicationMixin(sidebar
 	#tools = [
 		{
 			id: 'utilities',
-			label: 'FU.SidebarUtilities',
+			label: 'FU.Utilities',
 			tools: {},
 		},
 	];

--- a/styles/css/app/_index.css
+++ b/styles/css/app/_index.css
@@ -4,3 +4,4 @@
 @import 'combat-hud-controls.css';
 @import 'meta-currency-tracker.css';
 @import 'inline-effect-config.css';
+@import 'sidebar.css';

--- a/styles/css/app/sidebar.css
+++ b/styles/css/app/sidebar.css
@@ -1,0 +1,19 @@
+.pfuTools-sidebar {
+	padding: 5px 1rem 1rem;
+}
+
+.pfuTools-sidebar__title {
+	text-align: center;
+	font-size: var(--font-size-32);
+	font-family: 'Credit Valley';
+}
+
+.pfuTools-sidebar__header {
+	margin-bottom: 0;
+}
+
+.pfuTools-sidebar__section {
+	column-gap: 0.5rem;
+	row-gap: 0.5rem;
+	padding-bottom: 1.5rem;
+}

--- a/templates/ui/sidebar-menu.hbs
+++ b/templates/ui/sidebar-menu.hbs
@@ -1,0 +1,19 @@
+  <section class="info flexcol">
+    <h1 class="pfuTools-sidebar__title">{{localize "FU.UiControlTitle"}}</h1>
+  </section>
+{{log "Tools" tools}}
+  {{#each tools as |group|}}
+    {{#if group.visible}}
+      <section class="pfuTools-sidebar__{{group.id}} pfuTools-sidebar__section flexcol form-group {{group.expandedClasses}}">
+        <h4 class="divider pfuTools-sidebar__header">{{localize group.label}}</h4>
+        {{#each group.tools as |tool|}}
+          {{#if tool.visible}}
+            <button type="button" data-action="clickToolButton" data-group="{{group.id}}" data-tool="{{@key}}" class="{{tool.expandedClasses}}">
+              {{#if tool.icon}}<i class="{{tool.icon}}"></i>{{/if}}
+              {{localize tool.label}}
+            </button>
+          {{/if}}
+        {{/each}}
+      </section>
+    {{/if}}
+  {{/each}}

--- a/templates/ui/sidebar-menu.hbs
+++ b/templates/ui/sidebar-menu.hbs
@@ -1,7 +1,7 @@
   <section class="info flexcol">
     <h1 class="pfuTools-sidebar__title">{{localize "FU.UiControlTitle"}}</h1>
   </section>
-{{log "Tools" tools}}
+
   {{#each tools as |group|}}
     {{#if group.visible}}
       <section class="pfuTools-sidebar__{{group.id}} pfuTools-sidebar__section flexcol form-group {{group.expandedClasses}}">

--- a/templates/ui/sidebar-tabs.hbs
+++ b/templates/ui/sidebar-tabs.hbs
@@ -1,0 +1,19 @@
+<nav class="tabs faded-ui" role="tablist" data-tooltip-direction="LEFT">
+    <menu class="flexcol">
+        {{#each tabs}}
+        {{log "Tab" this}}
+        <li>
+            <button type="button" class="ui-control plain icon {{ icon }}" data-action="tab" data-tab="{{ @key }}"
+                    role="tab" aria-pressed="{{ active }}" data-group="primary" aria-label="{{ localize tooltip }}"
+                    aria-controls="{{ @key }}" data-tooltip>
+              {{#if img}}<img src="{{img}}">{{/if}}
+            </button>
+            <div class="notification-pip"></div>
+        </li>
+        {{/each}}
+        <li>
+            <button type="button" class="collapse ui-control plain icon fas fa-caret-left" data-tooltip
+                    aria-label="{{ localize "Expand" }}" data-action="toggleState"></button>
+        </li>
+    </menu>
+</nav>


### PR DESCRIPTION
Overrides the Sidebar application to add a custom PFU-specific tab to hold a set of buttons for arbitrary tasks.

<img width="395" align="right" alt="image" src="https://github.com/user-attachments/assets/d2fd2b2f-fa77-40ce-b989-b63d7f6f5a1c" />


Buttons are organized in two levels:  The `SidebarToolGroup` and the `SidebarTool`
```
/**
 * @typedef {Function} SidebarToolCondition
 * @returns {boolean}
 */

/**
 * @typedef SidebarTool
 * @property {string} label
 * @property {string} [icon]
 * @property {Function} click
 * @property {string[]} [classes]
 * @property {SidebarToolCondition} [condition]
 */

/**
 * @typedef SidebarToolGroup
 * @property {string} id
 * @property {string} label
 * @property {string[]} [classes]
 * @property {Record<string, SidebarTool>} tools
 */
```

The list of tools is composited via a hook - `projectfu.getSidebarTools` to allow for 3rd-party modules (Such as Lookfar or the NPC Quirk Wizard) to register their own tools for the sidebar.

The tools currently registered with the sidebar are the same items registered in the scene controls, as well as the Combat HUD buttons from the combat tracker, and a few settings applications that come up frequently in questions on Discord:
- The Configure Sheets option, to help visibility for the new party sheet themes
- Manage Optional Rules because of how often people ask about enabling Quirks or Camping Activities
- Manage Combat HUD Settings because of how often people just do not know there's a built-in combat HUD