### PR TITLE
Compendium draggable clarity

### DIFF
--- a/module/helpers/tables/table-renderer.mjs
+++ b/module/helpers/tables/table-renderer.mjs
@@ -8,7 +8,7 @@ import { PseudoItem } from '../../documents/items/pseudo-item.mjs';
  * @template {Object} T the type of the items in the table
  * @property {string, (() => string)} cssClass
  * @property {string} id An unique identifier to the table.
- * @property {"item", "effect", "custom"} [tablePreset="item"]
+ * @property {"item", "effect", "custom", "compendium-item"} [tablePreset="item"]
  * @property {(document: D, options: FUTableRendererRenderOptions) => T[]} getItems
  * @property {boolean, ((a: D, b: D) => number)} [sort=true] sorting function to determine the order of entries, true means sort using foundry sort order, false means don't sort
  * @property {(element: HTMLElement) => void} activateListeners
@@ -158,6 +158,18 @@ export class FUTableRenderer {
 					tableClass: 'item-list',
 					rowClass: 'item',
 					draggable: true,
+				};
+				break;
+			}
+
+			case 'compendium-item': {
+				config.advancedConfig = {
+					getKey: (item) => item.uuid,
+					keyDataAttribute: 'data-uuid',
+					additionalRowAttributes: [],
+					tableClass: 'item-list',
+					rowClass: 'item',
+					draggable: false,
 				};
 				break;
 			}

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -19,7 +19,7 @@ class CompendiumTableRenderer extends FUTableRenderer {
 	/** @type TableConfig */
 	static TABLE_CONFIG = {
 		getItems: async (entries) => entries.filter((e) => e.name),
-		tablePreset: 'item',
+		tablePreset: 'compendium-item',
 		sort: true,
 	};
 }
@@ -129,7 +129,7 @@ class AdversariesCompendiumTableRenderer extends CompendiumTableRenderer {
 	static TABLE_CONFIG = {
 		...super.TABLE_CONFIG,
 		cssClass: 'compendium-adversaries-table',
-		tablePreset: 'actor',
+		tablePreset: 'compendium-item',
 		columns: {
 			name: CommonColumns.actorAnchorColumn({ columnName: 'FU.Name' }),
 			species: CommonColumns.propertyColumn('FU.Species', 'system.species.value', FU.species),

--- a/styles/css/components/table/cell-item-name.css
+++ b/styles/css/components/table/cell-item-name.css
@@ -36,6 +36,14 @@
 			text-overflow: ellipsis;
 			flex-shrink: 1;
 		}
+
+		a[data-link][draggable] {
+			cursor: grab;
+		}
+
+		a[data-link][draggable]:active {
+			cursor: grabbing;
+		}
 	}
 
 	.cell-item-name__caption {


### PR DESCRIPTION
Cursor only changes to a draggable indicator on a compendium item, when the user has their cursor over the image.