### PR TITLE
Update chat message toggle functionality

### DIFF
--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -664,44 +664,6 @@ const isCheck = (message, type = allExceptDisplay) => {
 	return false;
 };
 
-document.addEventListener('click', (event) => {
-	const toggleLink = event.target.closest('.universal-toggle');
-	if (!toggleLink) return;
-
-	const chatMessage = toggleLink.closest('.chat-message');
-	const toggleSections = chatMessage.querySelectorAll('.toggle-section');
-	const toggleIcon = toggleLink.querySelector('.toggle-icon');
-	const isHidden = toggleIcon.classList.contains('fa-chevron-up');
-
-	// Get game settings (true means hide, false means show)
-	const settings = {
-		tags: game.settings.get('projectfu', 'optionChatMessageHideTags'),
-		quality: game.settings.get('projectfu', 'optionChatMessageHideQuality'),
-		description: game.settings.get('projectfu', 'optionChatMessageHideDescription'),
-		rollDetails: game.settings.get('projectfu', 'optionChatMessageHideRollDetails'),
-	};
-
-	// Toggle visibility based on current state and settings
-	toggleSections.forEach((section) => {
-		const shouldAlwaysShow = [
-			{ className: 'accuracy-check-results', setting: settings.rollDetails },
-			{ className: 'damage-results', setting: settings.rollDetails },
-			{ className: 'description', setting: settings.description },
-			{ className: 'quality', setting: settings.quality },
-			{ className: 'tags', setting: settings.tags },
-		].some(({ className, setting }) => section.classList.contains(className) && !setting);
-
-		section.classList.toggle('shown', shouldAlwaysShow || isHidden);
-		section.classList.toggle('hidden', !shouldAlwaysShow && !isHidden);
-	});
-
-	// Update toggle icon and tooltip
-	const newState = !isHidden;
-	toggleIcon.classList.toggle('fa-chevron-up', newState);
-	toggleIcon.classList.toggle('fa-chevron-down', !newState);
-	toggleLink.setAttribute('data-tooltip', game.i18n.localize(newState ? 'FU.ChatMessageHide' : 'FU.ChatMessageShow'));
-});
-
 export const Checks = Object.freeze({
 	display,
 	accuracyCheck,

--- a/module/documents/items/armor/armor-data-model.mjs
+++ b/module/documents/items/armor/armor-data-model.mjs
@@ -35,9 +35,8 @@ Hooks.on(CheckHooks.renderCheck, (data, check, actor, item) => {
 
 		if (game.settings.get(SYSTEM, SETTINGS.technospheres)) {
 			CommonSections.slottedTechnospheres(data.sections, item.system.slotted);
-		} else {
-			CommonSections.description(data.sections, item.system.description, item.system.summary.value);
 		}
+		CommonSections.description(data.sections, item.system.description, item.system.summary.value);
 	}
 });
 

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -110,6 +110,7 @@ export const preloadHandlebarsTemplates = async function () {
 			'systems/projectfu/templates/chat/partials/chat-collapsible-description.hbs',
 			'systems/projectfu/templates/chat/partials/chat-generic-text.hbs',
 			'systems/projectfu/templates/chat/partials/chat-item-text.hbs',
+			'systems/projectfu/templates/chat/partials/chat-message-toggle.hbs',
 
 			// UI FUComponents
 			'systems/projectfu/templates/ui/combat-tracker.hbs',

--- a/module/ui/chat-log.mjs
+++ b/module/ui/chat-log.mjs
@@ -22,6 +22,10 @@ export class FUChatLog extends foundry.applications.sidebar.tabs.ChatLog {
 	}
 }
 
+// These icons refer the CURRENT state
+const SHOWN_ICON = 'fa-eye';
+const HIDDEN_ICON = 'fa-eye-slash';
+
 /**
  * @param {ChatMessage} message
  * @param {HTMLElement} html
@@ -31,37 +35,58 @@ function onRenderChatMessage(message, html) {
 	if (toggleSections.length === 0) return;
 
 	// Get game settings (true means hide, false means show)
-	const hideSettings = {
+	const settings = {
 		tags: getSystemSetting('optionChatMessageHideTags'),
 		quality: getSystemSetting('optionChatMessageHideQuality'),
 		description: getSystemSetting('optionChatMessageHideDescription'),
 		rollDetails: getSystemSetting('optionChatMessageHideRollDetails'),
 	};
 
+	const toggleVisibility = (visible) => {
+		toggleSections.forEach((section) => {
+			const shouldAlwaysShow = [
+				{ className: 'accuracy-check-results', setting: settings.rollDetails },
+				{ className: 'damage-results', setting: settings.rollDetails },
+				{ className: 'description', setting: settings.description },
+				{ className: 'quality', setting: settings.quality },
+				{ className: 'tags', setting: settings.tags },
+				{ className: 'pfu-tags', setting: settings.tags },
+			].some(({ className, setting }) => section.classList.contains(className) && !setting);
+
+			//section.classList.toggle('shown', shouldAlwaysShow || visible);
+			section.classList.toggle('hidden', !shouldAlwaysShow && !visible);
+		});
+	};
+
+	const setIconTooltip = (icon, visible) => {
+		icon.setAttribute('data-tooltip', game.i18n.localize(visible ? 'FU.ChatMessageShow' : 'FU.ChatMessageHide'));
+	};
+
+	// Add a button to do the toggle
 	const metaData = html.querySelector('.message-metadata');
 	const button = document.createElement('a');
 	button.classList.add('pfu-chat-message__toggle-section__button');
 	const icon = document.createElement('i');
-	icon.classList.add('fa', 'fa-eye-slash');
+	icon.classList.add('fa', HIDDEN_ICON);
+	setIconTooltip(icon, false);
 	button.appendChild(icon);
-	button.addEventListener('click', () => {});
-	metaData.appendChild(button);
-
-	// TODO: Add a conditional button in the 'message-metadata' to toggle after this
-	// Toggle visibility based on current state and settings
-	toggleSections.forEach((section) => {
-		const shouldHide = [
-			{ className: 'accuracy-check-results', setting: hideSettings.rollDetails },
-			{ className: 'damage-results', setting: hideSettings.rollDetails },
-			{ className: 'description', setting: hideSettings.description },
-			{ className: 'quality', setting: hideSettings.quality },
-			{ className: 'tags', setting: hideSettings.tags },
-			{ className: 'pfu-tags', setting: hideSettings.tags },
-		].some(({ className, setting }) => section.classList.contains(className) && setting);
-
-		//section.classList.toggle('shown', !shouldHide);
-		section.classList.toggle('hidden', shouldHide);
+	button.addEventListener('click', (event) => {
+		const icon = event.target;
+		const visible = icon.classList.contains(SHOWN_ICON);
+		if (visible) {
+			icon.classList.add(HIDDEN_ICON);
+			icon.classList.remove(SHOWN_ICON);
+		} else {
+			icon.classList.remove(HIDDEN_ICON);
+			icon.classList.add(SHOWN_ICON);
+		}
+		setIconTooltip(icon, visible);
+		toggleVisibility(!visible);
 	});
+	metaData.lastChild.before(button);
+
+	// Apply the default
+	toggleVisibility(false);
 }
 
 Hooks.on('renderChatMessageHTML', onRenderChatMessage);

--- a/module/ui/chat-log.mjs
+++ b/module/ui/chat-log.mjs
@@ -1,4 +1,4 @@
-import { getSystemSetting } from '../settings.js';
+import { getSystemSetting, SETTINGS } from '../settings.js';
 
 /**
  * The sidebar chat tab.
@@ -36,11 +36,16 @@ function onRenderChatMessage(message, html) {
 
 	// Get game settings (true means hide, false means show)
 	const settings = {
-		tags: getSystemSetting('optionChatMessageHideTags'),
-		quality: getSystemSetting('optionChatMessageHideQuality'),
-		description: getSystemSetting('optionChatMessageHideDescription'),
-		rollDetails: getSystemSetting('optionChatMessageHideRollDetails'),
+		tags: getSystemSetting(SETTINGS.optionChatMessageHideTags),
+		quality: getSystemSetting(SETTINGS.optionChatMessageHideQuality),
+		description: getSystemSetting(SETTINGS.optionChatMessageHideDescription),
+		rollDetails: getSystemSetting(SETTINGS.optionChatMessageHideRollDetails),
 	};
+
+	const hideAnything = Object.values(settings).some((hide) => hide === true);
+	if (!hideAnything) {
+		return;
+	}
 
 	const toggleVisibility = (visible) => {
 		toggleSections.forEach((section) => {
@@ -53,7 +58,6 @@ function onRenderChatMessage(message, html) {
 				{ className: 'pfu-tags', setting: settings.tags },
 			].some(({ className, setting }) => section.classList.contains(className) && !setting);
 
-			//section.classList.toggle('shown', shouldAlwaysShow || visible);
 			section.classList.toggle('hidden', !shouldAlwaysShow && !visible);
 		});
 	};
@@ -63,27 +67,29 @@ function onRenderChatMessage(message, html) {
 	};
 
 	// Add a button to do the toggle
-	const metaData = html.querySelector('.message-metadata');
-	const button = document.createElement('a');
-	button.classList.add('pfu-chat-message__toggle-section__button');
-	const icon = document.createElement('i');
-	icon.classList.add('fa', HIDDEN_ICON);
-	setIconTooltip(icon, false);
-	button.appendChild(icon);
-	button.addEventListener('click', (event) => {
-		const icon = event.target;
-		const visible = icon.classList.contains(SHOWN_ICON);
-		if (visible) {
-			icon.classList.add(HIDDEN_ICON);
-			icon.classList.remove(SHOWN_ICON);
-		} else {
-			icon.classList.remove(HIDDEN_ICON);
-			icon.classList.add(SHOWN_ICON);
-		}
-		setIconTooltip(icon, visible);
-		toggleVisibility(!visible);
-	});
-	metaData.lastChild.before(button);
+	if (hideAnything) {
+		const metaData = html.querySelector('.message-metadata');
+		const button = document.createElement('a');
+		button.classList.add('pfu-chat-message__toggle-section__button');
+		const icon = document.createElement('i');
+		icon.classList.add('fa', HIDDEN_ICON);
+		setIconTooltip(icon, false);
+		button.appendChild(icon);
+		button.addEventListener('click', (event) => {
+			const icon = event.target;
+			const visible = icon.classList.contains(SHOWN_ICON);
+			if (visible) {
+				icon.classList.add(HIDDEN_ICON);
+				icon.classList.remove(SHOWN_ICON);
+			} else {
+				icon.classList.remove(HIDDEN_ICON);
+				icon.classList.add(SHOWN_ICON);
+			}
+			setIconTooltip(icon, visible);
+			toggleVisibility(!visible);
+		});
+		metaData.lastChild.before(button);
+	}
 
 	// Apply the default
 	toggleVisibility(false);

--- a/module/ui/chat-log.mjs
+++ b/module/ui/chat-log.mjs
@@ -19,3 +19,42 @@ export class FUChatLog extends foundry.applications.sidebar.tabs.ChatLog {
 		});
 	}
 }
+
+document.addEventListener('click', (event) => {
+	const toggleLink = event.target.closest('.pfu-chat-message__toggle');
+	if (!toggleLink) return;
+
+	const chatMessage = toggleLink.closest('.chat-message');
+	const isHidden = toggleIcon.classList.contains('fa-chevron-up');
+
+	const toggleSections = chatMessage.querySelectorAll('.toggle-section');
+	const toggleIcon = toggleLink.querySelector('.toggle-icon');
+
+	// Get game settings (true means hide, false means show)
+	const settings = {
+		tags: game.settings.get('projectfu', 'optionChatMessageHideTags'),
+		quality: game.settings.get('projectfu', 'optionChatMessageHideQuality'),
+		description: game.settings.get('projectfu', 'optionChatMessageHideDescription'),
+		rollDetails: game.settings.get('projectfu', 'optionChatMessageHideRollDetails'),
+	};
+
+	// Toggle visibility based on current state and settings
+	toggleSections.forEach((section) => {
+		const shouldAlwaysShow = [
+			{ className: 'accuracy-check-results', setting: settings.rollDetails },
+			{ className: 'damage-results', setting: settings.rollDetails },
+			{ className: 'description', setting: settings.description },
+			{ className: 'quality', setting: settings.quality },
+			{ className: 'tags', setting: settings.tags },
+		].some(({ className, setting }) => section.classList.contains(className) && !setting);
+
+		section.classList.toggle('shown', shouldAlwaysShow || isHidden);
+		section.classList.toggle('hidden', !shouldAlwaysShow && !isHidden);
+	});
+
+	// Update toggle icon and tooltip
+	const newState = !isHidden;
+	toggleIcon.classList.toggle('fa-chevron-up', newState);
+	toggleIcon.classList.toggle('fa-chevron-down', !newState);
+	toggleLink.setAttribute('data-tooltip', game.i18n.localize(newState ? 'FU.ChatMessageHide' : 'FU.ChatMessageShow'));
+});

--- a/module/ui/chat-log.mjs
+++ b/module/ui/chat-log.mjs
@@ -1,3 +1,5 @@
+import { getSystemSetting } from '../settings.js';
+
 /**
  * The sidebar chat tab.
  *
@@ -20,37 +22,67 @@ export class FUChatLog extends foundry.applications.sidebar.tabs.ChatLog {
 	}
 }
 
+/**
+ * @param {ChatMessage} message
+ * @param {HTMLElement} html
+ */
+function onRenderChatMessage(message, html) {
+	const toggleSections = html.querySelectorAll('.pfu-chat-message__toggle-section');
+	if (toggleSections.length === 0) return;
+
+	// Get game settings (true means hide, false means show)
+	const hideSettings = {
+		tags: getSystemSetting('optionChatMessageHideTags'),
+		quality: getSystemSetting('optionChatMessageHideQuality'),
+		description: getSystemSetting('optionChatMessageHideDescription'),
+		rollDetails: getSystemSetting('optionChatMessageHideRollDetails'),
+	};
+
+	const metaData = html.querySelector('.message-metadata');
+	const button = document.createElement('a');
+	button.classList.add('pfu-chat-message__toggle-section__button');
+	const icon = document.createElement('i');
+	icon.classList.add('fa', 'fa-eye-slash');
+	button.appendChild(icon);
+	button.addEventListener('click', () => {});
+	metaData.appendChild(button);
+
+	// TODO: Add a conditional button in the 'message-metadata' to toggle after this
+	// Toggle visibility based on current state and settings
+	toggleSections.forEach((section) => {
+		const shouldHide = [
+			{ className: 'accuracy-check-results', setting: hideSettings.rollDetails },
+			{ className: 'damage-results', setting: hideSettings.rollDetails },
+			{ className: 'description', setting: hideSettings.description },
+			{ className: 'quality', setting: hideSettings.quality },
+			{ className: 'tags', setting: hideSettings.tags },
+			{ className: 'pfu-tags', setting: hideSettings.tags },
+		].some(({ className, setting }) => section.classList.contains(className) && setting);
+
+		//section.classList.toggle('shown', !shouldHide);
+		section.classList.toggle('hidden', shouldHide);
+	});
+}
+
+Hooks.on('renderChatMessageHTML', onRenderChatMessage);
+
+/**
+ * @desc Toggles the whole chat message section.
+ */
 document.addEventListener('click', (event) => {
 	const toggleLink = event.target.closest('.pfu-chat-message__toggle');
 	if (!toggleLink) return;
 
 	const chatMessage = toggleLink.closest('.chat-message');
+	const chatMessageContent = chatMessage.querySelector('.message-content');
+	const toggleIcon = toggleLink.querySelector('.toggle-icon');
 	const isHidden = toggleIcon.classList.contains('fa-chevron-up');
 
-	const toggleSections = chatMessage.querySelectorAll('.toggle-section');
-	const toggleIcon = toggleLink.querySelector('.toggle-icon');
-
-	// Get game settings (true means hide, false means show)
-	const settings = {
-		tags: game.settings.get('projectfu', 'optionChatMessageHideTags'),
-		quality: game.settings.get('projectfu', 'optionChatMessageHideQuality'),
-		description: game.settings.get('projectfu', 'optionChatMessageHideDescription'),
-		rollDetails: game.settings.get('projectfu', 'optionChatMessageHideRollDetails'),
-	};
-
-	// Toggle visibility based on current state and settings
-	toggleSections.forEach((section) => {
-		const shouldAlwaysShow = [
-			{ className: 'accuracy-check-results', setting: settings.rollDetails },
-			{ className: 'damage-results', setting: settings.rollDetails },
-			{ className: 'description', setting: settings.description },
-			{ className: 'quality', setting: settings.quality },
-			{ className: 'tags', setting: settings.tags },
-		].some(({ className, setting }) => section.classList.contains(className) && !setting);
-
-		section.classList.toggle('shown', shouldAlwaysShow || isHidden);
-		section.classList.toggle('hidden', !shouldAlwaysShow && !isHidden);
-	});
+	if (isHidden) {
+		chatMessageContent.classList.add('hidden');
+	} else {
+		chatMessageContent.classList.remove('hidden');
+	}
 
 	// Update toggle icon and tooltip
 	const newState = !isHidden;

--- a/styles/css/chat/chat.css
+++ b/styles/css/chat/chat.css
@@ -1,0 +1,8 @@
+.pfu-chat-message__toggle {
+}
+
+.pfu-chat-message__toggle-section {
+}
+
+.pfu-chat-message__toggle-section__button {
+}

--- a/styles/projectfu.css
+++ b/styles/projectfu.css
@@ -51,6 +51,7 @@
 @import 'css/app/_index.css';
 @import 'css/actor/_index.css';
 
+@import 'css/chat/chat.css';
 @import 'css/chat/chat-prompt.css';
 @import 'css/chat/chat-slotted-technospheres.css';
 @import 'css/chat/chat-optional-features.css';

--- a/templates/chat/chat-check-flavor-item-v2.hbs
+++ b/templates/chat/chat-check-flavor-item-v2.hbs
@@ -4,12 +4,7 @@
 	{{#each linked as |li|}}
 		{{pfuItemAnchor li classes="fu-image__link"}}
 	{{/each}}
-	<a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
-		 data-tooltip="{{localize 'FU.ChatMessageShow'}}">
-			<span class="fu-tag button" style="padding: 5px;">
-				<i class="fas fa-chevron-up toggle-icon"></i>
-			</span>
-	</a>
+	{{> "systems/projectfu/templates/chat/partials/chat-message-toggle.hbs"}}
 </header>
 {{#if subtitle}}
 	<div class="chat-header" style="padding: 0;">

--- a/templates/chat/chat-check-flavor-item-v2.hbs
+++ b/templates/chat/chat-check-flavor-item-v2.hbs
@@ -4,7 +4,7 @@
 	{{#each linked as |li|}}
 		{{pfuItemAnchor li classes="fu-image__link"}}
 	{{/each}}
-	<a class="universal-toggle pfu-tags flexrow gap-5" style="align-items:end;"
+	<a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
 		 data-tooltip="{{localize 'FU.ChatMessageShow'}}">
 			<span class="fu-tag button" style="padding: 5px;">
 				<i class="fas fa-chevron-up toggle-icon"></i>

--- a/templates/chat/chat-check-flavor-item.hbs
+++ b/templates/chat/chat-check-flavor-item.hbs
@@ -3,10 +3,5 @@
 																									 alt="Image" data-item-id="{{id}}" class="item-img"></a>
 	<h2 style="flex-grow: 8;">{{name}}</h2>
 
-	<a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
-		 data-tooltip="{{localize 'FU.ChatMessageShow'}}">
-        <span class="fu-tag button" style="padding: 5px;">
-            <i class="fas fa-chevron-up toggle-icon"></i>
-        </span>
-	</a>
+	{{> "systems/projectfu/templates/chat/partials/chat-message-toggle.hbs"}}
 </header>

--- a/templates/chat/chat-check-flavor-item.hbs
+++ b/templates/chat/chat-check-flavor-item.hbs
@@ -3,7 +3,7 @@
 																									 alt="Image" data-item-id="{{id}}" class="item-img"></a>
 	<h2 style="flex-grow: 8;">{{name}}</h2>
 
-	<a class="universal-toggle pfu-tags flexrow gap-5" style="align-items:end;"
+	<a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
 		 data-tooltip="{{localize 'FU.ChatMessageShow'}}">
         <span class="fu-tag button" style="padding: 5px;">
             <i class="fas fa-chevron-up toggle-icon"></i>

--- a/templates/chat/partials/chat-accuracy-check.hbs
+++ b/templates/chat/partials/chat-accuracy-check.hbs
@@ -17,7 +17,7 @@
 </header>
 
 <!-- Roll Details Section -->
-<div class="toggle-section accuracy-check-results {{#if (pfuGetSetting 'optionChatMessageHideRollDetails')}}hidden{{/if}}">
+<div class="pfu-chat-message__toggle-section accuracy-check-results {{#if (pfuGetSetting 'optionChatMessageHideRollDetails')}}hidden{{/if}}">
     <div class="flexrow gap-5">
         <div class='detail-desc flex-group-center grid grid-3col flex3'>
             <div data-tooltip="(Die Size: {{primary.dice}})">

--- a/templates/chat/partials/chat-basic-attack-details.hbs
+++ b/templates/chat/partials/chat-basic-attack-details.hbs
@@ -1,11 +1,11 @@
 {{#if basic.quality}}
-    <div class="toggle-section quality {{#if (pfuGetSetting 'optionChatMessageHideQuality')}}hidden{{/if}}">
+    <div class="pfu-chat-message__toggle-section quality {{#if (pfuGetSetting 'optionChatMessageHideQuality')}}hidden{{/if}}">
         {{> 'systems/projectfu/templates/chat/partials/chat-item-quality.hbs' quality=basic.quality}}
     </div>
 {{/if}}
 
 {{#if (or basic.summary basic.description)}}
-    <div class="toggle-section description {{#if (pfuGetSetting 'optionChatMessageHideDescription')}}hidden{{/if}}">
+    <div class="pfu-chat-message__toggle-section description {{#if (pfuGetSetting 'optionChatMessageHideDescription')}}hidden{{/if}}">
         {{> 'systems/projectfu/templates/chat/partials/chat-item-description.hbs' summary=basic.summary description=basic.description}}
     </div>
 {{/if}}

--- a/templates/chat/partials/chat-check-damage.hbs
+++ b/templates/chat/partials/chat-check-damage.hbs
@@ -7,7 +7,7 @@
 	</label>
 </header>
 
-<div class="toggle-section accuracy-check-results {{#if (pfuGetSetting 'optionChatMessageHideRollDetails')}}hidden{{/if}}">
+<div class="pfu-chat-message__toggle-section accuracy-check-results {{#if (pfuGetSetting 'optionChatMessageHideRollDetails')}}hidden{{/if}}">
     <div class="flexrow gap-5">
         <div class='detail-desc flex-group-center grid grid-2col desc flex2'>
             <div>

--- a/templates/chat/partials/chat-item-description.hbs
+++ b/templates/chat/partials/chat-item-description.hbs
@@ -1,11 +1,9 @@
-<div>
-    <div class='chat-desc'>
-        <details {{#unless (pfuGetSetting 'optionChatMessageCollapseDescription')}}{{open}}{{/unless}}>
-            <summary class="collapsible-description align-center">{{localize 'FU.Description'}}</summary>
-            {{#if summary}}
-                <blockquote class='summary quote'>{{summary}}</blockquote>
-            {{/if}}
-            {{{description}}}
-        </details>
-    </div>
+<div class='pfu-chat-message__toggle-section description chat-desc'>
+	<details {{#unless (pfuGetSetting 'optionChatMessageCollapseDescription')}}{{open}}{{/unless}}>
+		<summary class="collapsible-description align-center">{{localize 'FU.Description'}}</summary>
+		{{#if summary}}
+			<blockquote class='summary quote'>{{summary}}</blockquote>
+		{{/if}}
+		{{{description}}}
+	</details>
 </div>

--- a/templates/chat/partials/chat-item-tags.hbs
+++ b/templates/chat/partials/chat-item-tags.hbs
@@ -1,4 +1,4 @@
-<div class="pfu-tags">
+<div class="pfu-chat-message__toggle-section pfu-tags">
     {{#each tags}}
         {{#if flip}}
             <div class="fu-tag" data-tooltip="{{localize tooltip}}">{{value}}{{separator}} {{localize tag}}</div>

--- a/templates/chat/partials/chat-item-tags.hbs
+++ b/templates/chat/partials/chat-item-tags.hbs
@@ -1,9 +1,11 @@
-<div class="pfu-chat-message__toggle-section pfu-tags">
-    {{#each tags}}
-        {{#if flip}}
-            <div class="fu-tag" data-tooltip="{{localize tooltip}}">{{value}}{{separator}} {{localize tag}}</div>
-        {{else}}
-            <div class="fu-tag" data-tooltip="{{localize tooltip}}">{{localize tag}}{{separator}} {{value}}</div>
-        {{/if}}
-    {{/each}}
-</div>
+{{#if tags}}
+	<div class="pfu-chat-message__toggle-section pfu-tags">
+		{{#each tags}}
+			{{#if flip}}
+				<div class="fu-tag" data-tooltip="{{localize tooltip}}">{{value}}{{separator}} {{localize tag}}</div>
+			{{else}}
+				<div class="fu-tag" data-tooltip="{{localize tooltip}}">{{localize tag}}{{separator}} {{value}}</div>
+			{{/if}}
+		{{/each}}
+	</div>
+{{/if}}

--- a/templates/chat/partials/chat-message-toggle.hbs
+++ b/templates/chat/partials/chat-message-toggle.hbs
@@ -1,0 +1,6 @@
+<a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
+   data-tooltip="{{localize 'FU.ChatMessageShow'}}">
+	<span class="fu-tag button" style="padding: 5px;">
+		<i class="fas fa-chevron-up toggle-icon"></i>
+	</span>
+</a>

--- a/templates/chat/partials/chat-spell-details.hbs
+++ b/templates/chat/partials/chat-spell-details.hbs
@@ -1,4 +1,4 @@
-<div class="toggle-section tags {{#if (pfuGetSetting 'optionChatMessageHideTags')}}hidden{{/if}}">
+<div class="pfu-chat-message__toggle-section tags {{#if (pfuGetSetting 'optionChatMessageHideTags')}}hidden{{/if}}">
     <div class="pfu-tags">
         <div class="fu-tag">
             {{#if spell.duration}}
@@ -25,13 +25,13 @@
 </div>
 
 {{#if spell.opportunity}}
-    <div class="toggle-section quality {{#if (pfuGetSetting 'optionChatMessageHideQuality')}}hidden{{/if}}">
+    <div class="pfu-chat-message__toggle-section quality {{#if (pfuGetSetting 'optionChatMessageHideQuality')}}hidden{{/if}}">
         {{> 'systems/projectfu/templates/chat/partials/chat-item-opportunity.hbs' opportunity=spell.opportunity}}
     </div>
 {{/if}}
 
 {{#if (or spell.summary spell.description)}}
-    <div class="toggle-section description {{#if (pfuGetSetting 'optionChatMessageHideDescription')}}hidden{{/if}}">
+    <div class="pfu-chat-message__toggle-section description {{#if (pfuGetSetting 'optionChatMessageHideDescription')}}hidden{{/if}}">
         {{> 'systems/projectfu/templates/chat/partials/chat-item-description.hbs' summary=spell.summary description=spell.description}}
     </div>
 {{/if}}

--- a/templates/chat/partials/chat-weapon-details.hbs
+++ b/templates/chat/partials/chat-weapon-details.hbs
@@ -1,11 +1,11 @@
 {{#if weapon.quality}}
-    <div class="toggle-section quality {{#if (pfuGetSetting 'optionChatMessageHideQuality')}}hidden{{/if}}">
+    <div class="pfu-chat-message__toggle-section quality {{#if (pfuGetSetting 'optionChatMessageHideQuality')}}hidden{{/if}}">
         {{> 'systems/projectfu/templates/chat/partials/chat-item-quality.hbs' quality=weapon.quality}}
     </div>
 {{/if}}
 
 {{#if (or weapon.summary weapon.description)}}
-    <div class="toggle-section description {{#if (pfuGetSetting 'optionChatMessageHideDescription')}}hidden{{/if}}">
+    <div class="pfu-chat-message__toggle-section description {{#if (pfuGetSetting 'optionChatMessageHideDescription')}}hidden{{/if}}">
         {{> 'systems/projectfu/templates/chat/partials/chat-item-description.hbs' summary=weapon.summary description=weapon.description}}
     </div>
 {{/if}}

--- a/templates/feature/invoker/invocation-use-flavor.hbs
+++ b/templates/feature/invoker/invocation-use-flavor.hbs
@@ -6,10 +6,5 @@
 	<i class="fu-icon--s {{icon}}"></i>
     <h2 style="flex-grow: 8; margin-left: 4px;">{{name}}</h2>
 
-    <a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
-			 data-tooltip="{{localize 'FU.ChatMessageShow'}}">
-        <span class="fu-tag button" style="padding: 5px;">
-            <i class="fas fa-chevron-up toggle-icon"></i>
-        </span>
-    </a>
+	{{> "systems/projectfu/templates/chat/partials/chat-message-toggle.hbs"}}
 </header>

--- a/templates/feature/invoker/invocation-use-flavor.hbs
+++ b/templates/feature/invoker/invocation-use-flavor.hbs
@@ -6,7 +6,7 @@
 	<i class="fu-icon--s {{icon}}"></i>
     <h2 style="flex-grow: 8; margin-left: 4px;">{{name}}</h2>
 
-    <a class="universal-toggle pfu-tags flexrow gap-5" style="align-items:end;"
+    <a class="pfu-chat-message__toggle pfu-tags flexrow gap-5" style="align-items:end;"
 			 data-tooltip="{{localize 'FU.ChatMessageShow'}}">
         <span class="fu-tag button" style="padding: 5px;">
             <i class="fas fa-chevron-up toggle-icon"></i>


### PR DESCRIPTION
This PR updates that chat message toggling, resolving several issues:

- The chevron button works correctly*.
- Updates the chat message rendering depending on the settings, hooking a toggle button for it as well.