### PR TITLE
Compendium - Bend Magic & Absorb MP

### DIFF
--- a/src/packs/heroic-skills/heroic_Bend_Magic_HsdYyIcbdvcleXQP.json
+++ b/src/packs/heroic-skills/heroic_Bend_Magic_HsdYyIcbdvcleXQP.json
@@ -77,38 +77,6 @@
         },
         "rules": {
           "elements": {
-            "aDeQ9cqfNSgNt5gT": {
-              "type": "ruleElement",
-              "_id": "aDeQ9cqfNSgNt5gT",
-              "trigger": {
-                "_id": "PXNjhhtCyx4s4nKh",
-                "type": "renderCheckRuleTrigger",
-                "eventRelation": "target",
-                "checkTypes": [
-                  "accuracy"
-                ],
-                "itemGroups": [
-                  "attack"
-                ],
-                "local": false,
-                "identifier": ""
-              },
-              "predicates": {
-                "TReEzSGP86Na5wnZ": {
-                  "type": "checkRulePredicate",
-                  "_id": "TReEzSGP86Na5wnZ",
-                  "parity": "even",
-                  "result": null
-                }
-              },
-              "actions": {
-                "TJgUq7nCcodY74d2": {
-                  "type": "messageRuleAction",
-                  "_id": "TJgUq7nCcodY74d2",
-                  "message": "<p>The invoker may use an <strong>Invocation</strong> back.</p>"
-                }
-              }
-            },
             "jotNPxvUv3VfB2R8": {
               "type": "ruleElement",
               "_id": "jotNPxvUv3VfB2R8",
@@ -135,7 +103,15 @@
                   "type": "checkRulePredicate",
                   "_id": "4JUflNoXPiCPK0sr",
                   "parity": "even",
-                  "result": null
+                  "result": null,
+                  "attributes": {
+                    "primary": {
+                      "value": ""
+                    },
+                    "secondary": {
+                      "value": ""
+                    }
+                  }
                 }
               },
               "actions": {
@@ -154,6 +130,11 @@
             "current": 0,
             "max": 6,
             "style": "basic"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
           }
         }
       },
@@ -165,7 +146,7 @@
       "_id": "Y5NywAw1nL87QTHa",
       "type": "base",
       "changes": [],
-      "description": "",
+      "description": "<p>After an enemy you can see hits or misses you with an offensive spell, if the Result of their Magic Check was an <strong>even number</strong>, you may immediately use the <strong>Invocation</strong> Skill for free.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -180,7 +161,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770875865113,
-        "modifiedTime": 1770876885246,
+        "modifiedTime": 1774844164325,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!HsdYyIcbdvcleXQP.Y5NywAw1nL87QTHa"

--- a/src/packs/heroic-skills/heroic_Comet_zggGDIOSuvO8uzHg.json
+++ b/src/packs/heroic-skills/heroic_Comet_zggGDIOSuvO8uzHg.json
@@ -9,7 +9,7 @@
     "summary": {
       "value": "Learn the Comet spell."
     },
-    "description": "<p><strong>Requirements:</strong> you must have mastered the <strong>Entropist</strong> Class.</p><hr /><p>You learn the ultimate <strong>Entropist</strong> spell: <strong>Comet</strong>.</p><table style=\"width:93.4884%\" border=\"1\"><tbody><tr><td style=\"text-align:center;width:16%\"><p><strong>Comet</strong></p></td><td style=\"text-align:center;width:18%\"><p><strong>MP: </strong>50</p></td><td style=\"text-align:center;width:32%\"><p><strong>Target: </strong>Special</p></td><td style=\"text-align:center;width:32%\"><p><strong>Duration: </strong>Instantaneous</p></td></tr></tbody></table><p>You rip open a large portal to the Cosmos, calling down astral debris from the gaping void. Choose one option: you deal 60 damage to one creature you can see; <strong>or</strong> you deal 40 damage to every enemy you can see. These amounts increase by 5 if you are <strong>level 20 or higher</strong>, or by 10 if you are <strong>level 40 or higher</strong>.</p><p>Damage dealt by this spell has no type (thus being unaffected by damage Affinities).</p><hr /><p>Add the @UUID[Compendium.projectfu.heroic-skills.Item.couQDFDzbxx7tKnx]{Comet} spell to your character sheet.</p>",
+    "description": "<p><strong>Requirements:</strong> you must have mastered the <strong>Entropist</strong> Class.</p><hr /><p>You learn the ultimate <strong>Entropist</strong> spell: <strong>Comet</strong>.</p><table style=\"width:93.4884%\" border=\"1\"><tbody><tr><td style=\"text-align:center;width:16%\"><p><strong>Comet</strong></p></td><td style=\"text-align:center;width:18%\"><p><strong>MP: </strong>50</p></td><td style=\"text-align:center;width:32%\"><p><strong>Target:</strong> Special</p></td><td style=\"text-align:center;width:32%\"><p><strong>Duration:</strong> Instantaneous</p></td></tr></tbody></table><p>You rip open a large portal to the Cosmos, calling down astral debris from the gaping void. Choose one option:</p><ul><li><p>You deal 60 damage to one creature you can see.</p></li><li><p>You deal 40 damage to every enemy you can see.</p></li></ul><p>These amounts increase by 5 if you are <strong>level 20 or higher</strong>, or by 10 if you are <strong>level 40 or higher</strong>.</p><p>Damage dealt by this spell has no type (thus being unaffected by damage Affinities).</p><hr /><p>Add the @UUID[Compendium.projectfu.heroic-skills.Item.couQDFDzbxx7tKnx]{Comet} spell to your character sheet.</p>",
     "isFavored": {
       "value": false
     },
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706583798150,
-    "modifiedTime": 1771887250617,
+    "modifiedTime": 1774899532166,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Volcano_FpTkfuZ5p4zCQKDP.json
+++ b/src/packs/heroic-skills/heroic_Volcano_FpTkfuZ5p4zCQKDP.json
@@ -9,7 +9,7 @@
     "summary": {
       "value": "Learn the Volcano spell."
     },
