### PR TITLE
More Clock Trackable Resources

### DIFF
--- a/module/documents/actors/character/character-data-model.mjs
+++ b/module/documents/actors/character/character-data-model.mjs
@@ -240,7 +240,7 @@ export class CharacterDataModel extends BaseCharacterDataModel {
 
 	#prepareClockResources() {
 		this.addClockResource('brainwave', 'brainwave-clock');
-		this.addClockResource('garden', 'floralist-garden');
+		this.addClockResource('garden', 'garden');
 		this.addClockResource('zeroPower', 'zero-power');
 	}
 }

--- a/module/documents/actors/character/character-data-model.mjs
+++ b/module/documents/actors/character/character-data-model.mjs
@@ -241,5 +241,6 @@ export class CharacterDataModel extends BaseCharacterDataModel {
 	#prepareClockResources() {
 		this.addClockResource('brainwave', 'brainwave-clock');
 		this.addClockResource('garden', 'floralist-garden');
+		this.addClockResource('zeroPower', 'zero-power');
 	}
 }

--- a/module/documents/actors/character/character-data-model.mjs
+++ b/module/documents/actors/character/character-data-model.mjs
@@ -240,5 +240,6 @@ export class CharacterDataModel extends BaseCharacterDataModel {
 
 	#prepareClockResources() {
 		this.addClockResource('brainwave', 'brainwave-clock');
+		this.addClockResource('garden', 'floralist-garden');
 	}
 }

--- a/module/documents/actors/character/character-data-model.mjs
+++ b/module/documents/actors/character/character-data-model.mjs
@@ -109,6 +109,7 @@ export class CharacterDataModel extends BaseCharacterDataModel {
 		this.resources.hp.attribute = 'mig';
 		this.resources.mp.attribute = 'wlp';
 		this.#prepareBasicResources();
+		this.#prepareClockResources();
 		this.vehicle.prepareData();
 		this.floralist.prepareData();
 		this.derived.prepareData();
@@ -235,5 +236,9 @@ export class CharacterDataModel extends BaseCharacterDataModel {
 		// Initialize fp and exp
 		this.resources.fp.value = this.resources.fp.value || 0;
 		this.resources.exp.value = this.resources.exp.value || 0;
+	}
+
+	#prepareClockResources() {
+		this.addClockResource('brainwave', 'brainwave-clock');
 	}
 }

--- a/module/documents/actors/common/base-character-data-model.mjs
+++ b/module/documents/actors/common/base-character-data-model.mjs
@@ -35,6 +35,38 @@ export class BaseCharacterDataModel extends foundry.abstract.TypeDataModel {
 	}
 
 	/**
+	 * Adds a trackable resource to the clocks property of this DataModel
+	 * @param {string} key - Key name for the clock to be added to the DataModel
+	 * @param {string} fuid - fuid of the progress clock -- will be resolved with {@link FUActor.resolveProgress}
+	 */
+	addClockResource(key, fuid) {
+		this.clocks ??= {};
+		this.clocks[key] ??= {};
+
+		const actor = this.parent;
+
+		Object.defineProperty(this.clocks[key], 'value', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				const clock = actor?.resolveProgress(fuid);
+				if (!clock) return 0;
+				return clock.current;
+			},
+		});
+
+		Object.defineProperty(this.clocks[key], 'max', {
+			configurable: true,
+			enumerable: true,
+			get() {
+				const clock = actor?.resolveProgress(fuid);
+				if (!clock) return 0;
+				return clock.max;
+			},
+		});
+	}
+
+	/**
 	 * @return FUActor
 	 */
 	get actor() {

--- a/module/documents/actors/npc/npc-data-model.mjs
+++ b/module/documents/actors/npc/npc-data-model.mjs
@@ -225,38 +225,6 @@ export class NpcDataModel extends BaseCharacterDataModel {
 		});
 	}
 
