### PR TITLE
Add a flag rule predicate

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1698,6 +1698,7 @@
 		"RulePredicateTargeting": "Targeting",
 		"RulePredicateTraits": "Traits",
 		"RulePredicateCheck": "Check",
+		"RulePredicateFlag": "Flag",
 		"AccuracyCheckRule": "Accuracy Check Rule",
 		"Type": "Type",
 		"Mode": "Mode",
@@ -1940,6 +1941,9 @@
 		"UploadClipboardImage": "Upload Clipboard Image",
 		"CodexUploadDirectory": "Codex Upload Directory",
 		"CodexUploadDirectoryMissing": "You must set an user directory for codex clipboard images to be uploaded to. This can be configured in the system settings.",
+		"Flag": "Flag",
+		"Key": "Key",
+		"Value": "Value",
 		"CODEX": {
 			"Character": "Character",
 			"Location": "Location",

--- a/module/documents/effects/predicates/flag-rule-predicate.mjs
+++ b/module/documents/effects/predicates/flag-rule-predicate.mjs
@@ -1,0 +1,83 @@
+import { RulePredicateDataModel } from './rule-predicate-data-model.mjs';
+import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
+import { FU } from '../../../helpers/config.mjs';
+
+const fields = foundry.data.fields;
+
+/**
+ * @property {String} scope
+ * @property {String} key
+ * @property {String} value If set, will be evaluated as part of the predicate.
+ * @property {FUTargetSelectorKey} selector
+ * @property {FUPredicateQuantifier} quantifier
+ */
+export class FlagRulePredicate extends RulePredicateDataModel {
+	static {
+		Object.defineProperty(this, 'TYPE', { value: 'flagRulePredicate' });
+	}
+
+	static defineSchema() {
+		return Object.assign(super.defineSchema(), {
+			selector: new fields.StringField({
+				initial: 'initial',
+				blank: true,
+				choices: Object.keys(FU.targetSelector),
+			}),
+			quantifier: new fields.StringField({
+				initial: 'any',
+				blank: true,
+				choices: Object.keys(FU.predicateQuantifier),
+			}),
+			scope: new fields.StringField({
+				initial: '',
+			}),
+			key: new fields.StringField({
+				initial: '',
+			}),
+			value: new fields.StringField({
+				initial: '',
+			}),
+		});
+	}
+
+	static get localization() {
+		return 'FU.RulePredicateFlag';
+	}
+
+	static get template() {
+		return systemTemplatePath('effects/predicates/flag-rule-predicate');
+	}
+
+	/**
+	 * @param {FUActor} actor
+	 * @return {Boolean}
+	 */
+	matchesFlag(actor) {
+		const actualValue = actor.getFlag(this.scope, this.key);
+		if (actualValue === undefined) {
+			return false;
+		}
+		if (this.value === undefined) {
+			return true;
+		}
+		return this.value === actualValue;
+	}
+
+	validateContext(context) {
+		const selected = context.selectTargets(this.selector);
+		switch (this.quantifier) {
+			case 'all':
+				// All selected actors must have the flag
+				return selected.every((character) => this.matchesFlag(character.actor));
+
+			case 'any':
+				// At least one actor must have the flag
+				return selected.some((character) => this.matchesFlag(character.actor));
+
+			case 'none':
+				// No actor should have the flag
+				return selected.every((character) => !this.matchesFlag(character.actor));
+		}
+		return false;
+	}
+}

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -72,4 +72,10 @@ export const FlagUtility = Object.freeze({
 			value: value,
 		};
 	},
+	hasSystemFlag: (document, flag) => {
+		if (document.getFlag) {
+			return document.getFlag(systemId, flag) !== undefined;
+		}
+		return false;
+	},
 });

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -58,6 +58,7 @@ import { FeatureRuleTrigger } from '../documents/effects/triggers/feature-rule-t
 import { FUItem } from '../documents/items/item.mjs';
 import { RenderMessageRuleTrigger } from '../documents/effects/triggers/render-message-rule-trigger.mjs';
 import { EmptyRuleTrigger } from '../documents/effects/triggers/empty-rule-trigger.mjs';
+import { FlagRulePredicate } from '../documents/effects/predicates/flag-rule-predicate.mjs';
 
 function register() {
 	RuleTriggerRegistry.instance.register(systemId, EmptyRuleTrigger.TYPE, EmptyRuleTrigger);
@@ -110,6 +111,7 @@ function register() {
 	RulePredicateRegistry.instance.register(systemId, TraitsRulePredicate.TYPE, TraitsRulePredicate);
 	RulePredicateRegistry.instance.register(systemId, SpellRulePredicate.TYPE, SpellRulePredicate);
 	RulePredicateRegistry.instance.register(systemId, CheckRulePredicate.TYPE, CheckRulePredicate);
+	RulePredicateRegistry.instance.register(systemId, FlagRulePredicate.TYPE, FlagRulePredicate);
 }
 
 /**

--- a/templates/effects/predicates/flag-rule-predicate.hbs
+++ b/templates/effects/predicates/flag-rule-predicate.hbs
@@ -1,0 +1,25 @@
+<div class="fu-form__property-row">
+	<label class="fu-form__property">
+		<span>{{localize 'FU.Scope'}}</span>
+		<input type="text" name="{{pfuConcat path '.scope'}}" value="{{predicate.scope}}" placeholder="projectfu">
+	</label>
+
+	<label class="fu-form__property">
+		<span>{{localize 'FU.Key'}}</span>
+		<input type="text" name="{{pfuConcat path '.key'}}" value="{{predicate.key}}">
+	</label>
+</div>
+
+<div class="fu-form__property-row">
+	<label class="fu-form__property">
+		<span>{{localize 'FU.Quantifier'}}</span>
+		<select name="{{pfuConcat path ".quantifier"}}" class="">
+			{{selectOptions options.predicateQuantifier selected=predicate.quantifier localize=true}}
+		</select>
+	</label>
+
+	<label class="fu-form__property">
+		<span>{{localize 'FU.Value'}}</span>
+		<input type="text" name="{{pfuConcat path '.value'}}" value="{{predicate.value}}" placeholder="Optionally, a matching value.">
+	</label>
+</div>


### PR DESCRIPTION
This pull request adds support for a new "Flag" rule predicate, enabling rules to check for the presence and value of specific flags on actors or documents. It introduces the new `FlagRulePredicate` class, registers it with the rule system, and provides the necessary UI and localization updates.

**New Flag Rule Predicate Functionality:**

* Introduced the `FlagRulePredicate` class in `flag-rule-predicate.mjs`, allowing predicates to check for the existence and value of flags on actors, with support for target selection and quantifiers (all/any/none).
* Registered `FlagRulePredicate` with the rule predicate registry in `rule-elements.mjs`, making it available for use in the system. [[1]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R61) [[2]](diffhunk://#diff-ddd67b2de14b96e6fe1c6b6436a7228adf3c6a2ed6d1a0f305886200bef6b484R114)
* Added a Handlebars template (`flag-rule-predicate.hbs`) for configuring the new predicate type in the UI, including fields for scope, key, value, and quantifier.

**Localization and Utility Updates:**

* Updated `en.json` to add new localization strings for "Flag", "Key", and "Value", and to support the new predicate type in the UI. [[1]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R1701) [[2]](diffhunk://#diff-1d56632a2d162f99c901e53b79a6224e984c14501bca3188a85dbb4b4c5e6da1R1944-R1946)
* Added a `hasSystemFlag` utility method to `flags.mjs` for checking if a document has a specific system flag.