-    "description": "<p><strong>Requirements:</strong> you must have mastered the <strong>Elementalist</strong> Class.</p><hr /><p><span>You learn the ultimate <strong>Elementalist</strong> spell: <strong>Volcano</strong> (if it better fits your character, you may give this spell a different name and change its damage to <strong>air</strong>, <strong>bolt</strong>, <strong>earth</strong>, or <strong>ice</strong>).</span></p><table style=\"width:93.4884%\" border=\"1\"><tbody><tr><td style=\"text-align:center;width:16%\"><p><strong>Volcano</strong></p></td><td style=\"text-align:center;width:18%\"><p><strong>MP: </strong>40</p></td><td style=\"text-align:center;width:32%\"><p><strong>Target: </strong>Special</p></td><td style=\"text-align:center;width:32%\"><p><strong>Duration: </strong>Instantaneous</p></td></tr></tbody></table><p><span>You channel the fury of the planet into a powerful wave of fire and magma. Choose one option: you deal 50 <strong>fire</strong> damage to one creature you can see; <strong>or</strong> you deal 30 <strong>fire</strong> damage to every enemy you can see. These amounts increase by 5 if you are <strong>level 20 or higher</strong>, or by 10 if you are <strong>level 40 or higher</strong>.</span></p><p><span>Damage dealt by this spell ignores Resistances and Immunities.</span></p><hr /><p>Add the @UUID[Compendium.projectfu.heroic-skills.Item.hAys6ZF4mjNMQ9xa]{Volcano} spell to your character sheet.</p>",
+    "description": "<p><strong>Requirements:</strong> you must have mastered the <strong>Elementalist</strong> Class.</p><hr /><p><span>You learn the ultimate <strong>Elementalist</strong> spell: <strong>Volcano</strong> (if it better fits your character, you may give this spell a different name and change its damage to <strong>air</strong>, <strong>bolt</strong>, <strong>earth</strong>, or <strong>ice</strong>).</span></p><table style=\"width:93.4884%\" border=\"1\"><tbody><tr><td style=\"text-align:center;width:16%\"><p><strong>Volcano</strong></p></td><td style=\"text-align:center;width:18%\"><p><strong>MP:</strong> 40</p></td><td style=\"text-align:center;width:32%\"><p><strong>Target: </strong>Special</p></td><td style=\"text-align:center;width:32%\"><p><strong>Duration:</strong> Instantaneous</p></td></tr></tbody></table><p><span>You channel the fury of the planet into a powerful wave of fire and magma. Choose one option:</span></p><ul><li><p><span>You deal 50 <strong>fire</strong> damage to one creature you can see.</span></p></li><li><p><span>You deal 30 <strong>fire</strong> damage to every enemy you can see.</span></p></li></ul><p><span>These amounts increase by 5 if you are <strong>level 20 or higher</strong>, or by 10 if you are <strong>level 40 or higher</strong>.</span></p><p><span>Damage dealt by this spell ignores Resistances and Immunities.</span></p><hr /><p>Add the @UUID[Compendium.projectfu.heroic-skills.Item.hAys6ZF4mjNMQ9xa]{Volcano} spell to your character sheet.</p>",
     "isFavored": {
       "value": false
     },
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706587625271,
-    "modifiedTime": 1771890628314,
+    "modifiedTime": 1774899572292,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Absorb_MP_jgGLuOvN8xCSQWLK.json
+++ b/src/packs/skills/skill_Absorb_MP_jgGLuOvN8xCSQWLK.json
@@ -8,7 +8,7 @@
     "summary": {
       "value": ""
     },
-    "description": "<p>After you suffer damage, you may immediately recover <strong>【SL × 2】 </strong>Mind Points.</p>",
+    "description": "<p>After you suffer damage, you may immediately recover <strong>【SL × 2】</strong> Mind Points.</p><hr /><p><strong>You Recover:</strong> @GAIN[$sl*2 mp]{SL × 2 MP}</p>",
     "isFavored": {
       "value": false
     },
@@ -118,6 +118,11 @@
     "fuid": "absorb-mp",
     "targeting": {
       "rule": "self"
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
     }
   },
   "img": "systems/projectfu/styles/static/compendium/classes/entropist/entropist_absorb_mp.png",
@@ -180,7 +185,7 @@
       "_id": "5VkoqLalYTeuaJX1",
       "type": "base",
       "changes": [],
-      "description": "<p>After you suffer damage, you may immediately recover <strong>【SL × 2】 </strong>Mind Points.</p>",
+      "description": "<p>After you suffer damage, you may immediately recover <strong>【SL × 2】</strong> Mind Points.</p>",
       "origin": null,
       "tint": "#ffffff",
       "transfer": true,
@@ -213,7 +218,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706421327382,
-    "modifiedTime": 1770253394802,
+    "modifiedTime": 1774844079234,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,


### PR DESCRIPTION
Some quick minor fixes to Compendium.

- Removed the Attack check in Bend Magic's Rule Element. ( #943 )
- Added inline MP Gain to Absorb MP in case game is not using Rule Elements.
- Made bulleted lists out of Volcano and Comet's options.