### PR TITLE
Refactor damage source to item group

### DIFF
--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -78,7 +78,7 @@ function attack(inspector, actor, item) {
  * @property {DamageType} type
  * @property {FUAffinity} affinity
  * @property {InlineSourceInfo} sourceInfo
- * @property {FUItemGroup} damageSource
+ * @property {FUItemGroup} itemGroup
  * @property {Number} amount
  * @property {CharacterInfo} target
  * @property {FUItem} item
@@ -93,7 +93,7 @@ async function damage(type, affinity, amount, traits, sourceActor, targetActor, 
 	const source = CharacterInfo.fromActor(sourceActor);
 	const target = CharacterInfo.fromActor(targetActor);
 	const item = sourceInfo.resolveItem();
-	const damageSource = ItemUtils.resolveItemGroup(item);
+	const itemGroup = ItemUtils.resolveItemGroup(item);
 
 	/** @type DamageEvent  **/
 	const damageEvent = {
@@ -103,7 +103,7 @@ async function damage(type, affinity, amount, traits, sourceActor, targetActor, 
 		affinity: affinity,
 		source: source,
 		sourceActor: sourceInfo,
-		damageSource: damageSource,
+		itemGroup: itemGroup,
 		target: target,
 		actor: target.actor,
 		token: target.token,
@@ -119,19 +119,19 @@ async function damage(type, affinity, amount, traits, sourceActor, targetActor, 
  * @property {CharacterInfo} source
  * @property {FUItem} item
  * @property {DamageType} type
- * @property {FUItemGroup} damageSource
+ * @property {FUItemGroup} itemGroup
  * @property {CharacterInfo[]} targets
  * @property {CheckConfigurer} config
  */
 
 function calculateDamage(actor, item, config) {
-	const damageSource = ItemUtils.resolveItemGroup(item);
+	const itemGroup = ItemUtils.resolveItemGroup(item);
 	const targets = config.getTargets();
 	const event = {
 		source: CharacterInfo.fromActor(actor),
 		targets: CharacterInfo.fromTargetData(targets),
 		item: item,
-		damageSource: damageSource,
+		itemGroup: itemGroup,
 		config: config,
 		type: config.getDamage()?.type,
 	};

--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -150,7 +150,6 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 						ruleTriggers: RuleTriggerRegistry.instance.localizedEntries,
 						damageTypeOptions: FoundryUtils.getFormOptions(FU.damageTypes),
 						itemGroupOptions: FoundryUtils.getFormOptions(FU.itemGroup),
-						damageSourceOptions: FoundryUtils.getFormOptions(FU.damageSource),
 						speciesOptions: FoundryUtils.getFormOptions(FU.species),
 						checkTypeOptions: FoundryUtils.getFormOptions(FU.checkTypes),
 						rankOptions: FoundryUtils.getFormOptions(FU.rank),

--- a/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-damage-rule-trigger.mjs
@@ -7,7 +7,7 @@ const fields = foundry.data.fields;
 /**
  * @description Trigger based on a {@linkcode CalculateDamageEvent}
  * @extends RuleTriggerDataModel
- * @property {Set<FUItemGroup>} damageSources
+ * @property {Set<FUItemGroup>} itemGroups
  * @property {Set<DamageType>} damageTypes
  * @property {String} identifier
  * @property {Boolean} local
@@ -28,12 +28,20 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 
 	static defineSchema() {
 		const schema = Object.assign(super.defineSchema(), {
-			damageSources: new fields.SetField(new fields.StringField()),
+			itemGroups: new fields.SetField(new fields.StringField()),
 			damageTypes: new fields.SetField(new fields.StringField()),
 			identifier: new fields.StringField(),
 			local: new fields.BooleanField(),
 		});
 		return schema;
+	}
+
+	static migrateData(source) {
+		if (source.damageSources) {
+			source.itemGroups = source.damageSources;
+			delete source.damageSources;
+		}
+		return super.migrateData(source);
 	}
 
 	static get localization() {
@@ -49,7 +57,7 @@ export class CalculateDamageRuleTrigger extends RuleTriggerDataModel {
 	 * @returns {boolean}
 	 */
 	validateContext(context) {
-		if (this.damageSources.size > 0 && !this.damageSources.has(context.event.damageSource)) {
+		if (this.itemGroups.size > 0 && !this.itemGroups.has(context.event.itemGroup)) {
 			return false;
 		}
 		if (this.damageTypes.size > 0 && !this.damageTypes.has(context.event.type)) {

--- a/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
@@ -54,11 +54,6 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 		return schema;
 	}
 
-	// TODO: Remove once design is finished
-	static migrateData(source) {
-		return super.migrateData(source);
-	}
-
 	static get localization() {
 		return 'FU.RuleTriggerCalculateExpense';
 	}

--- a/module/documents/effects/triggers/damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/damage-rule-trigger.mjs
@@ -9,7 +9,7 @@ const fields = foundry.data.fields;
  * @description Trigger based on a {@linkcode DamageEvent}
  * @extends RuleTriggerDataModel
  * @property {DamageType} damageTypes
- * @property {Set<FUItemGroup>} damageSource
+ * @property {Set<FUItemGroup>} itemGroups
  * @property {FUThreshold} damageThreshold
  * @property {FUAffinity} affinity
  * @inheritDoc
@@ -39,13 +39,21 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 				choices: Object.keys(FU.affValue),
 				blank: true,
 			}),
-			damageSources: new fields.SetField(new fields.StringField()),
+			itemGroups: new fields.SetField(new fields.StringField()),
 			damageThreshold: new fields.SchemaField({
 				operator: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.comparisonOperator) }),
 				amount: new fields.NumberField({ initial: 0 }),
 			}),
 		});
 		return schema;
+	}
+
+	static migrateData(source) {
+		if (source.damageSources) {
+			source.itemGroups = source.damageSources;
+			delete source.damageSources;
+		}
+		return super.migrateData(source);
 	}
 
 	static get localization() {
@@ -70,8 +78,8 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 				return false;
 			}
 		}
