### PR TITLE
Compendium Update - Heroic Classes & Spellblade Fix

### DIFF
--- a/src/packs/heroic-skills/heroic_Ambidextrous_wr1if7rQttzxelbV.json
+++ b/src/packs/heroic-skills/heroic_Ambidextrous_wr1if7rQttzxelbV.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Ace of Cards, Arcanist, Chanter, Chimerist, Commander, Dancer, Darkblade, Elementalist, Entropist, Esper, Floralist, Fury, Gourmet, Guardian, Invoker, Loremaster, Merchant, Mutant, Necromancer, Orator, Pilot, Rogue, Sharpshooter, Spiritist, Symbolist, Tinkerer, Wayfarer, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -184,7 +184,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706583614340,
-    "modifiedTime": 1771887148248,
+    "modifiedTime": 1775356028642,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Anatomist_yfJzxbsgRbI0LCpt.json
+++ b/src/packs/heroic-skills/heroic_Anatomist_yfJzxbsgRbI0LCpt.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Fury</strong>, <strong>Loremaster</strong>, <strong>Sharpshooter</strong> and <strong>Weaponmaster</strong>, and have acquired the <strong>Knowledge is Power</strong> Skill.</p><hr /><p>Whenever you acquire this Heroic Skill, choose <strong>two</strong> Species among <strong>beast</strong>, <strong>construct</strong>, <strong>demon</strong>, <strong>elemental</strong>, <strong>monster</strong>, <strong>plant</strong>, and <strong>undead</strong>.</p><p>When you deal damage to a creature belonging to the <strong>humanoid</strong> Species or to a Species you have chosen for this Heroic Skill, you may choose one option:</p><ul><li><p>You deal 5 extra damage to that creature.</p></li><li><p>That creature becomes <strong>reeling</strong> until the end of the scene. When a <strong>reeling</strong> creature recovers Hit Points and/or Mind Points, instead that creature recovers <strong>half</strong> the normal amount of HP and/or MP and is no longer <strong>reeling</strong>.</p></li></ul><p>This Heroic Skill can be acquired <strong>up to three times</strong>.</p>",
     "class": {
-      "value": ""
+      "value": "Fury, Loremaster, Sharpshooter, Weaponmaster"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771885043613,
+    "modifiedTime": 1775353673565,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Arcane_Mark_hH6SHCiX0HAdXugI.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Mark_hH6SHCiX0HAdXugI.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Sharpshooter, Symbolist, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -239,7 +239,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684532126,
-    "modifiedTime": 1771892101080,
+    "modifiedTime": 1775354797953,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Arcane_Sacrifice_uDjrET5eZnO6yaoQ.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Sacrifice_uDjrET5eZnO6yaoQ.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Arcanist</strong> and <strong>Guardian</strong>.</p><hr /><p>Once per scene, when you and/or one or more allies you can see are reduced to 0 Hit Points, if you are <strong>merged</strong> with an Arcanum, you may instead be reduced to exactly 1 Hit Point. If you do, you must immediately <strong>dismiss</strong> that Arcanum (without applying any dismiss effect), and cannot summon them again until the end of the scene.</p><hr /><p><strong>You Receive:</strong> @GAIN[1 hp]</p>",
     "class": {
-      "value": ""
+      "value": "Arcanist, Guardian"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771885054448,
+    "modifiedTime": 1775353701360,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Arcane_Soldier_E3OppAz7I4f0g19B.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Soldier_E3OppAz7I4f0g19B.json
@@ -23,7 +23,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Elementalist, Sharpshooter, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": true,
@@ -113,7 +113,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711473807263,
-    "modifiedTime": 1771895181239,
+    "modifiedTime": 1775355299237,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Auramancer_s_Refraction_DVaiA90aHgq9gPYI.json
+++ b/src/packs/heroic-skills/heroic_Auramancer_s_Refraction_DVaiA90aHgq9gPYI.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": "Arcanist"
+      "value": "Arcanist, Spiritist"
     },
     "hasResource": {
       "value": false
@@ -78,7 +78,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771893579165,
+    "modifiedTime": 1775355073695,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Bend_Magic_HsdYyIcbdvcleXQP.json
+++ b/src/packs/heroic-skills/heroic_Bend_Magic_HsdYyIcbdvcleXQP.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Elementalist, Entropist, Invoker, Symbolist"
     },
     "hasResource": {
       "value": false
@@ -180,7 +180,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771893598675,
+    "modifiedTime": 1775355087925,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Bimagus_sx1dhJqczTT4UkYw.json
+++ b/src/packs/heroic-skills/heroic_Bimagus_sx1dhJqczTT4UkYw.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Elementalist, Entropist, Spiritist"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684543795,
-    "modifiedTime": 1771892115132,
+    "modifiedTime": 1775354827378,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Black___White_OSJ4PCp6GmSnLaS3.json
+++ b/src/packs/heroic-skills/heroic_Black___White_OSJ4PCp6GmSnLaS3.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": "Ace of Cards"
+      "value": "Ace of Cards, Darkblade, Entropist, Spiritist"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1708940657180,
-    "modifiedTime": 1771885073210,
+    "modifiedTime": 1775353715304,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Blade_Adept_s316rQUTr3lgeTx7.json
+++ b/src/packs/heroic-skills/heroic_Blade_Adept_s316rQUTr3lgeTx7.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Rogue, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -190,7 +190,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684553854,
-    "modifiedTime": 1771892202477,
+    "modifiedTime": 1775354838758,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Brambleheart_FvqC34UYxD3O2bFt.json
+++ b/src/packs/heroic-skills/heroic_Brambleheart_FvqC34UYxD3O2bFt.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Darkblade, Floralist"
     },
     "hasResource": {
       "value": false
@@ -198,7 +198,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771893607962,
+    "modifiedTime": 1775355099380,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Brave_Bash_eOGrMEqq2sBta0AN.json
+++ b/src/packs/heroic-skills/heroic_Brave_Bash_eOGrMEqq2sBta0AN.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Commander, Guardian, Weaponmaster"
     },
     "hasResource": {
       "value": false
@@ -180,7 +180,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771893635978,
+    "modifiedTime": 1775355108971,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Broken_Wing_Tactic_qDXaDmoLcasT2o37.json
+++ b/src/packs/heroic-skills/heroic_Broken_Wing_Tactic_qDXaDmoLcasT2o37.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Commander</strong> and <strong>Guardian</strong>.</p><hr /><p>After an enemy you can see performs an <strong>Accuracy Check</strong> or a <strong>Magic Check</strong> for an offensive spell (@ICON[offensive]) on their turn during a conflict, you may grant them a +3 bonus to the Result of the Check. If you do, choose one option:</p><ul><li><p>You and every ally who is able to hear you gain Resistance to all damage types until the end of this turn.</p></li><li><p>You and every ally who is able to hear you deal 5 extra damage until the end of this turn.</p></li></ul><p>Once you use this Skill, you cannot use it again until the start of your next turn.</p><hr /><p><strong>You &amp; Allies Receive:</strong> @EFFECT[Compendium.projectfu.heroic-skills.Item.lqgayJpoKwrXlPVl]</p>",
     "class": {
-      "value": ""
+      "value": "Commander, Guardian"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771885126692,
+    "modifiedTime": 1775353724698,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Bullet_Time_RD8MoXlaZMNolEnN.json
+++ b/src/packs/heroic-skills/heroic_Bullet_Time_RD8MoXlaZMNolEnN.json
@@ -23,7 +23,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Entropist, Rogue"
     },
     "useWeapon": {
       "accuracy": {
@@ -192,7 +192,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711473807263,
-    "modifiedTime": 1771895726759,
+    "modifiedTime": 1775355313906,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Cheer_Up__cSzzcGmQur0Zo6R5.json
+++ b/src/packs/heroic-skills/heroic_Cheer_Up__cSzzcGmQur0Zo6R5.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Chanter, Esper, Orator"
     },
     "hasResource": {
       "value": false
@@ -191,7 +191,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771893798968,
+    "modifiedTime": 1775355118587,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Chimeric_Soul_nmeZ2ukzybP0lpR9.json
+++ b/src/packs/heroic-skills/heroic_Chimeric_Soul_nmeZ2ukzybP0lpR9.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Chimerist, Mutant"
     },
     "hasResource": {
       "value": false
@@ -74,7 +74,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894195741,
+    "modifiedTime": 1775355128567,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Cleansing_Moonlight_KLo8fztm26jzY2Zn.json
+++ b/src/packs/heroic-skills/heroic_Cleansing_Moonlight_KLo8fztm26jzY2Zn.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Entropist, Spiritist"
     },
     "hasResource": {
       "value": false
@@ -212,7 +212,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894208445,
+    "modifiedTime": 1775355140642,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Double_Arrow_ibuohUO9YHDIId4x.json
+++ b/src/packs/heroic-skills/heroic_Double_Arrow_ibuohUO9YHDIId4x.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Commander, Sharpshooter"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684593529,
-    "modifiedTime": 1771892290980,
+    "modifiedTime": 1775354862536,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Dreamslice_jdhnFWPhnFtLRLe8.json
+++ b/src/packs/heroic-skills/heroic_Dreamslice_jdhnFWPhnFtLRLe8.json
@@ -23,7 +23,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Darkblade, Esper"
     },
     "useWeapon": {
       "accuracy": {
@@ -216,7 +216,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711473807263,
-    "modifiedTime": 1771895992280,
+    "modifiedTime": 1775355327503,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Duel_Master_ngt7aBn7AykfzJDg.json
+++ b/src/packs/heroic-skills/heroic_Duel_Master_ngt7aBn7AykfzJDg.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": "Ace of Cards"
+      "value": "Ace of Cards, Fury, Rogue, Sharpshooter, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1708940657180,
-    "modifiedTime": 1771885160689,
+    "modifiedTime": 1775353754789,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Ephemeral_Tranquility_mYZHKPvfVmvZ4vNy.json
+++ b/src/packs/heroic-skills/heroic_Ephemeral_Tranquility_mYZHKPvfVmvZ4vNy.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Dancer, Esper, Rogue, Spiritist, Symbolist"
     },
     "hasResource": {
       "value": false
@@ -194,7 +194,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894277954,
+    "modifiedTime": 1775355170382,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Extra_HP_okxC0Vg7jOXrEg6V.json
+++ b/src/packs/heroic-skills/heroic_Extra_HP_okxC0Vg7jOXrEg6V.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Ace of Cards, Arcanist, Chanter, Chimerist, Commander, Dancer, Darkblade, Elementalist, Entropist, Esper, Floralist, Fury, Gourmet, Guardian, Invoker, Loremaster, Merchant, Mutant, Necromancer, Orator, Pilot, Rogue, Sharpshooter, Spiritist, Symbolist, Tinkerer, Wayfarer, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -184,7 +184,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706584138219,
-    "modifiedTime": 1771887801030,
+    "modifiedTime": 1775356034529,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Extra_IP_RSacdfMknVY24eCH.json
+++ b/src/packs/heroic-skills/heroic_Extra_IP_RSacdfMknVY24eCH.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Ace of Cards, Arcanist, Chanter, Chimerist, Commander, Dancer, Darkblade, Elementalist, Entropist, Esper, Floralist, Fury, Gourmet, Guardian, Invoker, Loremaster, Merchant, Mutant, Necromancer, Orator, Pilot, Rogue, Sharpshooter, Spiritist, Symbolist, Tinkerer, Wayfarer, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -184,7 +184,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706584237881,
-    "modifiedTime": 1771887795037,
+    "modifiedTime": 1775356036981,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Extra_MP_VwPy5u5mcj9xLF6T.json
+++ b/src/packs/heroic-skills/heroic_Extra_MP_VwPy5u5mcj9xLF6T.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Ace of Cards, Arcanist, Chanter, Chimerist, Commander, Dancer, Darkblade, Elementalist, Entropist, Esper, Floralist, Fury, Gourmet, Guardian, Invoker, Loremaster, Merchant, Mutant, Necromancer, Orator, Pilot, Rogue, Sharpshooter, Spiritist, Symbolist, Tinkerer, Wayfarer, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -184,7 +184,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706584261327,
-    "modifiedTime": 1771887805275,
+    "modifiedTime": 1775356038728,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Fast_Rituals_6bLqejGbDDsGTj93.json
+++ b/src/packs/heroic-skills/heroic_Fast_Rituals_6bLqejGbDDsGTj93.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Chimerist, Elementalist, Entropist, Spiritist"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684602733,
-    "modifiedTime": 1771892317030,
+    "modifiedTime": 1775354904761,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Fitcast_VUOVB6ej86Ml3d1j.json
+++ b/src/packs/heroic-skills/heroic_Fitcast_VUOVB6ej86Ml3d1j.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Chimerist, Darkblade, Esper, Fury, Wayfarer"
     },
     "hasResource": {
       "value": false
@@ -74,7 +74,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894300455,
+    "modifiedTime": 1775355164573,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Flow_of_Yin_and_Yang_HvneaDgpLe2cAKH7.json
+++ b/src/packs/heroic-skills/heroic_Flow_of_Yin_and_Yang_HvneaDgpLe2cAKH7.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Dancer</strong>, <strong>Elementalist</strong>, <strong>Esper</strong>, and <strong>Invoker</strong>.</p><hr /><p>When you deal <strong>dark</strong>, <strong>earth</strong>, <strong>ice</strong>, or <strong>physical</strong> damage for the first time during a turn, you gain <strong>1 Yin Point</strong> and, if you have <strong>at least 1 Yang Point</strong>, you deal 5 extra damage.</p><p>When you deal <strong>air</strong>, <strong>bolt</strong>, <strong>fire</strong>, or <strong>light</strong> damage for the first time during a turn, you gain <strong>1 Yang Point</strong> and, if you have <strong>at least 1 Yin Point</strong>, you deal 5 extra damage.</p><p>At the end of your turn, if you have <strong>3 or more Yin and/or Yang points</strong> and have <strong>at least 1 point of each type</strong>, you lose all <strong>Yin and Yang Points</strong> and perform one of the following effects based on the points you lost (perform <strong>both</strong> in case of a tie):</p><ul><li><p><strong>Yin majority</strong>: every enemy present on the scene loses an amount of Mind Points equal to <strong>【half your level】</strong>.</p></li><li><p><strong>Yang majority</strong>: one creature you can see that is present on the scene recovers an amount of Mind Points equal to <strong>【your level】</strong>.</p></li></ul><p>You may gain and use <strong>Yin and Yang Points</strong> only during conflicts, and you lose all your <strong>Yin and Yang Points</strong> at the end of each scene.</p><hr /><p><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.heroic-skills.Item.0HGU4K2CyxTGtDAP] or @EFFECT[Compendium.projectfu.heroic-skills.Item.XziwyFx5pn8OHLM1]<br /><strong>Enemies Lose:</strong> @LOSS[floor($cl/2) mp]{Half Level MP}<br /><strong>Target Gains:</strong> @GAIN[$cl mp]{Level MP}</p>",
     "class": {
-      "value": ""
+      "value": "Dancer, Elementalist, Esper, Invoker"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "flow-of-yin-and-yang"
+    "fuid": "flow-of-yin-and-yang",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [
     {
@@ -156,7 +165,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771008883074,
+    "modifiedTime": 1775353764148,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Forbidden_Rite_UhjNswMk6idkCg0c.json
+++ b/src/packs/heroic-skills/heroic_Forbidden_Rite_UhjNswMk6idkCg0c.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": "Ace of Cards"
+      "value": "Ace of Cards, Arcanist"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1708940657180,
-    "modifiedTime": 1771885195362,
+    "modifiedTime": 1775353775339,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Great_Cauldron_s_Secret_D0wG80uPK1MmHUf5.json
+++ b/src/packs/heroic-skills/heroic_Great_Cauldron_s_Secret_D0wG80uPK1MmHUf5.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered the <strong>Tinkerer</strong> Class, and have acquired the <strong>superior alchemy</strong> benefit from the <strong>Gadgets</strong> Skill.</p><hr /><p>When you create a <strong>potion</strong> via <strong>alchemy</strong>, you may treat the die assigned to <strong>\"target\"</strong> as showing a value of <strong>13</strong> or <strong>17</strong> (even if that die shows a different number).</p>",
     "class": {
-      "value": ""
+      "value": "Tinkerer"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771885214726,
+    "modifiedTime": 1775353787572,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Harvester_of_Sorrow_pqT5C8ap91WD7TDf.json
+++ b/src/packs/heroic-skills/heroic_Harvester_of_Sorrow_pqT5C8ap91WD7TDf.json
@@ -16,7 +16,7 @@
       "min": 0
     },
     "class": {
-      "value": "Necromancer"
+      "value": "Entropist, Necromancer"
     },
     "useWeapon": {
       "accuracy": {
@@ -264,7 +264,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1697668153306,
-    "modifiedTime": 1771885221937,
+    "modifiedTime": 1775353797206,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Hit_the_Nerve_IMg6ssWeH5hyBtIi.json
+++ b/src/packs/heroic-skills/heroic_Hit_the_Nerve_IMg6ssWeH5hyBtIi.json
@@ -23,7 +23,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Chanter, Orator"
     },
     "useWeapon": {
       "accuracy": {
@@ -300,7 +300,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711473807263,
-    "modifiedTime": 1771896889924,
+    "modifiedTime": 1775355348956,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Hoplite_sEXgOpgUF00z55Y3.json
+++ b/src/packs/heroic-skills/heroic_Hoplite_sEXgOpgUF00z55Y3.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Commander, Guardian"
     },
     "useWeapon": {
       "accuracy": {
@@ -185,7 +185,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684635660,
-    "modifiedTime": 1771892366370,
+    "modifiedTime": 1775354925207,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Hunter_s_Trick_C85rsZpRK6htfbv6.json
+++ b/src/packs/heroic-skills/heroic_Hunter_s_Trick_C85rsZpRK6htfbv6.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Sharpshooter</strong> and <strong>Weaponmaster</strong>.</p><hr /><p>When you transform a <strong>transforming custom weapon</strong> on your turn, choose <strong>one</strong> option:</p><ul><li><p>If you have not performed any attacks during this turn, the next attack you perform with this weapon during this turn deals 5 extra damage.</p></li><li><p>If you hit one or more creatures with an attack using this weapon during this turn, you recover 5 Hit Points and 5 Mind Points.</p></li></ul><hr /><p><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.heroic-skills.Item.0jslWSatV2i8SKix] or @EFFECT[Compendium.projectfu.heroic-skills.Item.3PRgAxgGjeOiBjKg]</p>",
     "class": {
-      "value": ""
+      "value": "Sharpshooter, Weaponmaster"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886049140,
+    "modifiedTime": 1775353807867,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Impaler_Dragon_0YxqgUTI6wRu7pV8.json
+++ b/src/packs/heroic-skills/heroic_Impaler_Dragon_0YxqgUTI6wRu7pV8.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Commander</strong> and <strong>Darkblade</strong>, and have acquired the <strong>Charging Cavalry</strong> and <strong>Shadow Strike</strong> Skills.</p><hr /><p>When you use the <strong>Shadow Strike</strong> Skill, you may treat your <strong>High Roll</strong> as being equal to 0 when determining damage dealt by this attack. If you do, after the effects granted by <strong>Shadow Strike</strong> are resolved, you may immediately perform the <strong>Charging Cavalry</strong> Skill for free (paying the appropriate MP cost).</p>",
     "class": {
-      "value": ""
+      "value": "Commander, Darkblade"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886064184,
+    "modifiedTime": 1775353820146,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Iron_Forest_9ga5k07i5o6nEE1c.json
+++ b/src/packs/heroic-skills/heroic_Iron_Forest_9ga5k07i5o6nEE1c.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Commander, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -240,7 +240,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684646291,
-    "modifiedTime": 1771892472071,
+    "modifiedTime": 1775354935655,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_It_Lives__LhE2uHqEfh9L179L.json
+++ b/src/packs/heroic-skills/heroic_It_Lives__LhE2uHqEfh9L179L.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Tinkerer</strong> and <strong>Wayfarer</strong>, and have acquired the <strong>Faithful Companion</strong> (<strong>construct</strong> Species) and <strong>Visionary</strong> Skills.</p><hr /><p>Your companion's base Affinity towards <strong>bolt</strong> damage is replaced with <strong>Absorption</strong>, and their maximum Hit Point score is increased by an amount equal to <strong>【twice your Skill Level in Visionary】</strong>.</p><p>When your companion deals damage, if they have no weapons equipped, they deal extra damage equal to <strong>【your Skill Level in Visionary】</strong>.</p><hr /><p><strong>Companion Receives:</strong> @EFFECT[Compendium.projectfu.heroic-skills.Item.6GuttgsSqvf1LmOo] @EFFECT[Compendium.projectfu.heroic-skills.Item.O5B4R2osb7LMqGzC]</p>",
     "class": {
-      "value": ""
+      "value": "Tinkerer, Wayfarer"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886071902,
+    "modifiedTime": 1775353833514,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Like_an_Open_Book_bNl3nhk2ULBwLaE4.json
+++ b/src/packs/heroic-skills/heroic_Like_an_Open_Book_bNl3nhk2ULBwLaE4.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Esper</strong>, <strong>Loremaster</strong> and <strong>Rogue</strong>, and have acquired the <strong>Soul Steal</strong> Skill.</p><hr /><p>After you successfully use the <strong>Soul Steal</strong> Skill against one or more enemies, you may choose one of them. If you do, you immediately perform the <strong>Study</strong> action for free against that enemy: treat the Result and High Roll of this Open Check as being equal to the Result and High Roll of the Check you performed for <strong>Soul Steal</strong> (do not roll dice for this Open Check).</p><p>When you deal damage to an <strong>elite</strong> or <strong>champion</strong>-rank enemy, if you stole that enemy's <strong>soul treasure</strong> during this scene, you deal extra damage equal to <strong>【your Skill Level in Soul Steal】</strong> to that enemy.</p>",
     "class": {
-      "value": ""
+      "value": "Esper, Loremaster, Rogue"
     },
     "showTitleCard": {
       "value": false
@@ -148,7 +148,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886088229,
+    "modifiedTime": 1775353844213,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Magic_Guard_dwmA3TWb8Ya3VSDZ.json
+++ b/src/packs/heroic-skills/heroic_Magic_Guard_dwmA3TWb8Ya3VSDZ.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Chimerist, Elementalist, Entropist, Spiritist"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684656698,
-    "modifiedTime": 1771892860800,
+    "modifiedTime": 1775354949632,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Make_it_or_Break_it_p8vmh280ByFh88tK.json
+++ b/src/packs/heroic-skills/heroic_Make_it_or_Break_it_p8vmh280ByFh88tK.json
@@ -23,7 +23,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Darkblade, Fury"
     },
     "useWeapon": {
       "accuracy": {
@@ -118,7 +118,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711519472393,
-    "modifiedTime": 1771896921163,
+    "modifiedTime": 1775355360616,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Mimeoclepsis_8vzHUmPg4Cksad7D.json
+++ b/src/packs/heroic-skills/heroic_Mimeoclepsis_8vzHUmPg4Cksad7D.json
@@ -23,7 +23,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Chimerist, Mutant"
     },
     "useWeapon": {
       "accuracy": {
@@ -118,7 +118,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1711473807263,
-    "modifiedTime": 1771896930044,
+    "modifiedTime": 1775355372141,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Nether_Slash_DkaqHnTnEw2eMRDa.json
+++ b/src/packs/heroic-skills/heroic_Nether_Slash_DkaqHnTnEw2eMRDa.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Darkblade</strong>, <strong>Elementalist</strong> and <strong>Pilot</strong>, and have acquired the <strong>Shadow Strike</strong> Skill.</p><hr /><p>When you use the @UUID[Compendium.projectfu.skills.Item.W5hE9L8x7AsJI7a1]{Shadow Strike} Skill, you may choose <strong>fire</strong> or <strong>ice</strong>. If you do, all damage dealt by this attack becomes of the chosen type instead of <strong>dark</strong> (its damage type cannot change, as usual), and you gain Resistance to the damage type you did not choose until the start of your next turn.</p><p>When you perform a <strong>free attack</strong> with a <strong>melee</strong> weapon as part of the <strong>Shadow Strike</strong> Skill, the attack may target enemies that cannot be targeted by <strong>melee</strong> attacks.</p><hr /><p><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.heroic-skills.Item.gJWZDrbPrRIA0Udi] or @EFFECT[Compendium.projectfu.heroic-skills.Item.YD0Qid4TdxUVksXQ]</p>",
     "class": {
-      "value": ""
+      "value": "Darkblade, Elementalist, Pilot"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "nether-slash"
+    "fuid": "nether-slash",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [
     {
@@ -193,7 +202,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771285299046,
+    "modifiedTime": 1775353854151,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Ofuda_Mastery_sD7qYF2LZhxfHJ8P.json
+++ b/src/packs/heroic-skills/heroic_Ofuda_Mastery_sD7qYF2LZhxfHJ8P.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Arcanist</strong>, <strong>Merchant</strong>, <strong>Symbolist</strong> and <strong>Spiritist</strong>, and have acquired the <strong>Symbolism</strong> Skill.</p><hr /><p>When you use the <strong>Symbolism</strong> Skill during a conflict, you may spend 20 Mind Points to ignore the Skill's normal cost in Inventory Points.</p><p>When you perform a <strong>free attack</strong> with a <strong>melee</strong> weapon as part of the <strong>Symbolism</strong> Skill, the attack may target enemies that cannot be targeted by <strong>melee</strong> attacks.</p>",
     "class": {
-      "value": ""
+      "value": "Arcanist, Merchant, Symbolist, Spiritist"
     },
     "showTitleCard": {
       "value": false
@@ -62,7 +62,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886921562,
+    "modifiedTime": 1775353871068,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Phagomagus_jHa5MjZpLP8OLSK9.json
+++ b/src/packs/heroic-skills/heroic_Phagomagus_jHa5MjZpLP8OLSK9.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Chimerist</strong>, <strong>Entropist</strong>, <strong>Gourmet</strong> and <strong>Mutant</strong>.</p><hr /><p>When you cast the @UUID[Compendium.projectfu.skills.Item.6QG5ZZgRs4xnxlVl]{Dispel} spell, its <strong>MP</strong> cost becomes \"10 × T\" and its <strong>target</strong> becomes \"Up to three creatures\".</p><p>When you cause one or more enemies to stop being affected by one or more spells with a <strong>duration</strong> of \"Scene\", choose <strong>one</strong> option:</p><ul><li><p>You recover 20 Mind Points for each different spell whose effects ended on at least one of those enemies this way.</p></li><li><p>For each different spell whose effects ended on at least one of those enemies this way, apply a copy of that spell on yourself (if a spell allowed for choices upon casting it, you must retain the same choices that were made for this casting of the spell). This copying effect does not require actions, Mind Points, or Checks, and is not treated as \"casting a spell\".</p></li></ul><hr /><p><strong>You Receive:</strong> @GAIN[20 mp]</p>",
     "class": {
-      "value": ""
+      "value": "Chimerist, Entropist, Gourmet, Mutant"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886963154,
+    "modifiedTime": 1775353880905,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Power_Nap_rlOIe9a68fkv8KS3.json
+++ b/src/packs/heroic-skills/heroic_Power_Nap_rlOIe9a68fkv8KS3.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Guardian, Merchant, Wayfarer"
     },
     "hasResource": {
       "value": false
@@ -74,7 +74,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894373327,
+    "modifiedTime": 1775355222639,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Powerful_Spell_lYKani6s0f2C8vqA.json
+++ b/src/packs/heroic-skills/heroic_Powerful_Spell_lYKani6s0f2C8vqA.json
@@ -9,7 +9,7 @@
     "summary": {
       "value": "Deal extra damage with spells."
     },
-    "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among the following: <strong>Chimerist</strong>, <strong>Elementalist</strong>, <strong>Entropist</strong>, or <strong>Spiritist</strong>. </p><hr /><p>When you cast a spell that deals damage to one or more creatures, that spell deals 5 extra damage to each creature. </p><p>The amount of extra damage increases to 10 if you are<strong> level 40 or higher</strong> . </p>",
+    "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Chimerist</strong>, <strong>Elementalist</strong>, <strong>Entropist</strong>, and <strong>Spiritist</strong>.</p><hr /><p>When you cast a spell that deals damage to one or more creatures, that spell deals 5 extra damage to each creature. </p><p>The amount of extra damage increases to 10 if you are<strong> level 40 or higher</strong> . </p>",
     "isFavored": {
       "value": false
     },
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Chimerist, Elementalist, Entropist, Spiritist"
     },
     "useWeapon": {
       "accuracy": {
@@ -178,7 +178,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706585369283,
-    "modifiedTime": 1771888706587,
+    "modifiedTime": 1775354647799,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Powerful_Strike_BsWM80bfvYRZjbED.json
+++ b/src/packs/heroic-skills/heroic_Powerful_Strike_BsWM80bfvYRZjbED.json
@@ -9,7 +9,7 @@
     "summary": {
       "value": "Deal extra damage with melee attacks."
     },
-    "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among the following: <strong>Fury </strong>or <strong>Weaponmaster</strong>.</p><hr /><p>When you hit one or more creatures with a <strong>melee </strong>attack, that attack deals 5 extra damage to each creature. </p><p>The amount of extra damage increases to 10 if you are <strong>level 40 or higher</strong>. </p>",
+    "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Fury</strong> and <strong>Weaponmaster</strong>.</p><hr /><p>When you hit one or more creatures with a <strong>melee </strong>attack, that attack deals 5 extra damage to each creature. </p><p>The amount of extra damage increases to 10 if you are <strong>level 40 or higher</strong>. </p>",
     "isFavored": {
       "value": false
     },
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Fury, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -178,7 +178,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706585658140,
-    "modifiedTime": 1771888716068,
+    "modifiedTime": 1775354708625,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Pulverizing_Strike_DppL1AyvffBGbjDM.json
+++ b/src/packs/heroic-skills/heroic_Pulverizing_Strike_DppL1AyvffBGbjDM.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Darkblade, Fury, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684687580,
-    "modifiedTime": 1771892974517,
+    "modifiedTime": 1775354968410,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Rising_Tide_8tBwzNz4egN1Lu4L.json
+++ b/src/packs/heroic-skills/heroic_Rising_Tide_8tBwzNz4egN1Lu4L.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Fury, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -221,7 +221,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684696121,
-    "modifiedTime": 1771893139526,
+    "modifiedTime": 1775354991844,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Silent_Hunter_1jiLF3jy7eEinL1k.json
+++ b/src/packs/heroic-skills/heroic_Silent_Hunter_1jiLF3jy7eEinL1k.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Rogue, Sharpshooter, Weaponmaster"
     },
     "hasResource": {
       "value": false
@@ -219,7 +219,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894939224,
+    "modifiedTime": 1775355247977,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Skillful_Dosage_1wnsaeyJ46ElqvPX.json
+++ b/src/packs/heroic-skills/heroic_Skillful_Dosage_1wnsaeyJ46ElqvPX.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Gourmet, Loremaster, Merchant, Tinkerer"
     },
     "hasResource": {
       "value": false
@@ -74,7 +74,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771894918087,
+    "modifiedTime": 1775355265414,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Spider_s_Web_8Y5cFfBejJdnj9bb.json
+++ b/src/packs/heroic-skills/heroic_Spider_s_Web_8Y5cFfBejJdnj9bb.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Fury, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684724160,
-    "modifiedTime": 1771893187604,
+    "modifiedTime": 1775355009489,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Swirling_Swarm_WKJ4ZSPBnlg4U3qt.json
+++ b/src/packs/heroic-skills/heroic_Swirling_Swarm_WKJ4ZSPBnlg4U3qt.json
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Dancer, Fury, Sharpshooter"
     },
     "useWeapon": {
       "accuracy": {
@@ -53,7 +53,9 @@
       "value": 0,
       "type": {
         "value": "physical"
-      }
+      },
+      "onRoll": "",
+      "onApply": ""
     },
     "impdamage": {
       "hasImpDamage": {
@@ -93,7 +95,12 @@
       "step": 1,
       "max": 5
     },
-    "fuid": "swirling-swarm"
+    "fuid": "swirling-swarm",
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [
     {
@@ -249,7 +256,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684737113,
-    "modifiedTime": 1770765364687,
+    "modifiedTime": 1775355025461,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Symbiotic_Roots_gnyG5SfCFuw0whnu.json
+++ b/src/packs/heroic-skills/heroic_Symbiotic_Roots_gnyG5SfCFuw0whnu.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Chimerist</strong>, <strong>Floralist</strong>, <strong>Mutant</strong> and <strong>Wayfarer</strong>, and have acquired the <strong>Faithful Companion</strong> (<strong>construct</strong> Species) Skill.</p><hr /><p>When you recover Hit Points, you may choose to recover only <strong>half</strong> of that amount; if you do, your companion recovers that many Hit Points.</p><p>At the end of your turn during a conflict, if your companion's current Hit Points are <strong>equal to or higher than</strong> their maximum Hit Points and your companion has not performed actions or attacks during this turn, you may have your companion perform a <strong>free attack</strong> with one of their basic attacks.</p>",
     "class": {
-      "value": ""
+      "value": "Chimerist, Floralist, Mutant, Wayfarer"
     },
     "showTitleCard": {
       "value": false
@@ -59,7 +59,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771886971485,
+    "modifiedTime": 1775353895631,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/heroic-skills/heroic_Triple_Slash_awqSSh3rbNZW8L5V.json
+++ b/src/packs/heroic-skills/heroic_Triple_Slash_awqSSh3rbNZW8L5V.json
@@ -9,7 +9,7 @@
     "summary": {
       "value": "Equip three daggers/swords and perform triple attacks."
     },
-    "description": "<p><strong>Requirements: </strong>you must have mastered one or more Classes among <strong>Dancer </strong>and <strong>Weaponmaster</strong>.</p><hr /><p>As long as you have a one-handed <strong>melee </strong>weapon that belongs to the <strong>dagger </strong>or <strong>sword </strong>Categories equipped in each of your normal hand slots, you may treat your <strong>armor </strong>slot as if it were a second <strong>off-hand</strong> slot. You may only use this special slot to equip a one-handed <strong>melee </strong>weapon that belongs to the <strong>dagger </strong>or <strong>sword </strong>Categories — note that the <strong>Monkey Grip</strong> Skill does not turn two-handed weapons into one-handed weapons, and thus cannot be used in combination with <strong>Triple Slash</strong>.</p><p>When you perform the <strong>Attack </strong>action while you have three <strong>daggers </strong>and/or <strong>swords </strong>equipped, you may attack once with each weapon. This follows the normal rules for <strong>two-weapon fighting</strong>: each of the three attacks loses the multi property and cannot gain it, and you treat the <strong>High Roll (HR)</strong> of each Accuracy Check as being equal to 0 when determining damage.</p><hr /><p>To <strong>automate</strong>, navigate to the '<strong>Items</strong>\" tab where the weapon you want to equip is located, and press <strong>Ctrl+Click</strong> on the icon in the '<strong>Equip?</strong>' column. The item will be added to the <strong>Phantom Slot</strong>. Equip weapons in both your main and off-hand slots. <strong>Shift+Click</strong> each weapon to roll as <strong>HR Zero</strong>. Make sure your <strong>Armor Slot</strong> is empty.</p>",
+    "description": "<p><strong>Requirements: </strong>you must have mastered one or more Classes among <strong>Dancer</strong> and <strong>Weaponmaster</strong>.</p><hr /><p>As long as you have a one-handed <strong>melee</strong> weapon that belongs to the <strong>dagger</strong> or <strong>sword </strong>Categories equipped in each of your normal hand slots, you may treat your <strong>armor</strong> slot as if it were a second <strong>off-hand</strong> slot. You may only use this special slot to equip a one-handed <strong>melee</strong> weapon that belongs to the <strong>dagger</strong> or <strong>sword</strong> Categories — note that the <strong>Monkey Grip</strong> Skill does not turn two-handed weapons into one-handed weapons, and thus cannot be used in combination with <strong>Triple Slash</strong>.</p><p>When you perform the <strong>Attack</strong> action while you have three <strong>daggers</strong> and/or <strong>swords</strong> equipped, you may attack once with each weapon. This follows the normal rules for <strong>two-weapon fighting</strong>: each of the three attacks loses the multi property and cannot gain it, and you treat the <strong>High Roll (HR)</strong> of each Accuracy Check as being equal to 0 when determining damage.</p><hr /><p><em>To <strong>automate</strong>, navigate to the '<strong>Items</strong>' tab where the weapon you want to equip is located, and press <strong>Ctrl+Click</strong> on the icon in the '<strong>Equip?</strong>' column. The item will be added to the <strong>Phantom Slot</strong>. Equip weapons in both your main and off-hand slots. <strong>Shift+Click</strong> each weapon to roll as <strong>HR Zero</strong>. Make sure your <strong>Armor Slot</strong> is empty.</em></p>",
     "isFavored": {
       "value": false
     },
@@ -22,7 +22,7 @@
       "min": 0
     },
     "class": {
-      "value": ""
+      "value": "Dancer, Weaponmaster"
     },
     "useWeapon": {
       "accuracy": {
@@ -122,7 +122,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706684778697,
-    "modifiedTime": 1771893380713,
+    "modifiedTime": 1775355054064,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/heroic-skills/heroic_Wise_Counsel_3wlO92LRBQOzfEB7.json
+++ b/src/packs/heroic-skills/heroic_Wise_Counsel_3wlO92LRBQOzfEB7.json
@@ -18,7 +18,7 @@
       "value": false
     },
     "class": {
-      "value": ""
+      "value": "Commander, Loremaster, Orator"
     },
     "hasResource": {
       "value": false
@@ -82,7 +82,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676906838,
-    "modifiedTime": 1771895066355,
+    "modifiedTime": 1775355285344,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/heroic-skills/heroic_Witchvoice_F663zXMwqDGSCfOp.json
+++ b/src/packs/heroic-skills/heroic_Witchvoice_F663zXMwqDGSCfOp.json
@@ -8,7 +8,7 @@
     },
     "description": "<p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Chanter</strong> and <strong>Orator</strong>.</p><hr /><p>After you sing a <strong>haunting verse</strong>, or after you succeed on an Opposed Check for your <strong>Condemn</strong> Skill, you may choose one enemy among the targets of that <strong>verse</strong> or Skill.</p><p>If you do, choose one status effect that enemy is currently suffering from: that enemy becomes <strong>bewitched</strong> until the start of your next turn or until they recover from the chosen status effect. Enemies you have <strong>bewitched</strong> must include you among the targets of their attacks and offensive spells (@ICON[offensive]), if able.</p>",
     "class": {
-      "value": ""
+      "value": "Chanter, Orator"
     },
     "showTitleCard": {
       "value": false
@@ -65,7 +65,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1767915231139,
-    "modifiedTime": 1771887028909,
+    "modifiedTime": 1775353905308,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "1Ky2u7fi2lfxr4JB",

--- a/src/packs/legacy/heroic_Impaler_Dragon__Legacy__pyynUuewsJt0XzPO.json
+++ b/src/packs/legacy/heroic_Impaler_Dragon__Legacy__pyynUuewsJt0XzPO.json
@@ -8,7 +8,7 @@
     },
     "description": "<blockquote><p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Commander</strong> and <strong>Darkblade</strong>, and have acquired the <strong>Charging Cavalry</strong> and <strong>Shadow Strike</strong> Skills.</p></blockquote><p>When you use the <strong>Shadow Strike</strong> Skill, you may treat your <strong>High Roll</strong> as being equal to 0 when determining damage dealt by this attack. If you do, after the attack from <strong>Shadow Strike</strong> is resolved, you may immediately perform the <strong>Charging Cavalry</strong> Skill for free (paying the appropriate MP cost).</p>",
     "class": {
-      "value": "Necromancer"
+      "value": "Commander, Darkblade"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "impaler-dragon-legacy"
+    "fuid": "impaler-dragon-legacy",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [],
   "flags": {
@@ -47,8 +56,8 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1769015048149,
-    "modifiedTime": 1771473329358,
-    "lastModifiedBy": "bgUzjEHd80A79gwp"
+    "modifiedTime": 1775355604749,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "nlJCekCcdyb2RFPe",
   "ownership": {

--- a/src/packs/legacy/heroic_It_Lives___Legacy__1vbXtddu6llM2SSA.json
+++ b/src/packs/legacy/heroic_It_Lives___Legacy__1vbXtddu6llM2SSA.json
@@ -8,7 +8,7 @@
     },
     "description": "<blockquote><p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Tinkerer</strong> and <strong>Wayfarer</strong>, and have acquired the <strong>Faithful Companion</strong> (<strong>construct</strong> Species) and <strong>Visionary</strong> Skills.</p></blockquote><p>Your companion's Affinity towards <strong>bolt</strong> damage becomes <strong>Absorption</strong>, and their maximum Hit Point score is increased by an amount equal to <strong>【twice your Skill Level in Visionary】</strong>.</p><p>When your companion deals damage, if they have no weapons equipped, they deal extra damage equal to <strong>【your Skill Level in Visionary】</strong>.</p>",
     "class": {
-      "value": "Necromancer"
+      "value": "Tinkerer, Wayfarer"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "it-lives-legacy"
+    "fuid": "it-lives-legacy",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [],
   "flags": {
@@ -47,8 +56,8 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1769015304122,
-    "modifiedTime": 1771473347995,
-    "lastModifiedBy": "bgUzjEHd80A79gwp"
+    "modifiedTime": 1775355595969,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "nlJCekCcdyb2RFPe",
   "ownership": {

--- a/src/packs/legacy/heroic_Nether_Slash__Legacy__Rn7Toxozw0DApZ3a.json
+++ b/src/packs/legacy/heroic_Nether_Slash__Legacy__Rn7Toxozw0DApZ3a.json
@@ -8,7 +8,7 @@
     },
     "description": "<blockquote><p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Darkblade</strong>, <strong>Elementalist</strong> and <strong>Pilot</strong>, and have acquired the <strong>Shadow Strike</strong> Skill.</p></blockquote><p>When you use the <strong>Shadow Strike</strong> Skill, you may choose <strong>fire</strong> or <strong>ice</strong>. If you do, all damage dealt by this attack becomes of the chosen type instead of <strong>dark</strong> (its damage type cannot change, as usual), and you gain Resistance to the damage type you did not choose until the start of your next turn.</p><p>When you perform a <strong>free attack</strong> with a <strong>melee</strong> weapon as part of the <strong>Shadow Strike</strong> Skill, the attack may target enemies that can only be targeted by a <strong>ranged</strong> attack.</p>",
     "class": {
-      "value": "Necromancer"
+      "value": "Darkblade, Elementalist, Pilot"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "nether-slash-legacy"
+    "fuid": "nether-slash-legacy",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [],
   "flags": {
@@ -47,8 +56,8 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1769015404602,
-    "modifiedTime": 1771473372715,
-    "lastModifiedBy": "bgUzjEHd80A79gwp"
+    "modifiedTime": 1775355585055,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "nlJCekCcdyb2RFPe",
   "ownership": {

--- a/src/packs/legacy/heroic_Ofuda_Mastery__Legacy__0bSEOVCgwOnZhYN2.json
+++ b/src/packs/legacy/heroic_Ofuda_Mastery__Legacy__0bSEOVCgwOnZhYN2.json
@@ -8,7 +8,7 @@
     },
     "description": "<blockquote><p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Arcanist</strong>, <strong>Merchant</strong>, <strong>Symbolist</strong> and <strong>Spiritist</strong>, and have acquired the <strong>Symbolism</strong> Skill.</p></blockquote><p>When you use the <strong>Symbolism</strong> Skill during a conflict, you may spend 20 Mind Points to ignore the Skill's normal cost in Inventory Points.</p><p>When you perform a <strong>free attack</strong> with a <strong>melee</strong> weapon as part of the <strong>Symbolism</strong> Skill, the attack may target enemies that can only be targeted by a <strong>ranged</strong> attack.</p>",
     "class": {
-      "value": "Necromancer"
+      "value": "Arcanist, Merchant, Symbolist, Spiritist"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "ofuda-mastery-legacy"
+    "fuid": "ofuda-mastery-legacy",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [],
   "flags": {
@@ -47,8 +56,8 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1769015453381,
-    "modifiedTime": 1771473388679,
-    "lastModifiedBy": "bgUzjEHd80A79gwp"
+    "modifiedTime": 1775355574254,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "nlJCekCcdyb2RFPe",
   "ownership": {

--- a/src/packs/legacy/heroic_Witchvoice__Legacy__n9xaYpPiSimUS3lU.json
+++ b/src/packs/legacy/heroic_Witchvoice__Legacy__n9xaYpPiSimUS3lU.json
@@ -8,7 +8,7 @@
     },
     "description": "<blockquote><p><strong>Requirements:</strong> you must have mastered one or more Classes among <strong>Chanter</strong> and <strong>Orator</strong>.</p></blockquote><p>After one or more enemies suffer one or more status effects due to a <strong>verse</strong> you sung or due to your <strong>Condemn</strong> Skill, each of those enemies becomes <strong>bewitched</strong> (this effect does not apply to creatures that are immune or already suffering from all status effects inflicted this way). A creature you <strong>bewitched</strong> must include you among the targets of their attacks and offensive spells ( @ICON[offensive] ), if able, and stops being <strong>bewitched</strong> at the start of your next turn or as soon as it recovers from one or more status effects.</p>",
     "class": {
-      "value": "Necromancer"
+      "value": "Chanter, Orator"
     },
     "showTitleCard": {
       "value": false
@@ -30,7 +30,16 @@
       "max": 6,
       "enabled": false
     },
-    "fuid": "witchvoice-legacy"
+    "fuid": "witchvoice-legacy",
+    "damage": {
+      "onRoll": "",
+      "onApply": ""
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [],
   "flags": {
@@ -47,8 +56,8 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1769014542471,
-    "modifiedTime": 1771473420876,
-    "lastModifiedBy": "bgUzjEHd80A79gwp"
+    "modifiedTime": 1775355613997,
+    "lastModifiedBy": "mA8SNY2rY4X5tOHa"
   },
   "folder": "nlJCekCcdyb2RFPe",
   "ownership": {

--- a/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
+++ b/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
@@ -106,7 +106,7 @@
       }
     },
     "hasRoll": {
-      "value": true
+      "value": false
     },
     "hasResource": {
       "value": false
@@ -118,7 +118,15 @@
       "max": 6
     },
     "defense": "def",
-    "fuid": "spellblade"
+    "fuid": "spellblade",
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    },
+    "targeting": {
+      "rule": "self"
+    }
   },
   "effects": [
     {
@@ -253,7 +261,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706498028252,
-    "modifiedTime": 1770331267776,
+    "modifiedTime": 1775353735730,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,


### PR DESCRIPTION
Updated all the Heroic Skills to now list all the classes that fulfill their requirements. That way they can be properly filtered in the Compendium Browser.

Also, removed the Weapon Check on the Spellblade Skill since its automation has no need for it anymore.