### PR TITLE
Add image picker clipboard upload

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1934,6 +1934,10 @@
 		"Codex": "Codex",
 		"Tags": "Tags",
 		"Hidden": "Hidden",
+		"BrowseImage": "Browse Image",
+		"UploadClipboardImage": "Upload Clipboard Image",
+		"CodexUploadDirectory": "Codex Upload Directory",
+		"CodexUploadDirectoryMissing": "You must set an user directory for codex clipboard images to be uploaded to. This can be configured in the system settings.",
 		"CODEX": {
 			"Character": "Character",
 			"Location": "Location",

--- a/module/helpers/file-utils.mjs
+++ b/module/helpers/file-utils.mjs
@@ -1,3 +1,5 @@
+import { StringUtils } from './string-utils.mjs';
+
 /**
  * @desc Helper for reading string content out of a text file.
  * @param {string} filePath The path to the file.
@@ -34,6 +36,22 @@ async function uploadClipboardImage(directory, prefix) {
 
 	const imageType = imageItem.types.find((type) => type.startsWith('image/'));
 	const blob = await imageItem.getType(imageType);
+
+	// Preview and confirm
+	const objectUrl = URL.createObjectURL(blob);
+	const confirm = await foundry.applications.api.DialogV2.confirm({
+		window: {
+			title: StringUtils.localize('FU.UploadClipboardImage'),
+		},
+		content: `<img id="clipboard-preview" style="max-width:100%; max-height:300px; object-fit:contain;">`,
+		render: (event, dialog) => {
+			dialog.element.querySelector('#clipboard-preview').src = objectUrl;
+		},
+		rejectClose: false,
+	});
+	URL.revokeObjectURL(objectUrl);
+
+	if (!confirm) return;
 
 	const extension = imageType.split('/')[1];
 	const filename = `${prefix}-${Date.now()}.${extension}`;

--- a/module/helpers/file-utils.mjs
+++ b/module/helpers/file-utils.mjs
@@ -17,6 +17,56 @@ async function readTextFromFile(filePath) {
 	});
 }
 
+async function uploadClipboardImage(directory, prefix) {
+	let imageItem;
+
+	try {
+		const clipboardItems = await navigator.clipboard.read();
+		imageItem = clipboardItems.find((item) => item.types.some((type) => type.startsWith('image/')));
+	} catch (error) {
+		return;
+	}
+
+	if (!imageItem) {
+		ui.notifications.warn('No image found in clipboard.');
+		return;
+	}
+
+	const imageType = imageItem.types.find((type) => type.startsWith('image/'));
+	const blob = await imageItem.getType(imageType);
+
+	const extension = imageType.split('/')[1];
+	const filename = `${prefix}-${Date.now()}.${extension}`;
+	const file = new File([blob], filename, { type: imageType });
+
+	const response = await FilePicker.upload('data', directory, file, {});
+	if (!response?.path) {
+		ui.notifications.error('Failed to upload clipboard image.');
+		return;
+	}
+
+	return response.path;
+}
+
+async function deleteFile(storage, path) {
+	return new Promise((resolve, reject) => {
+		game.socket.emit(
+			'manageFiles',
+			{
+				action: 'deleteFile',
+				storage: storage,
+				path,
+			},
+			(response) => {
+				if (response.error) reject(new Error(response.error));
+				else resolve(response);
+			},
+		);
+	});
+}
+
 export const FileUtils = Object.freeze({
 	readTextFromFile,
+	uploadClipboardImage,
+	deleteFile,
 });

--- a/module/settings.js
+++ b/module/settings.js
@@ -102,6 +102,7 @@ export const SETTINGS = Object.freeze({
 	// Party
 	activeParty: 'optionActiveParty',
 	partySheetTheme: 'optionPartySheetTheme',
+	codexUploadDirectory: 'optionCodexUploadDirectory',
 	// Class Features
 	activeWellsprings: 'activeWellsprings',
 	// Drag ruler
@@ -178,6 +179,14 @@ export const registerSystemSettings = async function () {
 		default: 'modern',
 		choices: FU.partySheetThemes,
 		requiresReload: false,
+	});
+
+	game.settings.register(SYSTEM, SETTINGS.codexUploadDirectory, {
+		name: game.i18n.localize('FU.CodexUploadDirectory'),
+		scope: 'world',
+		config: true,
+		type: String,
+		filePicker: 'folder',
 	});
 
 	game.settings.register(SYSTEM, SETTINGS.optionNPCNotesTab, {

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -70,6 +70,7 @@ export class FUPartySheet extends FUActorSheet {
 			addCodexEntry: this.#onAddCodexEntry,
 			forCodexEntry: this.#onCodexAction,
 			resetCodexTags: this.#onResetCodexTags,
+			browseUploadDirectory: this.onBrowseUploadDirectory,
 			inspectBondNode: { handler: this.#onInspectBondNode, buttons: [2] },
 		},
 		position: { width: 920, height: 1000 },
@@ -573,6 +574,23 @@ export class FUPartySheet extends FUActorSheet {
 	 */
 	static async #onResetCodexTags(event, target) {
 		return this.codexBrowser.resetTags();
+	}
+
+	/**
+	 * @this FUPartySheet
+	 * @param {PointerEvent} event   The originating click event
+	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+	 * @returns {Promise<void>}
+	 */
+	static async onBrowseUploadDirectory(event, target) {
+		const uploadDirectory = getSystemSetting(SETTINGS.codexUploadDirectory);
+		if (uploadDirectory) {
+			new foundry.applications.apps.FilePicker({
+				type: 'file',
+				current: uploadDirectory,
+				activeSource: 'data',
+			}).render(true);
+		}
 	}
 
 	/**

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -234,7 +234,7 @@ export class CodexBrowser {
 		}
 	}
 
-	static UPLOAD_FILE_PATTERN = new RegExp('codex-entry');
+	static UPLOAD_FILE_PREFIX = 'codex-entry';
 
 	/**
 	 * @param {CodexEntryDataModel} entry
@@ -271,7 +271,7 @@ export class CodexBrowser {
 						return;
 					}
 
-					const imagePath = await FileUtils.uploadClipboardImage(uploadDirectory, CodexBrowser.UPLOAD_FILE_PATTERN);
+					const imagePath = await FileUtils.uploadClipboardImage(uploadDirectory, CodexBrowser.UPLOAD_FILE_PREFIX);
 					if (!imagePath) {
 						return;
 					}
@@ -311,7 +311,7 @@ export class CodexBrowser {
 		if (uploadDirectory) {
 			const entries = this.party.codex.entries;
 			const usedImages = new Set(entries.map((e) => e.img).filter((img) => img !== undefined));
-			const filePattern = CodexBrowser.UPLOAD_FILE_PATTERN;
+			const filePattern = new RegExp(CodexBrowser.UPLOAD_FILE_PREFIX);
 
 			// Browse the directory to get all files
 			const browse = await FilePicker.browse('data', uploadDirectory);

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -1,6 +1,9 @@
 import FoundryUtils from '../helpers/foundry-utils.mjs';
 import { CodexDataModel, CodexEntryDataModel } from '../documents/actors/party/codex-data-model.mjs';
 import { HTMLUtils } from '../helpers/html-utils.mjs';
+import { getSystemSetting, SETTINGS } from '../settings.js';
+import { StringUtils } from '../helpers/string-utils.mjs';
+import { FileUtils } from '../helpers/file-utils.mjs';
 
 export class CodexBrowser {
 	/** @type FUPartySheet **/
