### PR TITLE
Re-add pfuClamp Helper

### DIFF
--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -196,6 +196,10 @@ export const FUHandlebars = Object.freeze({
 			}[operator];
 		});
 
+		Handlebars.registerHelper('pfuClamp', (val, min, max) => {
+			return Math.clamp(val, min, max);
+		});
+
 		Handlebars.registerHelper('pfuImage', (src, classes, label) => {
 			if (VideoHelper.hasVideoExtension(src)) {
 				return new Handlebars.SafeString(`<video class="${classes}" autoplay loop muted playsinline src="${src}" data-tooltip="${label}"></video>`);


### PR DESCRIPTION
#903 erroneously removed the `pfuClamp` Handlebars helper that is used by the Mother combat HUD theme.