### PR TITLE
Generalize apex attributes implementation to support multiple out-of-bounds attributes with arbitrary values.

### DIFF
--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -1,3 +1,4 @@
+import { MathHelper } from '../../../helpers/math-helper.mjs';
 import { CheckHooks } from './check-hooks.mjs';
 import { FU, SYSTEM } from '../helpers/config.mjs';
 import { Flags } from '../helpers/flags.mjs';
@@ -334,7 +335,6 @@ async function prepareCheckDryRun(type, actor, item, initialConfigCallback) {
 
 const CRITICAL_THRESHOLD = 6;
 const ATTRIBUTE_MAXIMUM_DIE = 12;
-const ATTRIBUTE_APEX_DIE = 20;
 
 /**
  * @param {CheckV2} check
@@ -350,15 +350,14 @@ async function rollCheck(check, actor, item) {
 	let primaryDice = attributes[primary].current;
 	let secondaryDice = attributes[secondary].current;
 
-	// Optional support for attribute paragon (use D20 instead of D12s during checks)
-	const apexAttribute = actor.getFlag(Flags.Scope, Flags.Toggle.ApexAttribute);
-	if (apexAttribute) {
-		if (primary === apexAttribute && attributes[primary].base >= ATTRIBUTE_MAXIMUM_DIE) {
-			primaryDice = ATTRIBUTE_APEX_DIE;
-		}
-		if (secondary === apexAttribute && attributes[secondary].base >= ATTRIBUTE_MAXIMUM_DIE) {
-			secondaryDice = ATTRIBUTE_APEX_DIE;
-		}
+	// Optional support for unlimited dice (ex. NeoHuman use d20 when base is d12)
+	let primaryBound = MathHelper.clamp(attributes[primary].abnormal, 6, 12);
+	if (attributes[primary].unlimit && attributes[primary].base == primaryBound) {
+		primaryDice = attributes[primary].abnormal;
+	}
+	let secondaryBound = MathHelper.clamp(attributes[secondary].abnormal, 6, 12);
+	if (attributes[primary].unlimit && attributes[secondary].base == secondaryBound) {
+		secondaryDice = attributes[secondary].abnormal;
 	}
 
 	const modifierTotal = modifiers.reduce((agg, curr) => (agg += curr.value), 0);

--- a/module/documents/actors/common/attribute-data-model.mjs
+++ b/module/documents/actors/common/attribute-data-model.mjs
@@ -32,7 +32,6 @@ export class AttributeDataModel extends foundry.abstract.DataModel {
 
 		// Set the initial current to start off the base value
 		this._current = this.base;
-		// Set the initial unlimit flag to start false
 		// Set the initial abnormal die size to d20 (Neo-Human)
 		this._abnormal = 20;
 

--- a/module/documents/actors/common/attribute-data-model.mjs
+++ b/module/documents/actors/common/attribute-data-model.mjs
@@ -8,20 +8,22 @@ function isEven(number) {
 	return number % 2 === 0;
 }
 
-// TODO: Provide support for NeoHuman
 const minimumValue = 6;
 const maximumValue = 12;
 
 /**
  * @property {number} base
  * @property {number} current
+ * @property {boolean} unlimit
+ * @property {number} abnormal
  * @property {number} bonus
  */
 export class AttributeDataModel extends foundry.abstract.DataModel {
 	static defineSchema() {
-		const { NumberField } = foundry.data.fields;
+		const { NumberField, BooleanField } = foundry.data.fields;
 		return {
 			base: new NumberField({ initial: 8, min: minimumValue, max: maximumValue, integer: true, nullable: false, validate: isEven }),
+			unlimit: new BooleanField({ initial: false, nullable: false })
 		};
 	}
 
@@ -30,6 +32,9 @@ export class AttributeDataModel extends foundry.abstract.DataModel {
 
 		// Set the initial current to start off the base value
 		this._current = this.base;
+		// Set the initial unlimit flag to start false
+		// Set the initial abnormal die size to d20 (Neo-Human)
+		this._abnormal = 20;
 
 		Object.defineProperty(this, 'current', {
 			configurable: false,
@@ -40,6 +45,19 @@ export class AttributeDataModel extends foundry.abstract.DataModel {
 			set: (newValue) => {
 				if (Number.isNumeric(newValue)) {
 					this._current = Number(newValue);
+				}
+			},
+		});
+
+		Object.defineProperty(this, 'abnormal', {
+			configurable: false,
+			enumerable: true,
+			get: () => {
+				return 2 * Math.floor(this._current / 2)
+			},
+			set: (newValue) => {
+				if (Number.isNumeric(newValue) && MathHelper.clamp(newValue, minimumValue, maximumValue) != Number(newValue)) {
+					this._abnormal = Number(newValue)
 				}
 			},
 		});

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -52,7 +52,6 @@ export const Flags = Object.freeze({
 	Scope: 'projectfu',
 	Toggle: Object.freeze({
 		WeaponMagicCheck: 'weaponMagicCheck',
-		ApexAttribute: 'apexAttribute',
 	}),
 	Modifier: Object.freeze({
 		ScaleIncomingDamage: 'scaleIncomingDamage',


### PR DESCRIPTION
Assuming I haven't made any dumb JavaScript errors, this should add the following Active Effects aspects:

attributes[attr].unlimit [bool]: If the base attribute die is at the max/min die size, uses abnormal if it is above/below max/min die size, respectively.
attributes[attr].abnormal [number]: The die size to be used when unlimit is true and base is the appropriate value.

This replaces the previous apex attribute implementation (I've yet to do the compendium changes for this. Obviously before the pull request is completed I intend to have the compendium changes finished.)