### PR TITLE
Remove Unnecessary Console Log From Sidebar Template

### DIFF
--- a/templates/ui/sidebar-tabs.hbs
+++ b/templates/ui/sidebar-tabs.hbs
@@ -1,7 +1,6 @@
 <nav class="tabs faded-ui" role="tablist" data-tooltip-direction="LEFT">
     <menu class="flexcol">
         {{#each tabs}}
-        {{log "Tab" this}}
         <li>
             <button type="button" class="ui-control plain icon {{ icon }}" data-action="tab" data-tab="{{ @key }}"
                     role="tab" aria-pressed="{{ active }}" data-group="primary" aria-label="{{ localize tooltip }}"


### PR DESCRIPTION
What it says on the tin.  Sidebar hbs template has an unnecessary `log` statement I neglected to remove before submitting #925 