### PR TITLE
Party Features

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1495,6 +1495,7 @@
 		"NpcProfileUpdate": "Update NPC Profile",
 		"ActiveParty": "Active Party",
 		"ActivePartyHint": "Set the active party",
+		"ActivePartySetNotification": "{name} is now the active party.",
 		"ActivePartyNotAssigned": "No party has been assigned in the system settings.",
 		"ActivePartySheetOpen": "Open Party Sheet",
 		"Identifier": "Identifier",

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -759,42 +759,6 @@ export class FUPartySheet extends FUActorSheet {
 	}
 
 	/**
-	 * Show selection dialog then confirmation
-	 * @param {JournalEntryPage[]} pages Array of pages to select from
-	 * @returns {Promise<JournalEntryPage[]|null>} Selected pages or null if cancelled
-	 */
-	async #promptSelectAndConfirmPages(documentType, pages) {
-		if (!pages || pages.length === 0) return null;
-
-		// First show selection dialog
-		const selectedPages = await this.#promptSelectItems(documentType, pages);
-
-		if (!selectedPages || selectedPages.length === 0) {
-			return null;
-		}
-
-		// Enrich pages with source journal info for confirmation display
-		const enrichedPages = selectedPages.map((page) => ({
-			name: `${page.name} (${page.parent?.name || 'Unknown Journal'})`,
-			img: page.src,
-		}));
-
-		// Show confirmation dialog
-		const content = await FoundryUtils.renderTemplate('common/document-list', {
-			message: 'The following journal entry pages will be imported as codex entries.',
-			documents: enrichedPages,
-		});
-
-		const confirm = await FoundryUtils.confirm('FU.Import', content);
-
-		if (confirm) {
-			return selectedPages;
-		}
-
-		return null;
-	}
-
-	/**
 	 * Show a selection dialog to choose which items to import
 	 * @param {string} documentType The type label (FU.Actor, DOCUMENT.JournalEntryPage, etc)
 	 * @param {Document[]} items Array of items to select from
@@ -1036,7 +1000,7 @@ export class FUPartySheet extends FUActorSheet {
 
 	/**
 	 * Helper to show actor import dialog with optional selection
-	 * @param {FUActor[]} [initialActors] Pre-selected actors from drop, shows selection dialog if provided
+	 * @param {FUActor[]} [initialActors] Pre-selected actors from drop
 	 * @returns {Promise<void>}
 	 */
 	async #showActorImportDialog(initialActors = null) {