-		if (this.damageSources.size > 0) {
-			if (!this.damageSources.has(context.event.damageSource)) {
+		if (this.itemGroups.size > 0) {
+			if (!this.itemGroups.has(context.event.itemGroup)) {
 				return false;
 			}
 		}

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -930,8 +930,6 @@ FU.itemGroup = {
 	item: 'FU.Item',
 };
 
-FU.damageSource = FU.itemGroup;
-
 /**
  * @typedef {"skill" | "spell" | "item"} FUExpenseSource
  */

--- a/templates/effects/triggers/calculate-damage-rule-trigger.hbs
+++ b/templates/effects/triggers/calculate-damage-rule-trigger.hbs
@@ -1,6 +1,6 @@
 <div class="fu-form__property">
-	<span>{{localize 'FU.DamageSource'}}</span>
-	{{formGroup trigger.schema.fields.damageSources value=trigger.damageSources options=options.damageSourceOptions name=(pfuConcat path ".damageSources") classes="fu-form__set stacked"}}
+	<span>{{localize 'FU.ItemGroup'}}</span>
+	{{formGroup trigger.schema.fields.itemGroups value=trigger.itemGroups options=options.itemGroupOptions name=(pfuConcat path ".itemGroups") classes="fu-form__set stacked"}}
 </div>
 
 <label class="fu-form__property">

--- a/templates/effects/triggers/damage-rule-trigger.hbs
+++ b/templates/effects/triggers/damage-rule-trigger.hbs
@@ -7,8 +7,8 @@
 </label>
 
 <div class="fu-form__property">
-	<span>{{localize 'FU.DamageSource'}}</span>
-	{{formGroup trigger.schema.fields.damageSources value=trigger.damageSources options=options.damageSourceOptions name=(pfuConcat path ".damageSources") classes="fu-form__set stacked"}}
+	<span>{{localize 'FU.ItemGroup'}}</span>
+	{{formGroup trigger.schema.fields.itemGroups value=trigger.itemGroups options=options.itemGroupOptions name=(pfuConcat path ".itemGroups") classes="fu-form__set stacked"}}
 </div>
 
 <label class="fu-form__property">


### PR DESCRIPTION
The concept of resolving which "group" of items a particular item in an event belongs to is of particular interest to some of the key rule elements. When I first used it was in the damage events but it's become obvious to me this same information will be useful across other events and rule triggers, thus I am standardizing it here. (I meant to do this way back but like other things it fell by the wayside)

- Updates damage events to use `itemGroup` instead of `damageSource`.
- Migrates calculate damage source rule trigger's `damageSources` to `itemGroups`.
- Migrates damage rule triggers `damageSources` to `itemGroups`.