@@ -14,8 +17,6 @@ export class CodexBrowser {
 	#linkPattern;
 	/** @type String[] **/
 	selected;
-	/** @type CodexEntryDataModel **/
-	entries;
 	/** @type String **/
 	filter;
 	/** @type String[] **/
@@ -233,6 +234,8 @@ export class CodexBrowser {
 		}
 	}
 
+	static UPLOAD_FILE_PATTERN = new RegExp('codex-entry');
+
 	/**
 	 * @param {CodexEntryDataModel} entry
 	 * @returns {Promise<boolean>}
@@ -248,6 +251,35 @@ export class CodexBrowser {
 			window: { title: `Edit — ${entry.name}` },
 			position: {
 				width: 750,
+			},
+			actions: {
+				// Image Picker: Clipboard
+				clipboardImage: async (event, target) => {
+					const { name } = target.dataset;
+					const imagePicker = event.currentTarget.querySelector('.image-picker');
+					if (!imagePicker) {
+						return;
+					}
+					const preview = imagePicker.querySelector('img');
+					const input = imagePicker.querySelector(`input[name="${name}"]`);
+
+					// Check if there's a valid upload directory
+					// TODO: Get full path from whatever it stores here
+					const uploadDirectory = getSystemSetting(SETTINGS.codexUploadDirectory);
+					if (!uploadDirectory) {
+						ui.notifications.warn(StringUtils.localize('FU.CodexUploadDirectoryMissing'));
+						return;
+					}
+
+					const imagePath = await FileUtils.uploadClipboardImage(uploadDirectory, CodexBrowser.UPLOAD_FILE_PATTERN);
+					if (!imagePath) {
+						return;
+					}
+
+					// Update the preview and input
+					preview.src = imagePath;
+					input.value = imagePath;
+				},
 			},
 			content,
 			context,
@@ -272,6 +304,35 @@ export class CodexBrowser {
 		entry.hidden = result.hidden;
 		entry.notes = result.notes;
 		return true;
+	}
+
+	async cleanCodexImages() {
+		const uploadDirectory = getSystemSetting(SETTINGS.codexUploadDirectory);
+		if (uploadDirectory) {
+			const entries = this.party.codex.entries;
+			const usedImages = new Set(entries.map((e) => e.img).filter((img) => img !== undefined));
+			const filePattern = CodexBrowser.UPLOAD_FILE_PATTERN;
+
+			// Browse the directory to get all files
+			const browse = await FilePicker.browse('data', uploadDirectory);
+			/** @type String[] **/
+			const imagesToDelete = browse.files.filter((file) => {
+				const filename = file.split('/').pop();
+				return filePattern.test(filename) && !usedImages.has(file);
+			});
+
+			// TODO: Delete all images in the upload directory that match the file pattern and are not being used
+			if (imagesToDelete.length > 0) {
+				const confirm = await FoundryUtils.confirmDialog('Unused Images', `${imagesToDelete.length} uploaded images are unused:\n${imagesToDelete.join('\n')}`);
+				if (confirm) {
+					// // TODO: Delete the images
+					// for (const file of imagesToDelete) {
+					// 	await FileUtils.deleteFile('data', file);
+					// }
+					// ui.notifications.info(`Deleted ${imagesToDelete.length} unused images.`);
+				}
+			}
+		}
 	}
 
 	/**

--- a/styles/css/actor/party.css
+++ b/styles/css/actor/party.css
@@ -329,8 +329,8 @@
 				img {
 					object-fit: cover;
 					width: 160px;
+					height: 120px;
 					padding: 0;
-					height: auto;
 					border: 2px solid var(--pfu-color-control-border);
 				}
 

--- a/styles/css/global/dialog.css
+++ b/styles/css/global/dialog.css
@@ -9,10 +9,15 @@
 		display: flex;
 		flex-direction: row;
 		gap: 1rem;
+		width: 100%;
 
 		img {
 			width: 240px;
-			height: auto;
+			min-width: 240px;
+			height: 240px;
+			object-fit: scale-down;
+			background-color: white;
+			border: 1px solid var(--pfu-color-app-border);
 		}
 
 		.inputs {
@@ -20,7 +25,12 @@
 			flex-direction: row;
 			justify-content: center;
 			align-items: center;
-			gap: 8px;
+			width: 100%;
+			gap: 4px;
+
+			label {
+				flex: 2;
+			}
 
 			button {
 				flex: 0;

--- a/templates/actor/party/actor-party-edit-codex-entry.hbs
+++ b/templates/actor/party/actor-party-edit-codex-entry.hbs
@@ -27,8 +27,15 @@
 				<label>
 					<input type="text" name="img" value="{{entry.img}}" />
 				</label>
-				<button type="button" data-action="browseImage" data-name="img" data-type="image">
+				<button type="button" data-action="browseImage"
+						data-tooltip="FU.BrowseImage"
+						data-name="img">
 					<i class="fas fa-file-image"></i>
+				</button>
+				<button type="button" data-action="clipboardImage"
+						data-tooltip="FU.UploadClipboardImage"
+						data-name="img">
+					<i class="fas fa-file-clipboard"></i>
 				</button>
 			</div>
 		</div>

--- a/templates/actor/party/actor-party-section-settings.hbs
+++ b/templates/actor/party/actor-party-section-settings.hbs
@@ -24,9 +24,10 @@
 			</legend>
 
 			<div class="grid-2col gap-4">
-				<div class="flexcol flex-group-center">
+				<div class="flexcol">
 					<button data-action="activate"><i class="fas fa-pen-to-square icon"></i>Set Active</button>
 					<button data-action="resetCodexTags"><i class="fas fa-list icon"></i>Reset Tags</button>
+					<button data-action="browseUploadDirectory"><i class="fas fa-clipboard"></i>Browse Upload Directory</button>
 				</div>
 				{{pfuArrayField array=system.codex.tags label="FU.Tags" path="system.codex.tags" type="string" }}
 			</div>


### PR DESCRIPTION
This pull request introduces a new feature for uploading clipboard images directly into Codex entries, along with related user interface improvements and settings. The main changes include adding clipboard image upload capability, configuring a dedicated upload directory, updating the Codex entry editing UI, and cleaning up unused images. There are also some style adjustments to improve image display.

**Clipboard Image Upload and Codex Integration:**
- Added a new helper function `uploadClipboardImage` in `file-utils.mjs` to allow users to upload images directly from their clipboard, with image preview and confirmation dialog. Also added a `deleteFile` helper for future image management. [[1]](diffhunk://#diff-ebdbba1b3fb7278324ad9c6ec6eed12e137df7527d84fdab7e75ab97d65a1bb4R1-R2) [[2]](diffhunk://#diff-ebdbba1b3fb7278324ad9c6ec6eed12e137df7527d84fdab7e75ab97d65a1bb4R22-R89)
- Integrated clipboard image upload into the Codex entry editing dialog, including UI buttons for browsing and uploading clipboard images, and logic to handle directory selection and error messages. [[1]](diffhunk://#diff-01d0a91c67c5848e2491752820b8dd7b08c88cc46139ce3d67d4ec3c8d5a9651R255-R283) [[2]](diffhunk://#diff-a36319f037e789f02a1ed8776270e15cbfcc5822d9287b99de4cf4dcb3708723L30-R39) [[3]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R1937-R1940)

**Codex Upload Directory Setting:**
- Introduced a new system setting `codexUploadDirectory` to specify where clipboard images for Codex entries are stored, with a file picker UI for configuration. [[1]](diffhunk://#diff-5a64af73e981d8c32be81d0711891c209b3a29261c686bae39b132a67fc41d62R105) [[2]](diffhunk://#diff-5a64af73e981d8c32be81d0711891c209b3a29261c686bae39b132a67fc41d62R184-R191)
- Added a button to the party sheet settings section to quickly browse the upload directory. [[1]](diffhunk://#diff-3e99b863230f0f0d7f312b9b74b8e578c7c3dbcf6af07f83efc246b52b0bce74R73) [[2]](diffhunk://#diff-3e99b863230f0f0d7f312b9b74b8e578c7c3dbcf6af07f83efc246b52b0bce74R579-R595) [[3]](diffhunk://#diff-f407a2fb813c0df52aaffa524a7b816e36eb85cc6c01307232746f92668a59a0L27-R30)

**Codex Image Management:**
- Implemented a method `cleanCodexImages` in `CodexBrowser` to identify and (optionally) delete unused uploaded images from the Codex upload directory, helping manage storage.

**Styling Improvements:**
- Updated image display styles in Codex and dialog UIs for better layout, consistent sizing, and improved appearance. [[1]](diffhunk://#diff-59266c8bd96787bceff2148a6c45f0f469b2371d95dc37361af92daf1235dd55R332-L333) [[2]](diffhunk://#diff-ba14f6ba3df81e011abe9e24f2069684973db6e7c0029c7f176f97c8a5c903c1R12-R33)

**Localization:**
- Added new localization strings for clipboard image upload and directory configuration.