### PR TITLE
fix: clipping buttons and missing chat background

### DIFF
--- a/module/ui/themes/theme-options.mjs
+++ b/module/ui/themes/theme-options.mjs
@@ -367,7 +367,7 @@ const defaultTheme = Object.freeze({
 	uiAccentImage: '',
 	appBgImage: systemAssetPath(`ui/HojitasDouble_highres.png`),
 	appSectionBgImage: '',
-	sidebarBgImage: systemAssetPath('ui/pattern_hojita_half.png'),
+	sidebarBgImage: systemAssetPath('ui/patterns/pattern_hojita_half.png'),
 
 	colorMiscShadowPrimary: '#77ebd7ff',
 	colorMiscShadowHighlight: '#E03A3AFF',

--- a/styles/css/components/table/cell-item-controls.css
+++ b/styles/css/components/table/cell-item-controls.css
@@ -1,6 +1,6 @@
 .cell-item-controls {
 	height: 100%;
-	padding-right: 5px;
+	padding: 0 5px 5px 0;
 
 	display: flex;
 	justify-content: end;

--- a/styles/css/components/table/table.css
+++ b/styles/css/components/table/table.css
@@ -13,6 +13,7 @@
 		display: grid;
 		grid-template-columns: subgrid;
 		grid-column: 1 / -1;
+		align-items: center;
 	}
 
 	.fu-table__row--deeply-nested {


### PR DESCRIPTION
* Fixes clipping at bottom of buttons in many tabs
  * Padding is probably not the perfect solution, but given how the styling of the buttons and the differences between tabs, it's probably the most straightforward / generic one.
* Fixes incorrect path for chat background