### PR TITLE
Combat-hud performance fixes & Sizing

### DIFF
--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -639,7 +639,7 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 			hudWidth = minWidth;
 		}
 
-		let uiRightWidth = uiRight.length ? uiRight.clientWidth : 0;
+		let uiRightWidth = uiRight ? uiRight.clientWidth : 0;
 		hudWidth -= uiRightWidth * 0.5;
 
 		const alpha = game.settings.get(SYSTEM, SETTINGS.optionCombatHudWidth) / 100;

--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -104,6 +104,7 @@ Hooks.once(FUHooks.GET_SIDEBAR_TOOLS, (tools) => {
 export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2) {
 	#hooks = [];
 	#renderTimer = null
+	#effectContextMenu = null;
 
 	static DEFAULT_OPTIONS = {
 		id: 'combat-hud',
@@ -529,7 +530,8 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 	}
 
 	_setEffectContextMenus() {
-		new foundry.applications.ux.ContextMenu(
+		if (this.#effectContextMenu) return;
+		this.#effectContextMenu = new foundry.applications.ux.ContextMenu(
 			this.element,
 			'.combat-effects [data-effect-id][data-actor-id]',
 			[

--- a/module/ui/combat-hud.mjs
+++ b/module/ui/combat-hud.mjs
@@ -103,6 +103,7 @@ Hooks.once(FUHooks.GET_SIDEBAR_TOOLS, (tools) => {
 
 export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMixin(foundry.applications.api.ApplicationV2) {
 	#hooks = [];
+	#renderTimer = null
 
 	static DEFAULT_OPTIONS = {
 		id: 'combat-hud',
@@ -1072,17 +1073,14 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 
 	_onUpdateHUD_Round() {
 		this._onUpdateHUD();
-
-		setTimeout(() => {
-			this._onUpdateHUD();
-		}, 300);
 	}
 
 	_onUpdateHUD() {
 		if (!game.combat) return;
 		if (!game.combat.isActive) return;
 
-		this.render(true);
+		clearTimeout(this.#renderTimer);
+		this.#renderTimer = setTimeout(() => this.render(true), 50);
 	}
 
 	_onUpdateCombatant() {
@@ -1219,6 +1217,7 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 	}
 
 	_onCombatEnd() {
+		clearTimeout(this.#renderTimer);
 		this._resetCombatState(!game.settings.get(SYSTEM, SETTINGS.optionCombatHudSaved));
 		this._resetButtons();
 		this.close();
@@ -1245,6 +1244,7 @@ export class CombatHUD extends foundry.applications.api.HandlebarsApplicationMix
 	}
 
 	unregisterHooks() {
+		clearTimeout(this.#renderTimer);
 		this.#hooks.forEach(({ hook, func }) => Hooks.off(hook, func));
 	}
 


### PR DESCRIPTION
Found a couple items when trying to hunt down why longer combat sessions were causing issues with players on weaker internet connections.

### 7af9631 - Moved debounce from _onUpdateHUD_Round to _onUpdateHUD to manage multiple render events and dropped to 50ms to accomodate render per actor

Steps to Reproduce:
1. Add Logging at the top of `_prepareContext`
2. Enable combat-hud
3. Start conflict
4. Start Turn

Each Turn emits a render for each actor in the tracker (and a few others). With this change, the log will show once or twice per Turn.

### https://github.com/League-of-Fabulous-Developers/FoundryVTT-Fabula-Ultima/commit/db0d7c4401c33d67b500e814e6fa6570b8e88260 - Add Guard to prevent leak of EffectContextMenus on each turn

It seems Foundry's stopping the propagation of events from being a big issue, and I can't seem to make it cause a visible issue but seems like there's a non-zero impact.

Steps to Reproduce:
1. Inspect combat-hud view event listeners, see `n` contextmenu listeners
2. Enable combat-hud
3. Start conflict
4. Start Turn 1, 2, 3, ...
5. Inspect combat-hud view event listeners, see >`n` contextmenu listeners

#### Init
<img width="522" height="486" alt="Init" src="https://github.com/user-attachments/assets/1f34310a-4bc5-4613-94d3-55692f717ccf" />

#### After 7 Turns on 7 Actors
<img width="518" height="1514" alt="7 turns - 1 Round" src="https://github.com/user-attachments/assets/bb29441f-d05b-4bd4-a15a-4eb482c12ea2" />

### https://github.com/League-of-Fabulous-Developers/FoundryVTT-Fabula-Ultima/commit/ab2b4d999bae8206f1dcc496c12743813b3ddef6 - uiRight.length is always undefined and defaults uiRightWidth to 0

Was looking into using viewport units and saw this logic was off. This seemed like a better idea. Removing `.length` seemed like the intended use here.

Steps to Reproduce:
1. Add breakpoint on `let uiRightWidth = uiRight.length ? uiRight.clientWidth : 0;`
2. `uiRight.length` is undefined
3. sets as 0
