### PR TITLE
Add codex entry audio

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1934,6 +1934,7 @@
 		"OptionArcanumPulseHint": "Whether to add pulses to arcanums as per the playtest materials.",
 		"Summon": "Summon",
 		"Codex": "Codex",
+		"CodexEntry": "Codex Entry",
 		"Tags": "Tags",
 		"Hidden": "Hidden",
 		"Entry": "Entry",

--- a/module/documents/actors/party/codex-data-model.mjs
+++ b/module/documents/actors/party/codex-data-model.mjs
@@ -2,6 +2,7 @@ import { VersionedDataModel } from '../../../fields/versioned-data-model.mjs';
 import { FU } from '../../../helpers/config.mjs';
 import { systemAssetPath } from '../../../helpers/system-utils.mjs';
 import { StringUtils } from '../../../helpers/string-utils.mjs';
+import { AudioDataModel } from '../../../fields/audio-data-model.mjs';
 
 const fields = foundry.data.fields;
 
@@ -11,6 +12,7 @@ const fields = foundry.data.fields;
  * @property {String} notes GM-only notes.
  * @property {String} img The path to the image.
  * @property {String[]} tags
+ * @property {AudioDataModel} audio
  * @property {Boolean} hidden
  */
 export class CodexEntryDataModel extends foundry.abstract.DataModel {
@@ -21,6 +23,7 @@ export class CodexEntryDataModel extends foundry.abstract.DataModel {
 			name: new fields.StringField({ initial: `` }),
 			description: new fields.StringField({ initial: `` }),
 			img: new fields.FilePathField({ categories: ['IMAGE'], initial: CodexEntryDataModel.DEFAULT_IMAGE_PATH }),
+			audio: new fields.EmbeddedDataField(AudioDataModel),
 			tags: new fields.ArrayField(new fields.StringField(), {}),
 			notes: new fields.StringField({ initial: `` }),
 			hidden: new fields.BooleanField(),
@@ -30,6 +33,53 @@ export class CodexEntryDataModel extends foundry.abstract.DataModel {
 	static migrateData(source) {
 		if (!source.img) source.img = CodexEntryDataModel.DEFAULT_IMAGE_PATH;
 		return super.migrateData(source);
+	}
+
+	/**
+	 * @param {Boolean} broadcast Whether to play the sound for all connected clients.
+	 * @returns {Promise<PlaylistSound|undefined>}
+	 */
+	async playSound({ broadcast = false } = {}) {
+		if (!this.audio.path) return;
+
+		// Find or create a dedicated playlist for this module
+		const playlistName = `Fabula Ultima - ${StringUtils.localize('FU.Codex')}`;
+		let playlist = game.playlists.getName(playlistName);
+		if (!playlist) {
+			// eslint-disable-next-line no-undef
+			playlist = await Playlist.create({
+				name: playlistName,
+				mode: CONST.PLAYLIST_MODES.DISABLED, // manual control only
+			});
+		}
+
+		// Check if this sound is already in the playlist
+		let sound = playlist.sounds.find((s) => s.path === this.audio.path);
+		if (!sound) {
+			// eslint-disable-next-line no-undef
+			sound = await PlaylistSound.create(
+				{
+					name: this.name, // this.path.split('/').pop(), // filename as name
+					path: this.audio.path,
+					volume: this.audio.volume,
+					repeat: this.audio.repeat,
+					fade: this.audio.fade,
+					channel: this.audio.channel,
+				},
+				{ parent: playlist },
+			);
+		} else {
+			await sound.update({
+				name: this.name,
+				volume: this.audio.volume,
+				repeat: this.audio.repeat,
+				fade: this.audio.fade,
+				channel: this.audio.channel,
+			});
+		}
+
+		// Play via the playlist, which handles broadcast automatically
+		return playlist.playSound(sound);
 	}
 }
 

--- a/module/documents/actors/party/codex-data-model.mjs
+++ b/module/documents/actors/party/codex-data-model.mjs
@@ -35,6 +35,10 @@ export class CodexEntryDataModel extends foundry.abstract.DataModel {
 		return super.migrateData(source);
 	}
 
+	static get PLAYLIST() {
+		return `Fabula Ultima - ${StringUtils.localize('FU.Codex')}`;
+	}
+
 	/**
 	 * @param {Boolean} broadcast Whether to play the sound for all connected clients.
 	 * @returns {Promise<PlaylistSound|undefined>}
@@ -43,12 +47,11 @@ export class CodexEntryDataModel extends foundry.abstract.DataModel {
 		if (!this.audio.path) return;
 
 		// Find or create a dedicated playlist for this module
-		const playlistName = `Fabula Ultima - ${StringUtils.localize('FU.Codex')}`;
-		let playlist = game.playlists.getName(playlistName);
+		let playlist = game.playlists.getName(CodexEntryDataModel.PLAYLIST);
 		if (!playlist) {
 			// eslint-disable-next-line no-undef
 			playlist = await Playlist.create({
-				name: playlistName,
+				name: CodexEntryDataModel.PLAYLIST,
 				mode: CONST.PLAYLIST_MODES.DISABLED, // manual control only
 			});
 		}
@@ -80,6 +83,18 @@ export class CodexEntryDataModel extends foundry.abstract.DataModel {
 
 		// Play via the playlist, which handles broadcast automatically
 		return playlist.playSound(sound);
+	}
+
+	async stopSound() {
+		if (!this.audio?.path) return;
+
+		const playlist = game.playlists.getName(CodexEntryDataModel.PLAYLIST);
+		if (!playlist) return;
+
+		const sound = playlist.sounds.find((s) => s.path === this.audio.path);
+		if (!sound) return;
+
+		return playlist.stopSound(sound);
 	}
 }
 

--- a/module/fields/audio-data-model.mjs
+++ b/module/fields/audio-data-model.mjs
@@ -1,0 +1,22 @@
+/**
+ * @desc Used to hold data for audio playback.
+ * @remarks Attempts to mirror Foundry's internal API (BasePlaylistSound).
+ * @property {String} path
+ * @property {Number} volume
+ * @property {Boolean} repeat
+ * @property {String} channel
+ */
+export class AudioDataModel extends foundry.abstract.DataModel {
+	static CHANNELS = ['music', 'environment', 'interface'];
+
+	static defineSchema() {
+		const fields = foundry.data.fields;
+		return {
+			path: new fields.FilePathField({ categories: ['AUDIO'], initial: '', blank: true }),
+			volume: new fields.AlphaField({ initial: 0.25 }),
+			repeat: new fields.BooleanField({ initial: false }),
+			fade: new fields.NumberField({ initial: 0, min: 0 }),
+			channel: new fields.StringField({ initial: 'environment', choices: AudioDataModel.CHANNELS }),
+		};
+	}
+}

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -223,9 +223,15 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 	 * @returns {Promise<void>}
 	 */
 	static async #removeArrayElement(event, target) {
-		const path = target.dataset.path;
+		const { path, prompt, label } = target.dataset;
 		const index = Number.parseInt(target.dataset.index);
 		if (path) {
+			if (prompt) {
+				const confirm = await FoundryUtils.confirmDialog(StringUtils.localize(`FU.Remove`), StringUtils.localize('FU.DialogRemoveMessage', { label: label ?? 'FU.Entry' }));
+				if (!confirm) {
+					return;
+				}
+			}
 			/** @type [] **/
 			const array = ObjectUtils.getProperty(this.actor, path);
 			if (array && index !== undefined) {

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -182,11 +182,6 @@ export class CodexBrowser {
 		if (!entry) {
 			return;
 		}
-		if (entry.toObject) {
-			entry = entry.toObject();
-		}
-		entry = foundry.utils.deepClone(entry);
-
 		switch (type) {
 			case 'view':
 				{
@@ -196,6 +191,10 @@ export class CodexBrowser {
 
 			case 'edit':
 				{
+					if (entry.toObject) {
+						entry = entry.toObject();
+					}
+					entry = foundry.utils.deepClone(entry);
 					const ok = await this.editCodexEntry(entry);
 					if (ok) {
 						entries[index] = entry;
@@ -220,6 +219,10 @@ export class CodexBrowser {
 
 			case 'display':
 				FoundryUtils.popoutImage(entry.img, entry.name);
+				break;
+
+			case 'playSound':
+				await entry.playSound();
 				break;
 		}
 	}
@@ -333,6 +336,10 @@ export class CodexBrowser {
 		const context = {
 			entry,
 			tags: this.party.codex.tags,
+			audioChannels: Object.entries(CONST.AUDIO_CHANNELS).reduce((channels, [key, value]) => {
+				channels[key] = game.i18n.localize(value);
+				return channels;
+			}, {}),
 		};
 		const content = await FoundryUtils.renderTemplate('actor/party/actor-party-edit-codex-entry', context);
 
@@ -380,6 +387,13 @@ export class CodexBrowser {
 					description: dialog.element.querySelector('[name="description"]').value.trim(),
 					notes: dialog.element.querySelector('[name="notes"]').value.trim(),
 					hidden: dialog.element.querySelector('[name="hidden"]').checked,
+
+					audio: {
+						path: dialog.element.querySelector('[name="audio.path"]').value.trim(),
+						volume: parseFloat(dialog.element.querySelector('[name="audio.volume"]').value),
+						channel: dialog.element.querySelector('[name="audio.channel"]').value.trim(),
+						repeat: dialog.element.querySelector('[name="audio.repeat"]').checked,
+					},
 				}),
 			},
 		});
@@ -392,6 +406,9 @@ export class CodexBrowser {
 		entry.description = result.description;
 		entry.hidden = result.hidden;
 		entry.notes = result.notes;
+
+		entry.audio = result.audio;
+
 		return true;
 	}
 

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -229,12 +229,12 @@ export class CodexBrowser {
 
 			case 'playSound':
 				await entry.playSound();
-				this.sheet.render({ parts: ['codex'] });
+				this.sheet.render(true);
 				break;
 
 			case 'stopSound':
 				await entry.stopSound();
-				this.sheet.render({ parts: ['codex'] });
+				this.sheet.render(true);
 				break;
 		}
 	}

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -70,6 +70,12 @@ export class CodexBrowser {
 	 */
 	async prepareContext(context) {
 		context.browser = this;
+		context.playingSounds = new Set(
+			game.playlists.contents
+				.flatMap((p) => p.sounds.contents)
+				.filter((s) => s.playing)
+				.map((s) => s.name),
+		);
 	}
 
 	/**
@@ -223,6 +229,12 @@ export class CodexBrowser {
 
 			case 'playSound':
 				await entry.playSound();
+				this.sheet.render({ parts: ['codex'] });
+				break;
+
+			case 'stopSound':
+				await entry.stopSound();
+				this.sheet.render({ parts: ['codex'] });
 				break;
 		}
 	}

--- a/styles/css/actor/party.css
+++ b/styles/css/actor/party.css
@@ -330,6 +330,8 @@
 				flex-direction: column;
 				justify-content: center;
 				gap: 8px;
+				min-width: 128px;
+				max-width: 128px;
 
 				img {
 					object-fit: cover;
@@ -343,8 +345,13 @@
 					display: flex;
 					flex-direction: row;
 					flex-wrap: nowrap;
+					justify-content: center;
+					gap: 1px;
 
 					button {
+						width: 24px;
+						height: 24px;
+						padding: 0;
 					}
 				}
 			}

--- a/styles/css/global/dialog.css
+++ b/styles/css/global/dialog.css
@@ -9,7 +9,7 @@
 
 	.image-picker {
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 		gap: 1rem;
 		width: 100%;
 
@@ -71,6 +71,13 @@
 		font-size: 16px;
 		text-align: justify;
 	}
+
+	.group {
+		border: 2px solid var(--pfu-color-app-control-border);
+		background: var(--pfu-color-control-content);
+		border-radius: var(--pfu-border-radius-small);
+		padding: 4px;
+	}
 }
 
 .fu-dialog form main {
@@ -90,7 +97,6 @@
 	text-align: center;
 	border: 1px solid var(--color-border-divider);
 	background: var(--pfu-color-app-control-fill);
-	color: var(--pfu-color-app-control-content);
 	border-radius: var(--pfu-border-radius-small);
 }
 

--- a/templates/actor/party/actor-party-edit-codex-entry.hbs
+++ b/templates/actor/party/actor-party-edit-codex-entry.hbs
@@ -1,8 +1,16 @@
 <fieldset>
-	<label class="pfu-dialog__input">
-		<span>{{localize "FU.Name"}}</span>
-		<input type="text" name="name" value="{{entry.name}}" />
-	</label>
+
+	<div class="flexrow flex-group-center">
+		<label class="pfu-dialog__input">
+			<span>{{localize "FU.Name"}}</span>
+			<input type="text" name="name" value="{{entry.name}}" />
+		</label>
+
+		<label class="pfu-dialog__input">
+			<span>{{localize "FU.Hidden"}}</span>
+			<input type="checkbox" name="hidden" {{checked entry.hidden}} />
+		</label>
+	</div>
 
 	<div class="pfu-dialog__input">
 		<span>{{localize "FU.Tags"}}</span>
@@ -42,8 +50,44 @@
 	</div>
 
 	<label class="pfu-dialog__input">
-		<span>{{localize "FU.Hidden"}}</span>
-		<input type="checkbox" name="hidden" {{checked entry.hidden}} />
+		<span>{{localize "Sound"}}</span>
+		<div class="grid-2col gap-16">
+
+			<div class="fu-form__property-row">
+				<label class="fu-form__property">
+					<span>{{localize 'PLAYLIST_SOUND.FIELDS.path.label'}}</span>
+					<input type="text" name="audio.path" value="{{entry.audio.path}}">
+					<button type="button" data-action="browse"
+							data-type="audio"
+							data-tooltip="FU.Browse"
+							data-name="audio.path">
+						<i class="fas fa-file-audio"></i>
+					</button>
+				</label>
+				<label class="fu-form__property">
+					<span>{{localize 'PLAYLIST_SOUND.FIELDS.channel.label'}}</span>
+					<select name="audio.channel" class="">
+						{{selectOptions audioChannels selected=entry.audio.channel localize=true}}
+					</select>
+				</label>
+			</div>
+
+			<div class="fu-form__property-row">
+				<label class="fu-form__property">
+					<span>{{localize 'PLAYLIST_SOUND.FIELDS.repeat.label'}}</span>
+					<input type="checkbox" name="audio.repeat" {{checked entry.audio.repeat}} />
+				</label>
+				<label class="fu-form__property">
+					<span>{{localize 'PLAYLIST_SOUND.FIELDS.volume.label'}}</span>
+					<div class="form-fields">
+						<input type="range"
+							   name="audio.volume"
+							   value="{{entry.audio.volume}}"
+							   min="0" max="1" step="0.05" />
+					</div>
+				</label>
+			</div>
+		</div>
 	</label>
 
 	<div class="pfu-dialog__input">

--- a/templates/actor/party/actor-party-edit-codex-entry.hbs
+++ b/templates/actor/party/actor-party-edit-codex-entry.hbs
@@ -1,6 +1,5 @@
 <fieldset>
-
-	<div class="flexrow flex-group-center">
+	<div class="flexrow flex-group-center gap-16">
 		<label class="pfu-dialog__input">
 			<span>{{localize "FU.Name"}}</span>
 			<input type="text" name="name" value="{{entry.name}}" />

--- a/templates/actor/party/actor-party-edit-codex-entry.hbs
+++ b/templates/actor/party/actor-party-edit-codex-entry.hbs
@@ -11,83 +11,72 @@
 		</label>
 	</div>
 
-	<div class="pfu-dialog__input">
-		<span>{{localize "FU.Tags"}}</span>
-		<div class="pfu-tag-selector">
-			{{#each tags as |tag|}}
-				<div class="tag {{#if (pfuCollectionContains tag ../entry.tags)}}active{{/if}}"
-					 data-action="toggleTag"
-					 data-path="entry.tags"
-					 data-tag="{{tag}}">
-					{{pfuHumanize tag}}
-				</div>
-			{{/each}}
-		</div>
-	</div>
 
-	<div class="pfu-dialog__input">
-		<span>{{localize "FU.Image"}}</span>
-		<div class="image-picker">
-			<img class="" src="{{lookup entry 'img'}}"
-				 title="{{entry.name}}" alt=""/>
-			<div class="inputs">
-				<label>
-					<input type="text" name="img" value="{{entry.img}}" />
-				</label>
-				<button type="button" data-action="browseImage"
-						data-tooltip="FU.BrowseImage"
-						data-name="img">
-					<i class="fas fa-file-image"></i>
-				</button>
-				<button type="button" data-action="clipboardImage"
-						data-tooltip="FU.UploadClipboardImage"
-						data-name="img">
-					<i class="fas fa-file-clipboard"></i>
-				</button>
-			</div>
-		</div>
-	</div>
 
-	<label class="pfu-dialog__input">
-		<span>{{localize "Sound"}}</span>
-		<div class="grid-2col gap-16">
-
-			<div class="fu-form__property-row">
-				<label class="fu-form__property">
-					<span>{{localize 'PLAYLIST_SOUND.FIELDS.path.label'}}</span>
-					<input type="text" name="audio.path" value="{{entry.audio.path}}">
-					<button type="button" data-action="browse"
-							data-type="audio"
-							data-tooltip="FU.Browse"
-							data-name="audio.path">
-						<i class="fas fa-file-audio"></i>
+	<div class="flexrow flex-group-center gap-16">
+		<div class="pfu-dialog__input">
+			<span>{{localize "Image"}}</span>
+			<div class="image-picker">
+				<img class="" src="{{lookup entry 'img'}}"
+					 title="{{entry.name}}" alt=""/>
+				<div class="inputs">
+					<label>
+						<input type="text" name="img" value="{{entry.img}}" />
+					</label>
+					<button type="button" data-action="browseImage"
+							data-tooltip="FU.BrowseImage"
+							data-name="img">
+						<i class="fas fa-file-image"></i>
 					</button>
-				</label>
-				<label class="fu-form__property">
-					<span>{{localize 'PLAYLIST_SOUND.FIELDS.channel.label'}}</span>
-					<select name="audio.channel" class="">
-						{{selectOptions audioChannels selected=entry.audio.channel localize=true}}
-					</select>
-				</label>
-			</div>
-
-			<div class="fu-form__property-row">
-				<label class="fu-form__property">
-					<span>{{localize 'PLAYLIST_SOUND.FIELDS.repeat.label'}}</span>
-					<input type="checkbox" name="audio.repeat" {{checked entry.audio.repeat}} />
-				</label>
-				<label class="fu-form__property">
-					<span>{{localize 'PLAYLIST_SOUND.FIELDS.volume.label'}}</span>
-					<div class="form-fields">
-						<input type="range"
-							   name="audio.volume"
-							   value="{{entry.audio.volume}}"
-							   min="0" max="1" step="0.05" />
-					</div>
-				</label>
+					<button type="button" data-action="clipboardImage"
+							data-tooltip="FU.UploadClipboardImage"
+							data-name="img">
+						<i class="fas fa-file-clipboard"></i>
+					</button>
+				</div>
 			</div>
 		</div>
-	</label>
+
+		<div class="pfu-dialog__input" style="height: 100%">
+			<span>{{localize "Sound"}}</span>
+			<div class="flexcol flex-group-center group">
+				<div class="fu-form__property-row">
+					<label class="fu-form__property">
+						<span>{{localize 'PLAYLIST_SOUND.FIELDS.path.label'}}</span>
+						<input type="text" name="audio.path" value="{{entry.audio.path}}">
+						<button type="button" data-action="browse"
+								data-type="audio"
+								data-tooltip="FU.Browse"
+								data-name="audio.path">
+							<i class="fas fa-file-audio"></i>
+						</button>
+					</label>
+					<label class="fu-form__property">
+						<span>{{localize 'PLAYLIST_SOUND.FIELDS.channel.label'}}</span>
+						<select name="audio.channel" class="">
+							{{selectOptions audioChannels selected=entry.audio.channel localize=true}}
+						</select>
+					</label>
+				</div>
+
+				<div class="fu-form__property-row">
+					<label class="fu-form__property">
+						<span>{{localize 'PLAYLIST_SOUND.FIELDS.repeat.label'}}</span>
+						<input type="checkbox" name="audio.repeat" {{checked entry.audio.repeat}} />
+					</label>
+					<label class="fu-form__property">
+						<span>{{localize 'PLAYLIST_SOUND.FIELDS.volume.label'}}</span>
+						<div class="form-fields">
+							<input type="range"
+								   name="audio.volume"
+								   value="{{entry.audio.volume}}"
+								   min="0" max="1" step="0.05" />
+						</div>
+					</label>
+				</div>
+			</div>
+		</div>
+	</div>
 
 	<div class="pfu-dialog__input">
 		<span>{{localize "FU.Description"}}</span>

--- a/templates/actor/party/actor-party-section-codex.hbs
+++ b/templates/actor/party/actor-party-section-codex.hbs
@@ -62,11 +62,19 @@
 									<i class="fu-icon--xs fas fa-comment"></i>
 								</button>
 								{{#if (and entry.audio.path @root.isGM)}}
-									<button data-action="forCodexEntry"
-											data-type="playSound"
-											data-index="{{index}}">
-										<i class="fu-icon--xs fas fa-play"></i>
-									</button>
+									{{#if (pfuCollectionContains entry.name ../playingSounds)}}
+										<button data-action="forCodexEntry"
+												data-type="stopSound"
+												data-index="{{index}}">
+											<i class="fu-icon--xs fas fa-stop"></i>
+										</button>
+									{{else}}
+										<button data-action="forCodexEntry"
+												data-type="playSound"
+												data-index="{{index}}">
+											<i class="fu-icon--xs fas fa-play"></i>
+										</button>
+									{{/if}}
 								{{/if}}
 								<button data-action="removeArrayElement"
 										data-prompt="true"

--- a/templates/actor/party/actor-party-section-codex.hbs
+++ b/templates/actor/party/actor-party-section-codex.hbs
@@ -61,12 +61,6 @@
 										data-index="{{index}}">
 									<i class="fu-icon--xs fas fa-comment"></i>
 								</button>
-								<button data-action="removeArrayElement"
-										data-prompt="true"
-										data-label="{{localize 'FU.CodexEntry'}}"
-										data-path="system.codex.entries"
-										data-index="{{index}}"
-										title="FU.Delete">✕</button>
 								{{#if (and entry.audio.path @root.isGM)}}
 									<button data-action="forCodexEntry"
 											data-type="playSound"
@@ -74,6 +68,13 @@
 										<i class="fu-icon--xs fas fa-play"></i>
 									</button>
 								{{/if}}
+								<button data-action="removeArrayElement"
+										data-prompt="true"
+										data-label="{{entry.name}}"
+										data-path="system.codex.entries"
+										data-index="{{index}}"
+										title="Delete">✕
+								</button>
 							</div>
 						{{/if}}
 					</div>

--- a/templates/actor/party/actor-party-section-codex.hbs
+++ b/templates/actor/party/actor-party-section-codex.hbs
@@ -47,7 +47,9 @@
 								<button data-action="forCodexEntry"
 										data-type="edit"
 										data-index="{{index}}"
-										title="Edit">✎</button>
+										title="Edit">
+									<i class="fu-icon--xs fa-solid fa-edit"></i>
+								</button>
 								<button data-action="forCodexEntry"
 										data-type="display"
 										data-index="{{index}}"
@@ -60,9 +62,18 @@
 									<i class="fu-icon--xs fas fa-comment"></i>
 								</button>
 								<button data-action="removeArrayElement"
+										data-prompt="true"
+										data-label="{{localize 'FU.CodexEntry'}}"
 										data-path="system.codex.entries"
 										data-index="{{index}}"
 										title="FU.Delete">✕</button>
+								{{#if (and entry.audio.path @root.isGM)}}
+									<button data-action="forCodexEntry"
+											data-type="playSound"
+											data-index="{{index}}">
+										<i class="fu-icon--xs fas fa-play"></i>
+									</button>
+								{{/if}}
 							</div>
 						{{/if}}
 					</div>


### PR DESCRIPTION
This pull request adds audio support to Codex entries, allowing each entry to have an associated sound that can be played or stopped directly from the UI. It introduces a new `AudioDataModel`, updates the data model and UI to support audio fields, and enhances user experience with improved controls and dialogs. Some minor style adjustments are also included.

**Audio support for Codex entries:**

* Added a new `AudioDataModel` to encapsulate audio properties such as path, volume, repeat, fade, and channel. (`module/fields/audio-data-model.mjs`)
* Extended `CodexEntryDataModel` to include an embedded `audio` field and methods to play and stop sounds, managing a dedicated playlist for Codex entries. (`module/documents/actors/party/codex-data-model.mjs`) [[1]](diffhunk://#diff-041839065330949f37f6ca625d336fd8a42e677f53818ee2db11f1581fa6808eR5) [[2]](diffhunk://#diff-041839065330949f37f6ca625d336fd8a42e677f53818ee2db11f1581fa6808eR15) [[3]](diffhunk://#diff-041839065330949f37f6ca625d336fd8a42e677f53818ee2db11f1581fa6808eR26) [[4]](diffhunk://#diff-041839065330949f37f6ca625d336fd8a42e677f53818ee2db11f1581fa6808eR37-R98)
* Updated the Codex entry edit dialog to allow setting audio properties, including file path, volume, repeat, and channel, with UI controls for each. (`templates/actor/party/actor-party-edit-codex-entry.hbs`, `module/ui/codex-browser.mjs`) [[1]](diffhunk://#diff-a36319f037e789f02a1ed8776270e15cbfcc5822d9287b99de4cf4dcb3708723L44-R79) [[2]](diffhunk://#diff-01d0a91c67c5848e2491752820b8dd7b08c88cc46139ce3d67d4ec3c8d5a9651R351-R354) [[3]](diffhunk://#diff-01d0a91c67c5848e2491752820b8dd7b08c88cc46139ce3d67d4ec3c8d5a9651R402-R408) [[4]](diffhunk://#diff-01d0a91c67c5848e2491752820b8dd7b08c88cc46139ce3d67d4ec3c8d5a9651R421-R423)

**UI and user experience improvements:**

* Added play/stop audio buttons for Codex entries in the Codex section, visible to GMs when an audio path is set, and visually indicate which sounds are currently playing. (`templates/actor/party/actor-party-section-codex.hbs`, `module/ui/codex-browser.mjs`) [[1]](diffhunk://#diff-04cb3c6429663c44e9091e7894a753a9e1fc5ec39c966db5d0e2eacc4b352b5aR64-R85) [[2]](diffhunk://#diff-01d0a91c67c5848e2491752820b8dd7b08c88cc46139ce3d67d4ec3c8d5a9651R229-R238) [[3]](diffhunk://#diff-01d0a91c67c5848e2491752820b8dd7b08c88cc46139ce3d67d4ec3c8d5a9651R73-R78)
* Improved array element removal by adding a confirmation dialog and better labeling for the delete button. (`module/sheets/actor-sheet.mjs`, `templates/actor/party/actor-party-section-codex.hbs`) [[1]](diffhunk://#diff-5c0a6ab02dc80ae1803d53f895801d17cf45cda3e151d0dd6a30289e2d4edd3cL226-R234) [[2]](diffhunk://#diff-04cb3c6429663c44e9091e7894a753a9e1fc5ec39c966db5d0e2eacc4b352b5aR64-R85)

**Styling and layout adjustments:**

* Refined dialog and Codex entry layouts for better alignment, spacing, and grouping of controls, including new group boxes for audio controls. (`styles/css/actor/party.css`, `styles/css/global/dialog.css`, `templates/actor/party/actor-party-edit-codex-entry.hbs`) [[1]](diffhunk://#diff-59266c8bd96787bceff2148a6c45f0f469b2371d95dc37361af92daf1235dd55R333-R334) [[2]](diffhunk://#diff-59266c8bd96787bceff2148a6c45f0f469b2371d95dc37361af92daf1235dd55R348-R354) [[3]](diffhunk://#diff-ba14f6ba3df81e011abe9e24f2069684973db6e7c0029c7f176f97c8a5c903c1L12-R12) [[4]](diffhunk://#diff-ba14f6ba3df81e011abe9e24f2069684973db6e7c0029c7f176f97c8a5c903c1R74-R80) [[5]](diffhunk://#diff-ba14f6ba3df81e011abe9e24f2069684973db6e7c0029c7f176f97c8a5c903c1L93) [[6]](diffhunk://#diff-a36319f037e789f02a1ed8776270e15cbfcc5822d9287b99de4cf4dcb3708723L44-R79)

**Localization:**

* Added a new localization string for "Codex Entry". (`lang/en.json`)

These changes collectively enhance the functionality and usability of Codex entries by integrating audio playback features and improving the related UI components.