-	/**
-	 * Adds a trackable resource to the clocks property of this DataModel
-	 * @param {string} key - Key name for the clock to be added to the DataModel
-	 * @param {string} fuid - fuid of the progress clock -- will be resolved with {@link FUActor.resolveProgress}
-	 */
-	addClockResource(key, fuid) {
-		this.clocks ??= {};
-		this.clocks[key] ??= {};
-
-		const actor = this.parent;
-
-		Object.defineProperty(this.clocks[key], 'value', {
-			configurable: true,
-			enumerable: true,
-			get() {
-				const clock = actor?.resolveProgress(fuid);
-				if (!clock) return 0;
-				return clock.current;
-			},
-		});
-
-		Object.defineProperty(this.clocks[key], 'max', {
-			configurable: true,
-			enumerable: true,
-			get() {
-				const clock = actor?.resolveProgress(fuid);
-				if (!clock) return 0;
-				return clock.max;
-			},
-		});
-	}
-
 	#prepareClockResources() {
 		this.addClockResource('pressure', 'pressure');
 	}

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -269,7 +269,7 @@ Hooks.once('init', async () => {
 
 	CONFIG.Actor.trackableAttributes = {
 		character: {
-			bar: ['resources.hp', 'resources.mp', 'resources.ip', 'clocks.brainwave'],
+			bar: ['resources.hp', 'resources.mp', 'resources.ip', 'clocks.brainwave', 'clocks.garden'],
 			value: ['resources.fp.value', 'resources.exp.value'],
 		},
 		npc: {

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -282,6 +282,10 @@ Hooks.once('init', async () => {
 		CONFIG.Actor.trackableAttributes.npc.bar.push('clocks.pressure');
 	}
 
+	if (game.settings.get(SYSTEM, SETTINGS.optionZeroPower)) {
+		CONFIG.Actor.trackableAttributes.character.bar.push('clocks.zeroPower');
+	}
+
 	// Set combat tracker
 	console.log(`${SYSTEM} | Initializing combat tracker`);
 	CONFIG.Combat.documentClass = FUCombat;

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -7,7 +7,7 @@ import { FUStandardItemSheet } from './sheets/item-standard-sheet.mjs';
 // Import helper/utility classes and constants.
 import { preloadHandlebarsTemplates } from './helpers/templates.mjs';
 import { FU, SYSTEM } from './helpers/config.mjs';
-import { registerSystemSettings } from './settings.js';
+import { registerSystemSettings, SETTINGS } from './settings.js';
 import { FUCombatTracker } from './ui/combat-tracker.mjs';
 import { FUCombat, FUCombatDataModel } from './ui/combat.mjs';
 import { FUCombatant } from './ui/combatant.mjs';
@@ -233,16 +233,7 @@ Hooks.once('init', async () => {
 		party: PartyDataModel,
 		stash: StashDataModel,
 	};
-	CONFIG.Actor.trackableAttributes = {
-		character: {
-			bar: ['resources.hp', 'resources.mp', 'resources.ip'],
-			value: ['resources.fp.value', 'resources.exp.value'],
-		},
-		npc: {
-			bar: ['resources.hp', 'resources.mp', 'clocks.pressure'],
-			value: ['resources.fp.value'],
-		},
-	};
+
 	CONFIG.Item.documentClass = FUItem;
 	CONFIG.Item.dataModels = {
 		accessory: AccessoryDataModel,
@@ -275,6 +266,21 @@ Hooks.once('init', async () => {
 	// Register system settings
 	await registerSystemSettings();
 	await registerKeyBindings();
+
+	CONFIG.Actor.trackableAttributes = {
+		character: {
+			bar: ['resources.hp', 'resources.mp', 'resources.ip', 'clocks.brainwave'],
+			value: ['resources.fp.value', 'resources.exp.value'],
+		},
+		npc: {
+			bar: ['resources.hp', 'resources.mp'],
+			value: ['resources.fp.value'],
+		},
+	};
+
+	if (game.settings.get(SYSTEM, SETTINGS.pressureSystem)) {
+		CONFIG.Actor.trackableAttributes.npc.bar.push('clocks.pressure');
+	}
 
 	// Set combat tracker
 	console.log(`${SYSTEM} | Initializing combat tracker`);


### PR DESCRIPTION
- Moves `addClockResource` function from `NPCDataModel` to `BaseDataModel`, which it should have been in in the first place (and I just completely missed azurelol's request to move it in the previous PR, woops)
- Only registers the pressure clock as a trackable resource if the pressure system is enabled
- Adds Zero Power clock as a trackable resource, if Zero Powers are enabled
  - This expects the Zero Power to have the fuid `zero-power`, which is the default when creating one
- Adds the Brainwave Clock as a trackable resource, using the fuid `brainwave-clock`
- Adds Garden Clock as a trackable resource, using the fuid `floralist-garden`