### PR TITLE
Fix inline resources not working from non-check messages

### DIFF
--- a/module/enrichers/inline-resources.mjs
+++ b/module/enrichers/inline-resources.mjs
@@ -116,13 +116,15 @@ async function onRender(element) {
 		const targets = await targetHandler();
 		if (targets.length > 0) {
 			let context = ExpressionContext.fromSourceInfo(renderContext.sourceInfo, targets);
+
 			let check = renderContext.document.getFlag(SYSTEM, Flags.ChatMessage.Check);
 			if (check) {
 				context = context.withCheck(check);
 			}
+
 			let amount = await Expressions.evaluateAsync(renderContext.dataset.amount, context);
 
-			if (context.actor) {
+			if (context.actor && check) {
 				const config = CheckConfiguration.configure(check);
 				config.setResource(type, amount);
 				const updateData = config.getResource();

--- a/module/pipelines/resource-pipeline.mjs
+++ b/module/pipelines/resource-pipeline.mjs
@@ -157,23 +157,6 @@ function getResourceValue(actor, resourcePath) {
 	return parseInt(foundry.utils.getProperty(actor.system, resourcePath), 10) || 0;
 }
 
-/**
- * @param {FUActor} actor
- * @param {String} attributePath
- * @param {Number} amountRecovered
- * @returns {Promise<*>
- */
-function createUpdateForRecovery(actor, attributePath, amountRecovered) {
-	const currentValue = getResourceValue(actor, attributePath);
-	const newValue = Math.floor(currentValue + amountRecovered);
-
-	// Update the actor's resource directly
-	const updateData = {
-		[`system.${attributePath}`]: newValue,
-	};
-	return actor.update(updateData);
-}
-
 function calculateMissingResource(actor, resourcePath) {
 	const resource = foundry.utils.getProperty(actor.system, resourcePath);
 	return resource.max - resource.value;
@@ -235,7 +218,24 @@ async function processRecovery(request) {
 		const updates = [];
 
 		if (request.isMetaCurrency) {
-			updates.push(createUpdateForRecovery(actor, request.attributeValuePath, amountRecovered));
+			const currentValue = getResourceValue(actor, request.attributeValuePath) || 0;
+			const newValue = Math.floor(currentValue + amountRecovered);
+			const updateData = {};
+			updateData[`system.${request.attributeValuePath}`] = newValue;
+			updates.push(
+				actor.update(updateData).then(async (result) => {
+					/** @type FURenderData **/
+					let renderData = {
+						sections: [],
+						postRenderActions: [],
+					};
+					CommonEvents.gain(actor, request.resourceType, amountRecovered, request.origin);
+					await CommonEvents.resource(request.sourceActor, request.targets, request.resourceType, amountRecovered, request.origin, renderData);
+					TokenUtils.showFloatyText(actor, `${amountRecovered} ${request.resourceType.toUpperCase()}`, `lightgreen`);
+					await createChatMessage(request, actor, Math.abs(amountRecovered), flavor, template, message, renderData);
+					return result;
+				}),
+			);
 		} else {
 			// Overheal recovery (uncapped)
 			if (request.uncapped === true && uncappedRecoveryValue > (attr.max || 0)) {


### PR DESCRIPTION
This pull request makes targeted changes to how resource recovery and inline resource enrichment are handled, focusing on improving update logic and event handling. The most significant updates include refining the conditions for resource updates in inline resources, removing a redundant helper function, and inlining and enhancing the recovery update process to ensure related events and UI feedback are triggered appropriately.

**Resource update and recovery improvements:**

* In `inline-resources.mjs`, resource updates during rendering now only occur if both `context.actor` and a `check` flag are present, preventing unintended updates when a check is not involved.
* The helper function `createUpdateForRecovery` was removed from `resource-pipeline.mjs`, and its logic was inlined and expanded within the `processRecovery` function. This ensures that after a resource is updated, related events (such as `gain` and `resource`), floating text feedback, and chat messages are all triggered in sequence. [[1]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8L160-L176) [[2]](diffhunk://#diff-4d81c1a5cc01d4a7b71d74f629360f62830f0c6af7aaced27957fbe774b876d8L238-R238)