### PR TITLE
Fix damage bonus for species and other missing traits

### DIFF
--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -42,36 +42,18 @@ const PIPELINE_STEP_LOCALIZATION_KEYS = {
 	affinity: 'FU.DamagePipelineStepAffinity',
 	incomingDamage: {
 		all: 'FU.DamagePipelineStepIncomingDamageAll',
-		physical: 'FU.DamagePipelineStepIncomingDamagePhysical',
-		air: 'FU.DamagePipelineStepIncomingDamageAir',
-		bolt: 'FU.DamagePipelineStepIncomingDamageBolt',
-		dark: 'FU.DamagePipelineStepIncomingDamageDark',
-		earth: 'FU.DamagePipelineStepIncomingDamageEarth',
-		fire: 'FU.DamagePipelineStepIncomingDamageFire',
-		ice: 'FU.DamagePipelineStepIncomingDamageIce',
-		light: 'FU.DamagePipelineStepIncomingDamageLight',
-		poison: 'FU.DamagePipelineStepIncomingDamagePoison',
 
-		beast: `FU.Beast`,
-		construct: 'FU.Construct',
-		demon: 'FU.Demon',
-		elemental: 'FU.Elemental',
-		humanoid: 'FU.Humanoid',
-		monster: 'FU.Monster',
-		plant: 'FU.Plant',
-		undead: 'FU.Undead',
+		...FU.damageTypes,
+		...FU.species,
+		...FU.weaponCategories,
 	},
 	// TODO: Better way to not duplicate?
 	damage: {
 		all: 'FU.DamageBonusAll',
-		beast: `FU.Beast`,
-		construct: 'FU.Construct',
-		demon: 'FU.Demon',
-		elemental: 'FU.Elemental',
-		humanoid: 'FU.Humanoid',
-		monster: 'FU.Monster',
-		plant: 'FU.Plant',
-		undead: 'FU.Undead',
+
+		...FU.damageTypes,
+		...FU.species,
+		...FU.weaponCategories,
 	},
 };
 
@@ -139,7 +121,7 @@ export class DamageRequest extends PipelineRequest {
  * @property {Number} affinity The index of the affinity
  * @property {String} affinityMessage The localized affinity message to use
  * @property {DamageType} damageType
- * @property {TableDamageData} damageData
+ * @property {DamageData} damageData
  * @property {DamageOverrideInfo} damageOverride
  * @property {String} extra An optional expression to evaluate for onApply damage
  * @property {Number} amount The base amount before bonuses or modifiers are applied
@@ -319,6 +301,8 @@ function overrideResult(context) {
  * @return {Promise<Boolean>}
  */
 async function collectIncrements(context) {
+	const outgoing = context.sourceActor?.system.bonuses.damage;
+
 	// Target
 	if (context.actor.system.bonuses) {
 		const incoming = context.actor.system.bonuses.incomingDamage;
@@ -332,10 +316,16 @@ async function collectIncrements(context) {
 			context.addBonus(`incomingDamage.${species}`, incoming[species] ?? 0);
 		}
 
+		// Potentially from specific weapon types, ...
+		for (const trait of context.traits) {
+			if (incoming[trait]) {
+				context.addBonus(`incomingDamage.${trait}`, incoming[trait] ?? 0);
+			}
+		}
+
 		// Potentially modify damage TO a specific species (from a PC)
-		if (context.sourceActor?.system.species && context.actor.system.species) {
+		if (outgoing && context.actor.system.species) {
 			const species = context.actor.system.species.value;
-			const outgoing = context.sourceActor.system.bonuses.damage;
 			context.addBonus(`damage.${species}`, outgoing[species] ?? 0);
 		}
 	}


### PR DESCRIPTION
This pull request refactors the way localization keys for damage types, species, and weapon categories are handled in the `damage-pipeline.mjs` module. It centralizes and simplifies the mapping of these keys by spreading from shared objects, and improves the logic for collecting damage bonuses, especially for traits and weapon types. Additionally, it clarifies some type annotations.

**Localization and bonus calculation improvements:**

* Centralized the mapping of localization keys for `damageTypes`, `species`, and `weaponCategories` in `PIPELINE_STEP_LOCALIZATION_KEYS` by spreading from shared `FU` objects, reducing duplication and making it easier to maintain.
* Enhanced the `collectIncrements` function to dynamically add incoming damage bonuses for all traits present in `context.traits`, including weapon types, by checking if a bonus exists for each trait.
* Ensured that outgoing damage bonuses are only applied when the `outgoing` bonuses object exists, improving robustness in the species bonus calculation.

**Type and variable improvements:**

* Updated the type annotation for `damageData` from `TableDamageData` to `DamageData` in the `DamageRequest` class documentation, aligning with the actual data structure used.
* Added assignment of the `outgoing` bonuses object at the start of `collectIncrements` for clearer and more consistent access.