### PR TITLE
Don't iterate all tokens on canvasPan when pressure gauge disabled

### DIFF
--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -195,12 +195,14 @@ Hooks.once('init', async () => {
 	};
 
 	Hooks.on('canvasPan', () => {
-		const start = performance.now();
-		const tokens = canvas.scene.tokens.filter((token) => token.object instanceof FUToken);
-		tokens.forEach((token) => token.object.pressureGauge.onCanvasScale());
-		const duration = performance.now() - start;
-		if (duration > 16) {
-			console.warn(`Rescaling ${tokens.length} tokens with pressure gauges took ${duration}ms`);
+		if (game.settings.get(SYSTEM, SETTINGS.pressureSystem) && game.settings.get(SYSTEM, SETTINGS.optionPressureGaugeShow)) {
+			const start = performance.now();
+			const tokens = canvas.scene.tokens.filter((token) => token.object instanceof FUToken);
+			tokens.forEach((token) => token.object.pressureGauge.onCanvasScale());
+			const duration = performance.now() - start;
+			if (duration > 16) {
+				console.warn(`Rescaling ${tokens.length} tokens with pressure gauges took ${duration}ms`);
+			}
 		}
 	});
 

--- a/module/ui/pressureGauges/pressure-gauge.mjs
+++ b/module/ui/pressureGauges/pressure-gauge.mjs
@@ -184,11 +184,6 @@ export class FUPressureGauge extends globalThis.PIXI.Container {
 	 */
 	refresh(force = false) {
 		try {
-			const { width, height } = this._getScaledSize();
-			if (force) {
-				this._destroyChildren();
-				this._createElements(width, height);
-			}
 			if (!this.shouldDrawPressureGauge) {
 				this.visible = false;
 				return;
@@ -196,6 +191,11 @@ export class FUPressureGauge extends globalThis.PIXI.Container {
 				this.visible = true;
 			}
 
+			const { width, height } = this._getScaledSize();
+			if (force) {
+				this._destroyChildren();
+				this._createElements(width, height);
+			}
 			const [bg, fg, border, mask] = ['BG', 'FG', 'Border', 'FGMask', 'Shadow'].map((name) => this._getChildElement(name));
 
 			if (!(bg && fg && border && mask)) throw new Error(`Pressure gauge PIXI elements not created for ${this.token.id}!`);


### PR DESCRIPTION
- Adds check to ensure pressure system and gauge enabled before refreshing gauges for all tokens in scene on canvas pan/zoom
- Moves check to make sure gauge should be drawn in gauge refresh function earlier, to exit sooner when it should not be drawn.

Fixes #1015 