@@ -1049,19 +1013,11 @@ export class FUPartySheet extends FUActorSheet {
 		}
 
 		if (selected && selected.length > 0) {
-			const content = await FoundryUtils.renderTemplate('common/document-list', {
-				message: 'The following actors will be imported as codex entries.',
-				documents: selected,
-			});
-
-			const confirm = await FoundryUtils.confirm('FU.Import', content);
-			if (confirm) {
-				const result = await this.#importActorsToCodex(selected);
-				if (result.skipped.length > 0) {
-					ui.notifications.warn(`Imported ${result.imported}/${selected.length} actors. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
-				} else {
-					ui.notifications.info(`Imported ${result.imported}/${selected.length} actors to Codex.`);
-				}
+			const result = await this.#importActorsToCodex(selected);
+			if (result.skipped.length > 0) {
+				ui.notifications.warn(`Imported ${result.imported}/${selected.length} actors. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
+			} else {
+				ui.notifications.info(`Imported ${result.imported}/${selected.length} actors to Codex.`);
 			}
 		}
 	}
@@ -1077,34 +1033,82 @@ export class FUPartySheet extends FUActorSheet {
 	}
 
 	/**
-	 * Helper to show journal entry import dialog with selection and confirmation combined
-	 * @param {JournalEntry[]} [initialEntries] Pre-selected journals from drop, shows selection in confirmation if provided
+	 * Helper to show journal entry import dialog
+	 * Groups journal pages by their parent journal with visual hierarchy
+	 * @param {JournalEntry[]} [initialEntries] Pre-selected journals from drop
 	 * @returns {Promise<void>}
 	 */
 	async #showJournalImportDialog(initialEntries = null) {
-		let selected = initialEntries;
+		let journals = initialEntries;
 
-		if (!selected) {
-			selected = await FoundryUtils.selectJournalEntries();
+		if (!journals) {
+			journals = game.journal.contents;
 		}
 
-		if (selected && selected.length > 0) {
-			let pages = selected.flatMap((je) => je.pages.contents);
+		if (!journals || journals.length === 0) {
+			ui.notifications.warn('No journal entries found in this world.');
+			return;
+		}
 
-			if (pages.length === 0) {
-				ui.notifications.warn('No pages found in selected journals.');
-				return;
+		const groups = [];
+		let allPages = [];
+		let itemIndex = 0;
+
+		for (const journal of journals) {
+			const journalPages = journal.pages.contents.map((page) => {
+				const pageItem = {
+					id: page.id,
+					uuid: page.uuid,
+					name: page.name,
+					img: page.src || journal.img,
+					_originalPage: page,
+					_flatIndex: itemIndex,
+					_journalUuid: journal.uuid,
+				};
+				allPages.push(pageItem);
+				itemIndex++;
+				return pageItem;
+			});
+
+			if (journalPages.length > 0) {
+				groups.push({
+					name: journal.name,
+					items: journalPages,
+				});
 			}
+		}
 
-			const selectedPages = await this.#promptSelectAndConfirmPages('DOCUMENT.JournalEntryPage', pages);
+		if (allPages.length === 0) {
+			ui.notifications.warn('No pages found in selected journals.');
+			return;
+		}
+
+		const data = {
+			title: `${StringUtils.localize('CONTROLS.CommonSelect')} ${StringUtils.localize('DOCUMENT.JournalEntryPage')}`,
+			style: 'grouped-list',
+			groups: groups,
+			items: allPages,
+			initial: [],
+			getDescription: async () => '',
+		};
+
+		try {
+			const dialog = new ItemSelectionDialog(data);
+			const selectedPages = await dialog.open();
 
 			if (selectedPages && selectedPages.length > 0) {
-				const result = await this.#importJournalPagesToCodex(selectedPages);
+				const pages = selectedPages.map((item) => item._originalPage);
+				const result = await this.#importJournalPagesToCodex(pages);
 				if (result.skipped.length > 0) {
-					ui.notifications.warn(`Imported ${result.imported}/${selectedPages.length} journal pages. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
+					ui.notifications.warn(`Imported ${result.imported}/${pages.length} journal pages. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
 				} else {
-					ui.notifications.info(`Imported ${result.imported}/${selectedPages.length} journal pages.`);
+					ui.notifications.info(`Imported ${result.imported}/${pages.length} journal pages.`);
 				}
+			}
+		} catch (error) {
+			if (error.message !== 'Canceled by user.') {
+				console.error('Error importing journal pages:', error);
+				ui.notifications.error('Error importing journal pages.');
 			}
 		}
 	}

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -472,7 +472,8 @@ export class FUPartySheet extends FUActorSheet {
 	 */
 	static async #activate() {
 		console.debug(`Setting ${this.actor.name} as the active party`);
-		game.settings.set(Flags.Scope, SETTINGS.activeParty, this.actor._id);
+		await game.settings.set(Flags.Scope, SETTINGS.activeParty, this.actor._id);
+		ui.notifications.info(game.i18n.format('FU.ActivePartySetNotification', { name: this.actor.name }));
 	}
 
 	/**

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -1,4 +1,5 @@
 import { ActorSheetUtils } from './actor-sheet-utils.mjs';
+import { ItemSelectionDialog } from '../ui/features/item-selection-dialog.mjs';
 import { SystemControls } from '../helpers/system-controls.mjs';
 import { FU, SYSTEM, systemPath } from '../helpers/config.mjs';
 import { getSystemSetting, SETTINGS } from '../settings.js';
@@ -144,6 +145,7 @@ export class FUPartySheet extends FUActorSheet {
 	#consumablesTable = new ConsumablesTableRenderer();
 	#otherItemsTable = new OtherItemsTableRenderer('accessory', 'armor', 'consumable', 'shield', 'treasure', 'weapon');
 	#codexBrowser;
+	#codexDrop;
 	/** @type SheetExtensions **/
 	#extensions;
 
@@ -344,6 +346,7 @@ export class FUPartySheet extends FUActorSheet {
 			case 'codex':
 				{
 					this.codexBrowser.attachListeners(html);
+					this.#attachCodexDropzoneListeners(html);
 
 					FoundryUtils.contextMenu(
 						html,
@@ -445,6 +448,15 @@ export class FUPartySheet extends FUActorSheet {
 
 		// Update the code browser
 		this.codexBrowser.refresh(this.actor, this.element);
+	}
+
+	/** @inheritdoc */
+	async _onClose(options) {
+		if (this.#codexDrop instanceof Function) {
+			this.#codexDrop();
+			this.#codexDrop = null;
+		}
+		return super._onClose(options);
 	}
 
 	/**
@@ -574,18 +586,393 @@ export class FUPartySheet extends FUActorSheet {
 		return super._onDropItem(event, item);
 	}
 
-	async _onDropActor(event, actor) {
-		console.debug(`${actor.name} was dropped onto party sheet`);
-		if (actor.type === 'character') {
-			return this.party.addCharacter(actor);
-		} else if (actor.type === 'npc') {
-			if (actor.system.rank.value === 'companion') {
-				return this.party.addCompanion(actor);
-			} else {
-				return this.party.addOrUpdateAdversary(actor, 0);
+	async _onDropFolder(event, folder) {
+		if (this.#isCodexDropZone(event)) {
+			if (folder?.type === 'Actor') {
+				const folderIds = this.#collectFolderIds(folder);
+				const actors = (game.actors?.contents ?? []).filter((actor) => folderIds.has(this.#resolveFolderId(actor)));
+
+				if (actors.length === 0) {
+					ui.notifications.warn('No actors found in this folder.');
+					return folder;
+				}
+
+				await this.#showActorImportDialog(actors);
+				return folder;
+			}
+
+			if (folder?.type === 'JournalEntry') {
+				const folderIds = this.#collectFolderIds(folder);
+				const entries = (game.journal?.contents ?? []).filter((entry) => folderIds.has(this.#resolveFolderId(entry)));
+
+				if (entries.length === 0) {
+					ui.notifications.warn('No journals found in this folder.');
+					return folder;
+				}
+
+				await this.#showJournalImportDialog(entries);
+				return folder;
+			}
+		} else {
+			if (folder?.type === 'Actor') {
+				const folderIds = this.#collectFolderIds(folder);
+				const actors = (game.actors?.contents ?? []).filter((actor) => folderIds.has(this.#resolveFolderId(actor)));
+
+				// Add each actor to the appropriate party list
+				for (const actor of actors) {
+					const actorCategory = this.#classifyDroppedActor(actor);
+					if (actorCategory === 'character') {
+						await this.party.addCharacter(actor);
+					} else if (actorCategory === 'companion') {
+						await this.party.addCompanion(actor);
+					} else if (actorCategory === 'adversary') {
+						await this.party.addOrUpdateAdversary(actor, 0);
+					}
+				}
+				return folder;
 			}
 		}
+
+		if (super._onDropFolder instanceof Function) {
+			return super._onDropFolder(event, folder);
+		}
+		return super._onDrop(event);
+	}
+
+	/**
+	 * Document drop routing
+	 * @param {DragEvent} event
+	 * @param {Document} document
+	 * @returns {Promise<Document|null|undefined>}
+	 */
+	async _onDropDocument(event, document) {
+		if (this.#isCodexDropZone(event)) {
+			if (document?.documentName === 'Actor') {
+				await this.#showActorImportDialog([document]);
+				return document;
+			}
+
+			if (document?.documentName === 'JournalEntry') {
+				await this.#showJournalImportDialog([document]);
+				return document;
+			}
+		}
+
+		if (super._onDropDocument instanceof Function) {
+			return super._onDropDocument(event, document);
+		}
+
+		// fallback for environments without _onDropDocument.
+		if (document?.documentName === 'Actor') {
+			return this._onDropActor(event, document);
+		}
+		return super._onDrop(event);
+	}
+
+	async _onDropActor(event, actor) {
+		if (this.#isCodexDropZone(event)) {
+			await this.#showActorImportDialog([actor]);
+			return actor;
+		}
+
+		if (this.#isCodexDropZone(event)) {
+			await this.#showActorImportDialog([actor]);
+			return actor;
+		}
+
+		console.debug(`${actor.name} was dropped onto party sheet`);
+		const actorCategory = this.#classifyDroppedActor(actor);
+		if (actorCategory === 'character') {
+			return this.party.addCharacter(actor);
+		}
+		if (actorCategory === 'companion') {
+			return this.party.addCompanion(actor);
+		}
+		if (actorCategory === 'adversary') {
+			return this.party.addOrUpdateAdversary(actor, 0);
+		}
 		return super._onDropActor(event, actor);
+	}
+
+	/**
+	 * @param {FUActor[]} actors
+	 * @returns {Promise<{imported: number, skipped: string[]}>}
+	 */
+	async #importActorsToCodex(actors) {
+		const existing = new Set((this.party.codex.entries ?? []).map((entry) => (entry?.name ?? '').trim().toLowerCase()).filter(Boolean));
+		let imported = 0;
+		const skipped = [];
+
+		for (const actor of actors) {
+			const name = (actor?.name ?? '').trim();
+			const key = name.toLowerCase();
+			if (!key || existing.has(key)) {
+				skipped.push(name || '(unnamed actor)');
+				continue;
+			}
+			await this.codexBrowser.importActor(actor);
+			existing.add(key);
+			imported += 1;
+		}
+
+		return { imported, skipped };
+	}
+
+	/**
+	 * @param {JournalEntryPage[]} pages
+	 * @returns {Promise<{imported: number, skipped: string[]}>}
+	 */
+	async #importJournalPagesToCodex(pages) {
+		const existing = new Set((this.party.codex.entries ?? []).map((entry) => (entry?.name ?? '').trim().toLowerCase()).filter(Boolean));
+		let imported = 0;
+		const skipped = [];
+
+		for (const page of pages) {
+			let name = (page?.name ?? '').trim();
+
+			if (!name) {
+				skipped.push('(unnamed page)');
+				continue;
+			}
+
+			// Include journal name for distinguishing pages with same name
+			const journalName = page.parent?.name;
+			if (journalName) {
+				name = `${name} (${journalName})`;
+			}
+
+			const key = name.toLowerCase();
+
+			// Skip if duplicate
+			if (existing.has(key)) {
+				skipped.push(name);
+				continue;
+			}
+
+			await this.codexBrowser.importJournalEntryPage(page);
+			existing.add(key);
+			imported += 1;
+		}
+
+		return { imported, skipped };
+	}
+
+	/**
+	 * Show selection dialog then confirmation
+	 * @param {JournalEntryPage[]} pages Array of pages to select from
+	 * @returns {Promise<JournalEntryPage[]|null>} Selected pages or null if cancelled
+	 */
+	async #promptSelectAndConfirmPages(documentType, pages) {
+		if (!pages || pages.length === 0) return null;
+
+		// First show selection dialog
+		const selectedPages = await this.#promptSelectItems(documentType, pages);
+
+		if (!selectedPages || selectedPages.length === 0) {
+			return null;
+		}
+
+		// Enrich pages with source journal info for confirmation display
+		const enrichedPages = selectedPages.map((page) => ({
+			name: `${page.name} (${page.parent?.name || 'Unknown Journal'})`,
+			img: page.src,
+		}));
+
+		// Show confirmation dialog
+		const content = await FoundryUtils.renderTemplate('common/document-list', {
+			message: 'The following journal entry pages will be imported as codex entries.',
+			documents: enrichedPages,
+		});
+
+		const confirm = await FoundryUtils.confirm('FU.Import', content);
+
+		if (confirm) {
+			return selectedPages;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Show a selection dialog to choose which items to import
+	 * @param {string} documentType The type label (FU.Actor, DOCUMENT.JournalEntryPage, etc)
+	 * @param {Document[]} items Array of items to select from
+	 * @returns {Promise<Document[]|null>} Selected items or null if cancelled
+	 */
+	async #promptSelectItems(documentType, items) {
+		if (!items || items.length === 0) return null;
+		if (items.length === 1) return items; // Skip dialog for single item
+
+		const displayItems = items.map((item, idx) => ({
+			_originalIndex: idx,
+			uuid: item?.uuid,
+			id: item?.id,
+			img: item?.img || item?.src,
+			pack: item?.pack,
+			documentName: item?.documentName,
+			parent: item?.parent,
+			name: item.parent?.name && item.documentName === 'JournalEntryPage' ? `${item.name} (${item.parent.name})` : item.name,
+		}));
+
+		const data = {
+			title: `Select ${game.i18n.localize(documentType)} to Import`,
+			style: 'list',
+			items: displayItems,
+			initial: displayItems,
+			max: displayItems.length,
+			getDescription: async (item) => item.name,
+		};
+
+		const dialog = new ItemSelectionDialog(data);
+		const selected = await dialog.open();
+
+		if (!selected || selected.length === 0) return null;
+
+		return selected
+			.filter((sel) => sel && sel._originalIndex !== undefined)
+			.map((sel) => items[sel._originalIndex])
+			.filter(Boolean);
+	}
+
+	/**
+	 * @param {DragEvent} event
+	 * @returns {boolean}
+	 */
+	#isCodexDropZone(event) {
+		const target = event?.target instanceof Element ? event.target.closest('[data-codex-dropzone]') : null;
+		return target?.dataset?.codexDropzone === 'entry';
+	}
+
+	/**
+	 * @param {Folder} root
+	 * @returns {Set<string>}
+	 */
+	#collectFolderIds(root) {
+		const ids = new Set();
+		const queue = [root];
+		const foldersByParent = new Map();
+
+		for (const folder of game.folders.filter((f) => f?.type === root?.type)) {
+			const parentId = this.#resolveFolderId(folder);
+			if (!foldersByParent.has(parentId)) foldersByParent.set(parentId, []);
+			foldersByParent.get(parentId).push(folder);
+		}
+
+		while (queue.length) {
+			const current = queue.shift();
+			if (!current?.id || ids.has(current.id)) continue;
+			ids.add(current.id);
+			queue.push(...(foldersByParent.get(current.id) ?? []));
+		}
+		return ids;
+	}
+
+	/**
+	 * @param {object} document
+	 * @returns {string|null}
+	 */
+	#resolveFolderId(document) {
+		if (!document) return null;
+		if (typeof document.folder === 'string') return document.folder;
+		if (document.folder?.id) return document.folder.id;
+		if (typeof document.parent === 'string') return document.parent;
+		if (document.parent?.id) return document.parent.id;
+		return null;
+	}
+
+	/**
+	 * @param {HTMLElement} html
+	 */
+	#attachCodexDropzoneListeners(html) {
+		if (this.#codexDrop instanceof Function) {
+			this.#codexDrop();
+			this.#codexDrop = null;
+		}
+
+		const dropRoot = html.querySelector('[data-codex-drop-root]');
+		if (!dropRoot) {
+			return;
+		}
+
+		let hideTimer = null;
+		const clearDropState = () => {
+			if (hideTimer) {
+				clearTimeout(hideTimer);
+				hideTimer = null;
+			}
+			dropRoot.classList.remove('show-dropzones');
+		};
+
+		const showDropState = () => {
+			if (hideTimer) {
+				clearTimeout(hideTimer);
+				hideTimer = null;
+			}
+			dropRoot.classList.add('show-dropzones');
+		};
+
+		const onRootDragEnter = () => {
+			showDropState();
+		};
+
+		const onRootDragOver = (event) => {
+			showDropState();
+			event.preventDefault();
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = 'copy';
+			}
+		};
+
+		const onRootDragLeave = () => {
+			if (hideTimer) {
+				clearTimeout(hideTimer);
+			}
+			hideTimer = setTimeout(() => clearDropState(), 80);
+		};
+
+		const onRootDrop = () => {
+			clearDropState();
+		};
+
+		const onGlobalDragEnd = () => {
+			clearDropState();
+		};
+
+		const onGlobalDrop = () => {
+			clearDropState();
+		};
+
+		dropRoot.addEventListener('dragenter', onRootDragEnter);
+		dropRoot.addEventListener('dragover', onRootDragOver);
+		dropRoot.addEventListener('dragleave', onRootDragLeave);
+		dropRoot.addEventListener('drop', onRootDrop);
+		document.addEventListener('dragend', onGlobalDragEnd);
+		document.addEventListener('drop', onGlobalDrop);
+
+		this.#codexDrop = () => {
+			clearDropState();
+			dropRoot.removeEventListener('dragenter', onRootDragEnter);
+			dropRoot.removeEventListener('dragover', onRootDragOver);
+			dropRoot.removeEventListener('dragleave', onRootDragLeave);
+			dropRoot.removeEventListener('drop', onRootDrop);
+			document.removeEventListener('dragend', onGlobalDragEnd);
+			document.removeEventListener('drop', onGlobalDrop);
+		};
+	}
+
+	/**
+	 * @param {FUActor} actor
+	 * @returns {'character'|'companion'|'adversary'|null}
+	 */
+	#classifyDroppedActor(actor) {
+		switch (actor?.type) {
+			case 'character':
+				return 'character';
+			case 'npc':
+				return actor.system?.rank?.value === 'companion' ? 'companion' : 'adversary';
+			default:
+				return null;
+		}
 	}
 
 	/**
@@ -647,22 +1034,75 @@ export class FUPartySheet extends FUActorSheet {
 	}
 
 	/**
+	 * Helper to show actor import dialog with optional selection
+	 * @param {FUActor[]} [initialActors] Pre-selected actors from drop, shows selection dialog if provided
+	 * @returns {Promise<void>}
+	 */
+	async #showActorImportDialog(initialActors = null) {
+		let selected = initialActors;
+
+		if (!selected) {
+			selected = await FoundryUtils.selectActors();
+		} else if (selected.length > 0) {
+			selected = await this.#promptSelectItems('FU.Actor', selected);
+		}
+
+		if (selected && selected.length > 0) {
+			const content = await FoundryUtils.renderTemplate('common/document-list', {
+				message: 'The following actors will be imported as codex entries.',
+				documents: selected,
+			});
+
+			const confirm = await FoundryUtils.confirm('FU.Import', content);
+			if (confirm) {
+				const result = await this.#importActorsToCodex(selected);
+				if (result.skipped.length > 0) {
+					ui.notifications.warn(`Imported ${result.imported}/${selected.length} actors. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
+				} else {
+					ui.notifications.info(`Imported ${result.imported}/${selected.length} actors to Codex.`);
+				}
+			}
+		}
+	}
+
+	/**
 	 * @this FUPartySheet
 	 * @param {PointerEvent} event   The originating click event
 	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
 	 * @returns {Promise<void>}
 	 */
 	static async #onImportCodexActorEntry(event, target) {
-		const selected = await FoundryUtils.selectActors();
-		if (selected) {
-			const content = await FoundryUtils.renderTemplate('common/document-list', {
-				message: 'The following actors will be imported as codex entries.',
-				documents: selected,
-			});
-			const confirm = await FoundryUtils.confirm('FU.Import', content);
-			if (confirm) {
-				for (const actor of selected) {
-					await this.codexBrowser.importActor(actor);
+		await this.#showActorImportDialog();
+	}
+
+	/**
+	 * Helper to show journal entry import dialog with selection and confirmation combined
+	 * @param {JournalEntry[]} [initialEntries] Pre-selected journals from drop, shows selection in confirmation if provided
+	 * @returns {Promise<void>}
+	 */
+	async #showJournalImportDialog(initialEntries = null) {
+		let selected = initialEntries;
+
+		if (!selected) {
+			selected = await FoundryUtils.selectJournalEntries();
+		}
+
+		if (selected && selected.length > 0) {
+			let pages = selected.flatMap((je) => je.pages.contents);
+
+			if (pages.length === 0) {
+				ui.notifications.warn('No pages found in selected journals.');
+				return;
+			}
+
+			const selectedPages = await this.#promptSelectAndConfirmPages('DOCUMENT.JournalEntryPage', pages);
+
+			if (selectedPages && selectedPages.length > 0) {
+				const result = await this.#importJournalPagesToCodex(selectedPages);
+				if (result.skipped.length > 0) {
+					ui.notifications.warn(`Imported ${result.imported}/${selectedPages.length} journal pages. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
+				} else {
+					ui.notifications.info(`Imported ${result.imported}/${selectedPages.length} journal pages.`);
 				}
 			}
 		}
@@ -675,21 +1115,7 @@ export class FUPartySheet extends FUActorSheet {
 	 * @returns {Promise<void>}
 	 */
 	static async #onImportCodexJournalEntry(event, target) {
-		// Built-in Foundry document selector
-		const selected = await FoundryUtils.selectJournalEntries();
-		if (selected) {
-			const pages = selected.flatMap((je) => je.pages.contents);
-			const content = await FoundryUtils.renderTemplate('common/document-list', {
-				message: 'The following journal entry pages will be imported as codex entries.',
-				documents: pages,
-			});
-			const confirm = await FoundryUtils.confirm('FU.Import', content);
-			if (confirm) {
-				for (const page of pages) {
-					await this.codexBrowser.importJournalEntryPage(page);
-				}
-			}
-		}
+		await this.#showJournalImportDialog();
 	}
 
 	/**

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -587,11 +587,37 @@ export class FUPartySheet extends FUActorSheet {
 		return super._onDropItem(event, item);
 	}
 
+	/**
+	 * Handle folder drop payloads that are not auto-resolved by the base sheet.
+	 * @param {DragEvent} event
+	 * @returns {Promise<unknown>}
+	 */
+	async _onDrop(event) {
+		const data = TextEditor.getDragEventData(event);
+		if (this.#isCodexDropZone(event) && data?.type === 'Folder') {
+			const folderFromUuid = data.uuid ? await fromUuid(data.uuid) : null;
+			if (folderFromUuid) {
+				return this._onDropFolder(event, folderFromUuid);
+			}
+
+			const packId = data.pack ?? data.compendium ?? null;
+			const folderId = data.id ?? data.folderId ?? data._id ?? null;
+			if (packId && folderId) {
+				const pack = game.packs?.get(packId);
+				const folder = pack?.folders?.get?.(folderId) ?? pack?.folders?.contents?.find((f) => f.id === folderId);
+				if (folder) {
+					return this._onDropFolder(event, folder);
+				}
+			}
+		}
+
+		return super._onDrop(event);
+	}
+
 	async _onDropFolder(event, folder) {
 		if (this.#isCodexDropZone(event)) {
 			if (folder?.type === 'Actor') {
-				const folderIds = this.#collectFolderIds(folder);
-				const actors = (game.actors?.contents ?? []).filter((actor) => folderIds.has(this.#resolveFolderId(actor)));
+				const actors = await this.#getActorsFromFolder(folder);
 
 				if (actors.length === 0) {
 					ui.notifications.warn('No actors found in this folder.');
@@ -603,8 +629,7 @@ export class FUPartySheet extends FUActorSheet {
 			}
 
 			if (folder?.type === 'JournalEntry') {
-				const folderIds = this.#collectFolderIds(folder);
-				const entries = (game.journal?.contents ?? []).filter((entry) => folderIds.has(this.#resolveFolderId(entry)));
+				const entries = await this.#getJournalEntriesFromFolder(folder);
 
 				if (entries.length === 0) {
 					ui.notifications.warn('No journals found in this folder.');
@@ -619,7 +644,7 @@ export class FUPartySheet extends FUActorSheet {
 				const folderIds = this.#collectFolderIds(folder);
 				const actors = (game.actors?.contents ?? []).filter((actor) => folderIds.has(this.#resolveFolderId(actor)));
 
-				// Add each actor to the appropriate party list
+				// Add dropped actors to the party in their matching section.
 				for (const actor of actors) {
 					const actorCategory = this.#classifyDroppedActor(actor);
 					if (actorCategory === 'character') {
@@ -641,7 +666,7 @@ export class FUPartySheet extends FUActorSheet {
 	}
 
 	/**
-	 * Document drop routing
+	 * Route direct document drops.
 	 * @param {DragEvent} event
 	 * @param {Document} document
 	 * @returns {Promise<Document|null|undefined>}
@@ -663,7 +688,7 @@ export class FUPartySheet extends FUActorSheet {
 			return super._onDropDocument(event, document);
 		}
 
-		// fallback for environments without _onDropDocument.
+		// Support environments without _onDropDocument.
 		if (document?.documentName === 'Actor') {
 			return this._onDropActor(event, document);
 		}
@@ -671,11 +696,6 @@ export class FUPartySheet extends FUActorSheet {
 	}
 
 	async _onDropActor(event, actor) {
-		if (this.#isCodexDropZone(event)) {
-			await this.#showActorImportDialog([actor]);
-			return actor;
-		}
-
 		if (this.#isCodexDropZone(event)) {
 			await this.#showActorImportDialog([actor]);
 			return actor;
@@ -744,7 +764,7 @@ export class FUPartySheet extends FUActorSheet {
 
 			const key = name.toLowerCase();
 
-			// Skip if duplicate
+			// Skip duplicates already in the codex.
 			if (existing.has(key)) {
 				skipped.push(name);
 				continue;
@@ -757,60 +777,6 @@ export class FUPartySheet extends FUActorSheet {
 
 		return { imported, skipped };
 	}
-
-	/**
-	 * Show a selection dialog to choose which items to import
-	 * @param {string} documentType The type label (FU.Actor, DOCUMENT.JournalEntryPage, etc)
-	 * @param {Document[]} items Array of items to select from
-	 * @returns {Promise<Document[]|null>} Selected items or null if cancelled
-	 */
-	// async #promptSelectItems(documentType, items) {
-	// 	if (!items || items.length === 0) return null;
-	// 	if (items.length === 1) return items; // Skip dialog for single item
-	// async #promptSelectItems(documentType, items) {
-	// 	if (!items || items.length === 0) return null;
-	// 	if (items.length === 1) return items; // Skip dialog for single item
-
-	// 	const displayItems = items.map((item, idx) => ({
-	// 		_originalIndex: idx,
-	// 		uuid: item?.uuid,
-	// 		id: item?.id,
-	// 		img: item?.img || item?.src,
-	// 		pack: item?.pack,
-	// 		documentName: item?.documentName,
-	// 		parent: item?.parent,
-	// 		name: item.parent?.name && item.documentName === 'JournalEntryPage' ? `${item.name} (${item.parent.name})` : item.name,
-	// 	}));
-	// 	const displayItems = items.map((item, idx) => ({
-	// 		_originalIndex: idx,
-	// 		uuid: item?.uuid,
-	// 		id: item?.id,
-	// 		img: item?.img || item?.src,
-	// 		pack: item?.pack,
-	// 		documentName: item?.documentName,
-	// 		parent: item?.parent,
-	// 		name: item.parent?.name && item.documentName === 'JournalEntryPage' ? `${item.name} (${item.parent.name})` : item.name,
-	// 	}));
-
-	// 	const data = {
-	// 		title: `Select ${game.i18n.localize(documentType)} to Import`,
-	// 		style: 'list',
-	// 		items: displayItems,
-	// 		initial: displayItems,
-	// 		max: displayItems.length,
-	// 		getDescription: async (item) => item.name,
-	// 	};
-
-	// 	const dialog = new ItemSelectionDialog(data);
-	// 	const selected = await dialog.open();
-
-	// 	if (!selected || selected.length === 0) return null;
-
-	// 	return selected
-	// 		.filter((sel) => sel && sel._originalIndex !== undefined)
-	// 		.map((sel) => items[sel._originalIndex])
-	// 		.filter(Boolean);
-	// }
 
 	/**
 	 * @param {DragEvent} event
@@ -829,8 +795,10 @@ export class FUPartySheet extends FUActorSheet {
 		const ids = new Set();
 		const queue = [root];
 		const foldersByParent = new Map();
+		const packId = this.#resolveFolderPack(root);
+		const folderSource = packId ? (game.packs?.get(packId)?.folders?.contents ?? []) : game.folders.filter((f) => f?.type === root?.type);
 
-		for (const folder of game.folders.filter((f) => f?.type === root?.type)) {
+		for (const folder of folderSource) {
 			const parentId = this.#resolveFolderId(folder);
 			if (!foldersByParent.has(parentId)) foldersByParent.set(parentId, []);
 			foldersByParent.get(parentId).push(folder);
@@ -843,6 +811,46 @@ export class FUPartySheet extends FUActorSheet {
 			queue.push(...(foldersByParent.get(current.id) ?? []));
 		}
 		return ids;
+	}
+
+	/**
+	 * @param {Folder} folder
+	 * @returns {Promise<FUActor[]>}
+	 */
+	async #getActorsFromFolder(folder) {
+		const folderIds = this.#collectFolderIds(folder);
+		const packId = this.#resolveFolderPack(folder);
+		if (packId) {
+			const pack = game.packs?.get(packId);
+			if (!pack || pack.documentName !== 'Actor') return [];
+			const actors = await pack.getDocuments();
+			return actors.filter((actor) => folderIds.has(this.#resolveFolderId(actor)));
+		}
+		return (game.actors?.contents ?? []).filter((actor) => folderIds.has(this.#resolveFolderId(actor)));
+	}
+
+	/**
+	 * @param {Folder} folder
+	 * @returns {Promise<JournalEntry[]>}
+	 */
+	async #getJournalEntriesFromFolder(folder) {
+		const folderIds = this.#collectFolderIds(folder);
+		const packId = this.#resolveFolderPack(folder);
+		if (packId) {
+			const pack = game.packs?.get(packId);
+			if (!pack || pack.documentName !== 'JournalEntry') return [];
+			const journals = await pack.getDocuments();
+			return journals.filter((entry) => folderIds.has(this.#resolveFolderId(entry)));
+		}
+		return (game.journal?.contents ?? []).filter((entry) => folderIds.has(this.#resolveFolderId(entry)));
+	}
+
+	/**
+	 * @param {Folder|object|null} folder
+	 * @returns {string|null}
+	 */
+	#resolveFolderPack(folder) {
+		return folder?.pack ?? folder?.compendium?.collection ?? null;
 	}
 
 	/**
@@ -1045,14 +1053,16 @@ export class FUPartySheet extends FUActorSheet {
 		const groupsByKey = new Map();
 
 		for (const actor of actors) {
+			const packId = this.#resolveFolderPack(actor) ?? '__world__';
 			const folderId = this.#resolveFolderId(actor) ?? '__none__';
-			if (!groupsByKey.has(folderId)) {
-				groupsByKey.set(folderId, {
-					name: this.#resolveFolderPath(folderId === '__none__' ? null : folderId),
+			const groupKey = `${packId}::${folderId}`;
+			if (!groupsByKey.has(groupKey)) {
+				groupsByKey.set(groupKey, {
+					name: this.#resolveFolderPath(folderId === '__none__' ? null : folderId, packId === '__world__' ? null : packId),
 					actors: [],
 				});
 			}
-			groupsByKey.get(folderId).actors.push(actor);
+			groupsByKey.get(groupKey).actors.push(actor);
 		}
 
 		const groups = [];
@@ -1092,15 +1102,22 @@ export class FUPartySheet extends FUActorSheet {
 
 	/**
 	 * @param {string|null} folderId
+	 * @param {string|null} [packId]
 	 * @returns {string}
 	 */
-	#resolveFolderPath(folderId) {
+	#resolveFolderPath(folderId, packId = null) {
 		if (!folderId) return game.i18n.localize('FU.None');
-		const folder = game.folders?.get(folderId);
+		const folderCollection = packId ? game.packs?.get(packId)?.folders : game.folders;
+		const getFolder = (id) => folderCollection?.get?.(id) ?? folderCollection?.contents?.find((f) => f.id === id);
+		const folder = getFolder(folderId);
 		if (!folder) return game.i18n.localize('FU.None');
 		const names = [folder.name];
 		let current = folder.folder ?? folder.parent ?? null;
 		while (current) {
+			if (typeof current === 'string') {
+				current = getFolder(current);
+				if (!current) break;
+			}
 			names.unshift(current.name);
 			current = current.folder ?? current.parent ?? null;
 		}

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -764,40 +764,53 @@ export class FUPartySheet extends FUActorSheet {
 	 * @param {Document[]} items Array of items to select from
 	 * @returns {Promise<Document[]|null>} Selected items or null if cancelled
 	 */
-	async #promptSelectItems(documentType, items) {
-		if (!items || items.length === 0) return null;
-		if (items.length === 1) return items; // Skip dialog for single item
+	// async #promptSelectItems(documentType, items) {
+	// 	if (!items || items.length === 0) return null;
+	// 	if (items.length === 1) return items; // Skip dialog for single item
+	// async #promptSelectItems(documentType, items) {
+	// 	if (!items || items.length === 0) return null;
+	// 	if (items.length === 1) return items; // Skip dialog for single item
 
-		const displayItems = items.map((item, idx) => ({
-			_originalIndex: idx,
-			uuid: item?.uuid,
-			id: item?.id,
-			img: item?.img || item?.src,
-			pack: item?.pack,
-			documentName: item?.documentName,
-			parent: item?.parent,
-			name: item.parent?.name && item.documentName === 'JournalEntryPage' ? `${item.name} (${item.parent.name})` : item.name,
-		}));
+	// 	const displayItems = items.map((item, idx) => ({
+	// 		_originalIndex: idx,
+	// 		uuid: item?.uuid,
+	// 		id: item?.id,
+	// 		img: item?.img || item?.src,
+	// 		pack: item?.pack,
+	// 		documentName: item?.documentName,
+	// 		parent: item?.parent,
+	// 		name: item.parent?.name && item.documentName === 'JournalEntryPage' ? `${item.name} (${item.parent.name})` : item.name,
+	// 	}));
+	// 	const displayItems = items.map((item, idx) => ({
+	// 		_originalIndex: idx,
+	// 		uuid: item?.uuid,
+	// 		id: item?.id,
+	// 		img: item?.img || item?.src,
+	// 		pack: item?.pack,
+	// 		documentName: item?.documentName,
+	// 		parent: item?.parent,
+	// 		name: item.parent?.name && item.documentName === 'JournalEntryPage' ? `${item.name} (${item.parent.name})` : item.name,
+	// 	}));
 
-		const data = {
-			title: `Select ${game.i18n.localize(documentType)} to Import`,
-			style: 'list',
-			items: displayItems,
-			initial: displayItems,
-			max: displayItems.length,
-			getDescription: async (item) => item.name,
-		};
+	// 	const data = {
+	// 		title: `Select ${game.i18n.localize(documentType)} to Import`,
+	// 		style: 'list',
+	// 		items: displayItems,
+	// 		initial: displayItems,
+	// 		max: displayItems.length,
+	// 		getDescription: async (item) => item.name,
+	// 	};
 
-		const dialog = new ItemSelectionDialog(data);
-		const selected = await dialog.open();
+	// 	const dialog = new ItemSelectionDialog(data);
+	// 	const selected = await dialog.open();
 
-		if (!selected || selected.length === 0) return null;
+	// 	if (!selected || selected.length === 0) return null;
 
-		return selected
-			.filter((sel) => sel && sel._originalIndex !== undefined)
-			.map((sel) => items[sel._originalIndex])
-			.filter(Boolean);
-	}
+	// 	return selected
+	// 		.filter((sel) => sel && sel._originalIndex !== undefined)
+	// 		.map((sel) => items[sel._originalIndex])
+	// 		.filter(Boolean);
+	// }
 
 	/**
 	 * @param {DragEvent} event
@@ -1004,22 +1017,94 @@ export class FUPartySheet extends FUActorSheet {
 	 * @returns {Promise<void>}
 	 */
 	async #showActorImportDialog(initialActors = null) {
-		let selected = initialActors;
-
-		if (!selected) {
-			selected = await FoundryUtils.selectActors();
-		} else if (selected.length > 0) {
-			selected = await this.#promptSelectItems('FU.Actor', selected);
+		let selected = initialActors ?? game.actors?.contents ?? [];
+		if (!selected.length) {
+			ui.notifications.warn('No actors found in this world.');
+			return;
 		}
 
-		if (selected && selected.length > 0) {
-			const result = await this.#importActorsToCodex(selected);
-			if (result.skipped.length > 0) {
-				ui.notifications.warn(`Imported ${result.imported}/${selected.length} actors. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
-			} else {
-				ui.notifications.info(`Imported ${result.imported}/${selected.length} actors to Codex.`);
+		selected = await this.#promptSelectActorsGrouped(selected);
+		if (!selected?.length) return;
+
+		const result = await this.#importActorsToCodex(selected);
+		if (result.skipped.length > 0) {
+			ui.notifications.warn(`Imported ${result.imported}/${selected.length} actors. Skipped ${result.skipped.length}: ${result.skipped.join(', ')}`);
+		} else {
+			ui.notifications.info(`Imported ${result.imported}/${selected.length} actors to Codex.`);
+		}
+	}
+
+	/**
+	 * @param {FUActor[]} actors
+	 * @returns {Promise<FUActor[]|null>}
+	 */
+	async #promptSelectActorsGrouped(actors) {
+		if (!actors?.length) return null;
+		if (actors.length === 1) return actors;
+
+		const groupsByKey = new Map();
+
+		for (const actor of actors) {
+			const folderId = this.#resolveFolderId(actor) ?? '__none__';
+			if (!groupsByKey.has(folderId)) {
+				groupsByKey.set(folderId, {
+					name: this.#resolveFolderPath(folderId === '__none__' ? null : folderId),
+					actors: [],
+				});
 			}
+			groupsByKey.get(folderId).actors.push(actor);
 		}
+
+		const groups = [];
+		const allActors = [];
+		let flatIndex = 0;
+		for (const group of [...groupsByKey.values()].sort((a, b) => a.name.localeCompare(b.name))) {
+			const items = group.actors
+				.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
+				.map((actor) => {
+					const entry = {
+						id: actor.id,
+						uuid: actor.uuid,
+						name: actor.name,
+						img: actor.img,
+						_originalActor: actor,
+						_flatIndex: flatIndex++,
+					};
+					allActors.push(entry);
+					return entry;
+				});
+
+			if (items.length > 0) groups.push({ name: group.name, items });
+		}
+
+		const selected = await new ItemSelectionDialog({
+			title: `${StringUtils.localize('CONTROLS.CommonSelect')} ${game.i18n.localize('FU.Actor')}`,
+			style: 'grouped-list',
+			groups,
+			items: allActors,
+			initial: [],
+			max: allActors.length,
+			getDescription: async (item) => item.name,
+		}).open();
+		if (!selected || selected.length === 0) return null;
+		return selected.map((item) => item._originalActor).filter(Boolean);
+	}
+
+	/**
+	 * @param {string|null} folderId
+	 * @returns {string}
+	 */
+	#resolveFolderPath(folderId) {
+		if (!folderId) return game.i18n.localize('FU.None');
+		const folder = game.folders?.get(folderId);
+		if (!folder) return game.i18n.localize('FU.None');
+		const names = [folder.name];
+		let current = folder.folder ?? folder.parent ?? null;
+		while (current) {
+			names.unshift(current.name);
+			current = current.folder ?? current.parent ?? null;
+		}
+		return names.join(' / ');
 	}
 
 	/**

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -74,6 +74,8 @@ export class CodexBrowser {
 	 * @returns {Promise<void>}
 	 */
 	async prepareContext(context) {
+		this.refresh(this.sheet.actor);
+		this.refresh(this.sheet.actor);
 		context.browser = this;
 		context.playingSounds = new Set(
 			game.playlists.contents
@@ -357,15 +359,17 @@ export class CodexBrowser {
 			return;
 		}
 
-		/** @type CodexEntryDataModel[] **/
-		const entries = this.party.codex.entries;
+		const description = typeof actor?.system?.description === 'string' ? actor.system.description : (actor?.system?.description?.value ?? actor?.system?.description?.content ?? '');
+
 		/** @type CodexEntryDataModel **/
 		let entry = {
 			name: actor.name,
 			img: actor.img,
-			description: actor.system?.description ?? '',
+			description,
 			tags: ['character'],
 		};
+
+		const entries = FoundryUtils.safeClone(this.actor.system.codex.entries ?? []);
 		entries.push(entry);
 		await this.actor.update({ [`system.codex.entries`]: entries });
 	}
@@ -375,16 +379,17 @@ export class CodexBrowser {
 	 * @returns {Promise<void>}
 	 */
 	async importJournalEntryPage(page) {
-		if (this.party.codex.resolveEntry(page.name)) {
-			ui.notifications.warn(`Failed to import journal entry page ${page.name} as there's already an entry with that name.`);
+		const journalName = page.parent?.name;
+		let entryName = journalName ? `${page.name} (${journalName})` : page.name;
+
+		if (this.party.codex.resolveEntry(entryName)) {
+			ui.notifications.warn(`Failed to import journal entry page "${page.name}" from "${journalName}" as there's already an entry with that name.`);
 			return;
 		}
 
-		/** @type CodexEntryDataModel[] **/
-		const entries = this.party.codex.entries;
 		/** @type CodexEntryDataModel **/
 		let entry = {
-			name: page.name,
+			name: entryName,
 			tags: [],
 		};
 
@@ -402,6 +407,7 @@ export class CodexBrowser {
 				break;
 		}
 
+		const entries = FoundryUtils.safeClone(this.actor.system.codex.entries ?? []);
 		entries.push(entry);
 		await this.actor.update({ [`system.codex.entries`]: entries });
 	}

--- a/module/ui/codex-browser.mjs
+++ b/module/ui/codex-browser.mjs
@@ -75,7 +75,6 @@ export class CodexBrowser {
 	 */
 	async prepareContext(context) {
 		this.refresh(this.sheet.actor);
-		this.refresh(this.sheet.actor);
 		context.browser = this;
 		context.playingSounds = new Set(
 			game.playlists.contents

--- a/module/ui/features/item-selection-dialog.mjs
+++ b/module/ui/features/item-selection-dialog.mjs
@@ -62,7 +62,7 @@ export class ItemSelectionDialog {
 		this.#selectedIndexes = [];
 		if (data.initial) {
 			this.#selectedItems.push(...data.initial);
-			this.#selectedIndexes.push(...data.initial.map((initial) => data.items.findIndex((item) => item.id === initial.id)));
+			this.#selectedIndexes.push(...data.initial.map((initial) => (initial._originalIndex !== undefined ? initial._originalIndex : data.items.findIndex((item) => item.id === initial.id))));
 		}
 	}
 
@@ -129,14 +129,18 @@ export class ItemSelectionDialog {
 				 *  @param {HTMLElement} dialog **/
 				selectAll: (event, dialog) => {
 					const inputs = dialog.closest('#items').querySelectorAll('input[name="selected"]');
+					const selectedIndexes = [];
 					for (const input of inputs) {
 						input.checked = true;
 						const card = input.closest('.fu-item');
 						if (card) {
 							card.classList.toggle('selected', true);
+							const index = Number.parseInt(card.dataset.index);
+							if (Number.isFinite(index)) selectedIndexes.push(index);
 						}
 					}
 					this.#selectedItems = this.data.items;
+					this.#selectedIndexes = selectedIndexes;
 					return false;
 				},
 				/** @param {Event} event
@@ -151,6 +155,7 @@ export class ItemSelectionDialog {
 						}
 					}
 					this.#selectedItems = [];
+					this.#selectedIndexes = [];
 					return false;
 				},
 			},
@@ -175,16 +180,36 @@ export class ItemSelectionDialog {
 						toggleCardSelection(container, card, false);
 					}
 				}
-				// ✅ Event handling
-				container.addEventListener('mousedown', async (event) => {
-					const card = event.target.closest('.fu-item');
-					if (!card) return;
-					toggleCardSelection(container, card);
-				});
+
+				if (this.data.style !== 'list') {
+					container.addEventListener('mousedown', async (event) => {
+						const card = event.target.closest('.fu-item');
+						if (!card) return;
+						toggleCardSelection(container, card);
+					});
+				} else {
+					container.addEventListener('change', (event) => {
+						const input = event.target;
+						if (input?.name !== 'selected') return;
+						const card = input.closest('.fu-item');
+						if (!card) return;
+						const index = Number.parseInt(card.dataset.index);
+						if (!Number.isFinite(index)) return;
+						const listItem = this.data.items[index];
+						if (input.checked) {
+							if (!this.#selectedIndexes.includes(index)) {
+								this.#selectedItems.push(listItem);
+								this.#selectedIndexes.push(index);
+							}
+						} else {
+							this.#selectedItems = this.#selectedItems.filter((it) => it !== listItem);
+							this.#selectedIndexes = this.#selectedIndexes.filter((it) => it !== index);
+						}
+					});
+				}
 			},
 		});
 		if (result) {
-			console.debug(result);
 			// If a custom payload is expected
 			if (this.data.payload) {
 				return this.#selectedIndexes.map((idx) => this.data.payload[idx]);

--- a/module/ui/features/item-selection-dialog.mjs
+++ b/module/ui/features/item-selection-dialog.mjs
@@ -14,7 +14,7 @@ import { StringUtils } from '../../helpers/string-utils.mjs';
  */
 
 /**
- * @typedef {'grid'|'list'|'deck'} FUSelectionDialogStyle
+ * @typedef {'grid'|'list'|'deck'|'grouped-list'} FUSelectionDialogStyle
  */
 
 /**
@@ -25,6 +25,7 @@ import { StringUtils } from '../../helpers/string-utils.mjs';
  * @property {Object[]} payload Associated data returned instead of the item reference.
  * @property {FUItem[]} compendiumItems If assigned, will be used to compare to the original items.
  * @property {Object[]} initial
+ * @property {{name: string, items: Object[]}[]} groups
  * @property {ItemSelectionColumn[]} columns Additional columns for the dialog.
  * @property {FUSelectionDialogStyle} style
  * @property {Number} max
@@ -204,13 +205,13 @@ export class ItemSelectionDialog {
 				document.addEventListener(
 					'click',
 					(clickEvent) => {
-						const wrapper = clickEvent.target.closest('.journal-page-icon-wrapper');
+						const wrapper = clickEvent.target.closest('.journal-page-icon-wrapper[data-journal-uuid][data-page-uuid]');
 						if (wrapper) {
-							clickEvent.preventDefault();
-							clickEvent.stopPropagation();
 							const journalUuid = wrapper.dataset.journalUuid;
 							const pageUuid = wrapper.dataset.pageUuid;
 							if (journalUuid && pageUuid) {
+								clickEvent.preventDefault();
+								clickEvent.stopPropagation();
 								const journal = fromUuidSync(journalUuid);
 								const page = fromUuidSync(pageUuid);
 

--- a/module/ui/features/item-selection-dialog.mjs
+++ b/module/ui/features/item-selection-dialog.mjs
@@ -171,6 +171,34 @@ export class ItemSelectionDialog {
 			render: async (event, dialog) => {
 				const document = dialog.element;
 				const container = document.querySelector('#items');
+				const searchInput = document.querySelector('[data-role="selection-filter"]');
+
+				const applySearchFilter = () => {
+					if (!container || !searchInput) return;
+					const query = searchInput.value.trim().toLocaleLowerCase();
+
+					for (const entry of container.querySelectorAll('.fu-item[data-index]')) {
+						const target = entry.closest('tr') ?? entry;
+						const name = (entry.dataset.name || entry.textContent || '').toLocaleLowerCase();
+						target.style.display = !query || name.includes(query) ? '' : 'none';
+					}
+
+					if (this.data.style !== 'grouped-list') return;
+					for (const header of container.querySelectorAll('.group-header')) {
+						let row = header.nextElementSibling;
+						let hasVisibleRows = false;
+						while (row && !row.classList.contains('group-header')) {
+							if (row.style.display !== 'none') {
+								hasVisibleRows = true;
+								break;
+							}
+							row = row.nextElementSibling;
+						}
+						header.style.display = hasVisibleRows ? '' : 'none';
+					}
+				};
+
+				searchInput?.addEventListener('input', applySearchFilter);
 
 				// Handle opening journal entries when clicking the icon
 				document.addEventListener(
@@ -268,6 +296,8 @@ export class ItemSelectionDialog {
 						}
 					});
 				}
+
+				applySearchFilter();
 			},
 		});
 		if (result) {

--- a/module/ui/features/item-selection-dialog.mjs
+++ b/module/ui/features/item-selection-dialog.mjs
@@ -172,6 +172,43 @@ export class ItemSelectionDialog {
 				const document = dialog.element;
 				const container = document.querySelector('#items');
 
+				// Handle opening journal entries when clicking the icon
+				document.addEventListener(
+					'click',
+					(clickEvent) => {
+						const wrapper = clickEvent.target.closest('.journal-page-icon-wrapper');
+						if (wrapper) {
+							clickEvent.preventDefault();
+							clickEvent.stopPropagation();
+							const journalUuid = wrapper.dataset.journalUuid;
+							const pageUuid = wrapper.dataset.pageUuid;
+							if (journalUuid && pageUuid) {
+								const journal = fromUuidSync(journalUuid);
+								const page = fromUuidSync(pageUuid);
+
+								if (journal && page) {
+									const jSheet = journal.sheet;
+									const goToPage = () => {
+										if (typeof jSheet.goToPage === 'function') return jSheet.goToPage(page.id);
+										if (typeof jSheet.navigatePage === 'function') return jSheet.navigatePage(page.id);
+									};
+
+									if (jSheet.rendered) {
+										goToPage();
+										return;
+									}
+
+									Hooks.once('renderJournalSheet', (sheet) => {
+										if (sheet === jSheet) goToPage();
+									});
+									jSheet.render(true, { pageId: page.id });
+								}
+							}
+						}
+					},
+					true,
+				);
+
 				// Initial Selection
 				const inputs = container.querySelectorAll('input[name="selected"]:checked');
 				for (const input of inputs) {
@@ -181,7 +218,7 @@ export class ItemSelectionDialog {
 					}
 				}
 
-				if (this.data.style !== 'list') {
+				if (this.data.style !== 'list' && this.data.style !== 'grouped-list') {
 					container.addEventListener('mousedown', async (event) => {
 						const card = event.target.closest('.fu-item');
 						if (!card) return;
@@ -190,6 +227,30 @@ export class ItemSelectionDialog {
 				} else {
 					container.addEventListener('change', (event) => {
 						const input = event.target;
+
+						// Handle group checkbox
+						if (input?.name === 'group-selected') {
+							const groupIndex = Number.parseInt(input.dataset.groupIndex);
+							if (Number.isFinite(groupIndex) && this.data.groups && this.data.groups[groupIndex]) {
+								const groupRow = input.closest('.group-header');
+								if (groupRow) {
+									const nextRow = groupRow.nextElementSibling;
+									let currentRow = nextRow;
+									// Toggle all pages in this group
+									while (currentRow && !currentRow.classList.contains('group-header')) {
+										const pageCheckbox = currentRow.querySelector('input[name="selected"]');
+										if (pageCheckbox) {
+											pageCheckbox.checked = input.checked;
+											pageCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+										}
+										currentRow = currentRow.nextElementSibling;
+									}
+								}
+							}
+							return;
+						}
+
+						// Handle individual page checkbox
 						if (input?.name !== 'selected') return;
 						const card = input.closest('.fu-item');
 						if (!card) return;

--- a/styles/css/actor/party.css
+++ b/styles/css/actor/party.css
@@ -316,6 +316,11 @@
 			gap: 1rem;
 		}
 
+		.entries.show-dropzones {
+			border: 2px dashed var(--pfu-color-app-control-border);
+			border-radius: 4px;
+		}
+
 		.entry {
 			display: flex;
 			flex-direction: row;

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -197,9 +197,76 @@
 	overflow-x: hidden;
 }
 
-/* 3.  Optional: make the table header sticky */
+/* Optional: make the table header sticky */
 .fu-table__wrapper thead th {
 	position: sticky;
-	top: 0; /* stays at the top of the wrapper */
-	z-index: 1; /* stays above the rows */
+	top: 0;
+	z-index: 1;
+}
+
+.fu-table__wrapper .fu-table--no-sticky thead th {
+	position: static;
+}
+
+.fu-selection-dialog {
+	border: unset;
+}
+
+.fu-selection-dialog__legend {
+	gap: 4px;
+}
+
+.fu-selection-dialog__select-col {
+	width: 40px;
+}
+
+.fu-selection-dialog__select-cell {
+	padding: 6px 8px !important;
+	width: 40px !important;
+}
+
+.fu-selection-dialog__entry-cell {
+	padding: 6px 8px !important;
+}
+
+.fu-selection-dialog__entry-cell--nested {
+	padding: 6px 8px 6px 24px !important;
+}
+
+.fu-selection-dialog__entry-content {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.fu-selection-dialog__entry-content--clickable {
+	cursor: pointer;
+}
+
+.fu-selection-dialog__entry-name {
+	display: inline-block;
+	min-width: 160px;
+}
+
+.fu-selection-dialog__group-header {
+	background: var(--color-background-alt);
+}
+
+.fu-selection-dialog__group-checkbox {
+	margin: 0;
+}
+
+.fu-selection-dialog__group-check-input {
+	cursor: pointer;
+	filter: invert(1);
+}
+
+.fu-selection-dialog__group-title {
+	padding: 8px;
+	font-weight: 600;
+	color: #ffffff;
+}
+
+.fu-selection-dialog__group-icon {
+	margin-right: 6px;
 }

--- a/styles/css/global/form.css
+++ b/styles/css/global/form.css
@@ -212,6 +212,10 @@
 	border: unset;
 }
 
+.fu-selection-dialog__filter {
+	margin-bottom: 8px;
+}
+
 .fu-selection-dialog__legend {
 	gap: 4px;
 }

--- a/templates/actor/party/actor-party-section-codex.hbs
+++ b/templates/actor/party/actor-party-section-codex.hbs
@@ -31,16 +31,16 @@
 			</div>
 		</div>
 
-		<ul class="entries content">
+		<ul class="entries content" data-codex-drop-root data-codex-dropzone="entry">
 			{{#each system.codex.entries as |entry index|}}
 				<li class="section-container entry {{#if (and entry.hidden (not @root.user.isGM))}}hidden{{/if}} " data-index="{{index}}" data-name="{{entry.name}}">
 					<div class="left">
 						<a data-action="forCodexEntry"
-						   data-type="view"
-						   data-index="{{index}}"
-						   title="View">
+							data-type="view"
+							data-index="{{index}}"
+							title="View">
 							<img class="flexcol" src="{{lookup entry 'img'}}"
-								 alt="Artwork"/>
+									alt="Artwork"/>
 						</a>
 						{{#if @root.isOwner}}
 							<div class="controls">
@@ -103,7 +103,4 @@
 			{{/each}}
 		</ul>
 	</div>
-
-
-
 </section>

--- a/templates/dialog/dialog-item-selection.hbs
+++ b/templates/dialog/dialog-item-selection.hbs
@@ -1,4 +1,4 @@
-<main style="border:unset;">
+<main class="fu-selection-dialog">
 	{{#if message}}
 		<div class="fu-form__message">
 			<span>
@@ -64,7 +64,7 @@
 
 	{{#if (eq style 'list')}}
 		<fieldset id="items" class='title-fieldset resource-content flex-group-center flexrow desc'>
-			<legend class='resource-label-m' style="gap: 4px;">
+			<legend class='resource-label-m fu-selection-dialog__legend'>
 				<span class="resource-label-sm">
 					<a type="button" class="resource-label-sm" data-tooltip="{{localize 'FU.SelectAll'}}" data-action="selectAll">
 						<i class="icon fas fa-list-check"></i>
@@ -78,7 +78,7 @@
 				</span>
 			</legend>
 			<div class="fu-table__wrapper">
-				<table class="table-compact scrollable" style="max-height: 400px;">
+				<table class="table-compact scrollable fu-table--no-sticky">
 					<thead>
 					<tr>
 						<th></th>
@@ -93,7 +93,7 @@
 					</thead>
 					{{#each items as |item|}}
 						<tr>
-							<td>
+							<td class="fu-selection-dialog__select-cell">
 								<label class="fu-item"
 									   data-index="{{@index}}"
 									   data-name="{{item.name}}">
@@ -103,9 +103,11 @@
 										   value="{{item.name}}">
 								</label>
 							</td>
-							<td>
-								{{pfuItemAnchor item}}
-								<span style="display: inline-block; min-width: 160px;" data-tooltip="{{lookup ../descriptions @index}}">{{item.name}}</span>
+							<td class="fu-selection-dialog__entry-cell">
+								<div class="fu-selection-dialog__entry-content">
+									{{pfuItemAnchor item}}
+									<span class="fu-selection-dialog__entry-name" data-tooltip="{{lookup ../descriptions @index}}">{{item.name}}</span>
+								</div>
 							</td>
 							{{#if @root.compendiumItems}}
 								<td>
@@ -124,6 +126,73 @@
 							{{/each}}
 						</tr>
 					{{/each}}
+				</table>
+			</div>
+		</fieldset>
+	{{/if}}
+
+	{{#if (eq style 'grouped-list')}}
+		<fieldset id="items" class='title-fieldset resource-content flex-group-center flexrow desc'>
+			<legend class='resource-label-m fu-selection-dialog__legend'>
+				<span class="resource-label-sm">
+					<a type="button" class="resource-label-sm" data-tooltip="{{localize 'FU.SelectAll'}}" data-action="selectAll">
+						<i class="icon fas fa-list-check"></i>
+					</a>
+				</span>
+				<label>{{localize 'FU.Selection'}}</label>
+				<span class="resource-label-sm">
+					<a type="button" class="resource-label-sm" data-tooltip="{{localize 'FU.DeselectAll'}}" data-action="deselectAll">
+						<i class="icon fas fa-xmark-square"></i>
+					</a>
+				</span>
+			</legend>
+			<div class="fu-table__wrapper">
+				<table class="table-compact scrollable fu-table--no-sticky">
+					<thead>
+					<tr>
+						<th class="fu-selection-dialog__select-col"></th>
+						<th>{{localize 'FU.Entry'}}</th>
+					</tr>
+					</thead>
+					<tbody>
+						{{#each groups as |group|}}
+							<tr class="group-header fu-selection-dialog__group-header" data-group-index="{{@index}}">
+								<td class="fu-selection-dialog__select-cell">
+									<label class="fu-item group-checkbox fu-selection-dialog__group-checkbox">
+										<input type="checkbox"
+											   name="group-selected"
+											   class="group-check fu-selection-dialog__group-check-input"
+											   data-group-index="{{@index}}"
+											   >
+									</label>
+								</td>
+								<td class="fu-selection-dialog__group-title">
+									<i class="icon fas fa-folder fu-selection-dialog__group-icon"></i>
+									{{group.name}}
+								</td>
+							</tr>
+							{{#each group.items as |item|}}
+								<tr>
+									<td class="fu-selection-dialog__select-cell">
+										<label class="fu-item"
+											   data-index="{{item._flatIndex}}"
+											   data-name="{{item.name}}">
+											<input type="checkbox"
+												   name="selected"
+												   {{#if (pfuCollectionContains item @root.initial)}}checked{{/if}}
+												   value="{{item.name}}">
+										</label>
+									</td>
+									<td class="fu-selection-dialog__entry-cell fu-selection-dialog__entry-cell--nested">
+										<div class="journal-page-icon-wrapper fu-selection-dialog__entry-content fu-selection-dialog__entry-content--clickable" data-journal-uuid="{{item._journalUuid}}" data-page-uuid="{{item.uuid}}">
+											{{pfuItemAnchor item}}
+											<span class="fu-selection-dialog__entry-name">{{item.name}}</span>
+										</div>
+									</td>
+								</tr>
+							{{/each}}
+						{{/each}}
+					</tbody>
 				</table>
 			</div>
 		</fieldset>

--- a/templates/dialog/dialog-item-selection.hbs
+++ b/templates/dialog/dialog-item-selection.hbs
@@ -6,6 +6,14 @@
 			</span>
 		</div>
 	{{/if}}
+	<div class="fu-selection-dialog__filter">
+		<input type="search"
+			   class="resource-inputs select-dropdown-full"
+			   data-role="selection-filter"
+			   placeholder="{{localize 'FU.Search'}}"
+			   aria-label="{{localize 'FU.Search'}}"
+			   autocomplete="off" />
+	</div>
 
 	{{#if (eq style 'grid')}}
 		<div id="items" class="fu-item-grid fu-icon__radio-group">


### PR DESCRIPTION
This PR addresses the following issues:

github.com/League-of-Fabulous-Developers/FoundryVTT-Fabula-Ultima/issues/365

- [ ] Drag & Drop inline commands into individual portraits to apply, outside of portrait in sheet, applies to all. (not needed/will address in another pr)
- [x] Drag & Drop folder containing pcs/npcs in sidebar to import all actors into the party sheet for their respective tab.
- [x] Drag & Drop individual journals and folder of actors/journals to import to codex
- [x] When importing journals add a selection dialog where you can toggle which individual entries you want to import from journal.
- [x] Single Import Dialog that acts as both importing individual journal pages and confirmation.
- [x] Added compendium folder Drag & Drop support
- [x] When Set Active is clicked, any sort of visual indicator would be good like a notification success message.
- [x] Add a search field on top of select list for better filtering out actors/journals.


Check if  the following issue is stale if not resolve it > github.com/League-of-Fabulous-Developers/FoundryVTT-Fabula-Ultima/issues/947 (will address in another pr)