### PR TITLE
Actor sheet header layout overhaul and related fixes

### DIFF
--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -363,7 +363,7 @@ export class FUStandardActorSheet extends FUActorSheet {
 		switch (partId) {
 			case 'header':
 				{
-					context.showMetaCurrency = this.isCharacter || this.actor.system.villain.value;
+					context.showMetaCurrency = this.isCharacter || (this.actor.system.villain.value && this.actor.system.rank.value !== 'companion');
 					// Setup status effect toggle data
 					context.statusEffectToggles = ActorSheetUtils.prepareStatusEffectToggles(this.actor);
 

--- a/module/ui/npc-profile.mjs
+++ b/module/ui/npc-profile.mjs
@@ -6,6 +6,7 @@ import { NpcProfileWeaponsTableRenderer } from '../helpers/tables/npc-profile-we
 import { NpcProfileSpellsTableRenderer } from '../helpers/tables/npc-profile-spells-table-renderer.mjs';
 import { getSystemSetting, SETTINGS } from '../settings.js';
 import FoundryUtils from '../helpers/foundry-utils.mjs';
+import { ActorSheetUtils } from '../sheets/actor-sheet-utils.mjs';
 
 /**
  * @typedef NpcProfileRevealData
@@ -84,6 +85,7 @@ export class NpcProfileWindow extends FUApplication {
 
 		/** @type FUActor **/
 		const actor = await fromUuid(this.data.uuid);
+		ActorSheetUtils.prepareCharacterData(actor);
 		/** @type NpcDataModel  **/
 		const system = actor.system;
 		const result = StudyRollHandler.resolveStudyResult(this.data.study);

--- a/styles/css/actor/actor.css
+++ b/styles/css/actor/actor.css
@@ -268,21 +268,35 @@
 	border-radius: 0 12px 0 0;
 }
 
-.projectfu .npc-level-container .champion-input {
-	display: inline-flex;
+.projectfu .npc-level-container .rank-combined {
+	display: flex;
+	place-items: center;
 }
 
-.projectfu .npc-level-container .champion-input * {
-	width: 0;
-	flex: 0;
-}
-
-.projectfu .npc-level-container .champion-input input {
+.projectfu .npc-level-container .rank-combined > * {
+	padding: 0;
+	background: none;
 	width: min-content;
 }
 
-.projectfu .npc-level-container .champion-input::before,
-.projectfu .npc-level-container .champion-input::after {
+.projectfu .npc-level-container .rank-combined > .champion-input {
+	display: flex;
+	flex: 0 1 auto;
+}
+
+.projectfu .npc-level-container .rank-combined > select {
+	flex: 1 0 auto;
+}
+
+.projectfu .npc-level-container .rank-combined .champion-input input {
+	width: min-content;
+	padding: 0;
+	line-height: normal;
+	height: auto;
+}
+
+.projectfu .npc-level-container .rank-combined .champion-input::before,
+.projectfu .npc-level-container .rank-combined .champion-input::after {
 	font-size: 120%;
 }
 

--- a/styles/css/actor/actor.css
+++ b/styles/css/actor/actor.css
@@ -1,14 +1,14 @@
 /* ----------------------------------------- */
 /* Forms Styles                       
 /* ----------------------------------------- */
-.projectfu.actor .window-content {
+.projectfu.sheet.actor .window-content {
 	gap: 5px;
 	.tab {
 		gap: 5px;
 	}
 }
 
-.projectfu.actor .tab {
+.projectfu.sheet.actor .tab {
 	padding: 0.5rem;
 }
 
@@ -24,6 +24,12 @@
 			gap: 1ch;
 		}
 	}
+}
+
+.projectfu.sheet.actor .profile {
+	display: flex;
+	flex-wrap: nowrap;
+	gap: 8px;
 }
 
 .projectfu .npc-border-col {
@@ -42,7 +48,7 @@
 .projectfu .npc-border-col .npc-desc {
 	max-height: 14em;
 	min-height: 12em;
-	padding: 0 0.5rem;
+	padding: 0.5rem;
 }
 
 .projectfu .npc-border-col .npc-desc .editor {
@@ -58,10 +64,13 @@
 .projectfu .action-container {
 	margin: 0 5px 5px 0px;
 	row-gap: 7px;
+
+	.study-button {
+		margin: 0 0.5rem;
+	}
 }
 
 .projectfu .item-settings {
-	margin: 0px 5px 0;
 	display: inline-flex;
 	align-items: center;
 	gap: 1em;
@@ -93,7 +102,7 @@
 	min-height: 20em;
 }
 
-.projectfu .window-content > .tab.active {
+.projectfu.actor:is(.character, .npc) .window-content > .tab.active {
 	margin-bottom: 5px;
 	overflow-y: auto;
 	padding: 0;
@@ -127,6 +136,12 @@
 .projectfu .sheet-content-wrapper .sheet-header,
 .projectfu .sheet-content-wrapper .sheet-footer {
 	flex: 0;
+}
+
+.projectfu.actor .sheet-header .header-fields {
+	display: grid;
+	grid-template-columns: 1fr min-content;
+	height: 100%;
 }
 
 .projectfu .vehicle-section .vehicle-header {
@@ -189,7 +204,6 @@
 	-webkit-box-flex: 1;
 	-ms-flex-positive: 1;
 	flex-grow: 1;
-	color: var(--pfu-color-app-control-content);
 }
 
 .projectfu .bonds {
@@ -234,38 +248,24 @@
 
 .projectfu .npc-level-container {
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-row: span 2;
+	grid-template-columns: auto 1fr;
+	max-height: min-content;
+}
+
+.projectfu .pc-level-container {
+	display: grid;
+	flex-direction: column;
+	grid-template-columns: auto 1fr;
+	max-height: min-content;
 }
 
 .projectfu .npc-level-container > label {
-	padding: 2px;
-	border-radius: initial !important;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	border: 1px solid rgba(44, 74, 66, 0.3294117647);
-	width: 100%;
-	justify-content: center;
-	background:
-		url(../static/ui/Bkg_highres.png),
-		-webkit-gradient(linear, left top, right top, from(#f5f5dc), to(#c9c7b8));
-	background: url(../static/ui/Bkg_highres.png), linear-gradient(to right, #f5f5dc, #c9c7b8);
-	background-blend-mode: multiply;
-	background-repeat: repeat-y;
-	background-position: right top;
-	border: 1px solid #6f6c66;
-	background-size: cover;
 }
 
 .projectfu .npc-level-container .level-input {
 	width: 100%;
 	border-radius: 0 12px 0 0;
-}
-
-.projectfu .npc-level-container .rank-select,
-.projectfu .npc-level-container .champion-input {
-	height: 100%;
-	border-radius: 0;
 }
 
 .projectfu .npc-level-container .champion-input {
@@ -701,8 +701,7 @@
 	-webkit-box-flex: 0;
 	-ms-flex: 0 0 150px;
 	flex: 0 0 150px;
-	margin-top: 12px;
-	margin-bottom: 12px;
+	padding: 0 0.5rem;
 	margin-right: 8px;
 }
 

--- a/styles/css/actor/party.css
+++ b/styles/css/actor/party.css
@@ -178,6 +178,7 @@
 		flex-direction: column;
 		max-width: 100%;
 		overflow-x: hidden;
+		gap: 5px;
 
 		.soldier,
 		.elite,

--- a/styles/css/actor/profile.css
+++ b/styles/css/actor/profile.css
@@ -31,8 +31,6 @@
 	}
 
 	.bottom-row {
-		padding: 10px;
-		margin-top: 5px;
 		overflow-y: auto;
 	}
 

--- a/styles/css/components/items.css
+++ b/styles/css/components/items.css
@@ -9,6 +9,10 @@
 	text-align: center;
 }
 
+.application.item .window-content {
+	gap: 5px;
+}
+
 .items-header .item-name {
 	font-weight: bold;
 	text-align: left;

--- a/styles/css/global/icon.css
+++ b/styles/css/global/icon.css
@@ -67,8 +67,9 @@
 .fu-icon--m,
 .fu-icon--l {
 	--icon-size: 100%;
+	display: inline-block;
 	line-height: 1;
-	font-size: var(--icon-size) !important;
+	font-size: var(--icon-size);
 	width: var(--icon-size);
 	height: var(--icon-size);
 	background-repeat: no-repeat;

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -28,9 +28,6 @@
 }
 
 .projectfu .sheet-header .combine-header {
-	flex: 0;
-	margin: 0;
-	overflow: visible;
 	flex-direction: row;
 	flex-wrap: wrap;
 	justify-content: flex-start;
@@ -61,12 +58,8 @@
 }
 
 .projectfu .sheet-header .charname-container {
-	margin-right: 1px;
-
-	border-radius: 0;
 	display: flex;
 	align-items: center;
-	padding: 4px;
 	gap: 4px;
 
 	& input[type='text'] {
@@ -86,58 +79,142 @@
 	white-space: normal;
 }
 
+.projectfu .affinities {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-around;
+	.affinity {
+		display: flex;
+		place-content: center;
+		flex: 1 1 auto;
+	}
+	.affinity > label {
+		flex: 0 1 auto;
+		gap: 4px;
+		display: flex;
+		place-content: center;
+		> * {
+			flex: 1 1 auto;
+		}
+	}
+}
+
 .projectfu .sheet-header .header-fields {
 	flex: 1;
-	padding: 5px;
+	gap: 8px;
 	border: none;
 	background: var(--pfu-app-section-bg-image), var(--pfu-color-app-section-primary-fill);
 	background-blend-mode: multiply;
 	background-position: right top;
 	background-size: var(--pfu-app-section-bg-image-size), cover;
 	background-repeat: var(--pfu-app-section-bg-image-repeat);
+	align-self: flex-start;
 
-	& span.combineBar:has(> .species-select) {
-		border: none !important;
-
-		& > .species-select {
-			border-radius: unset;
-		}
-	}
-
-	& > .desc {
+	> .desc {
 		border: none;
 	}
 
-	& .header-start {
-		border: none;
-	}
-
-	& .header-center {
-		background: none;
-	}
-
-	& span:has(.levelup-container) {
-		border: none !important;
-	}
-
-	& .resource-content.level-field {
+	.resource-content.level-field {
 		border: none;
 		background: none;
 		margin: 0 1px 0 1px;
 	}
 
-	& .npc-level-container > label {
-		border: none;
-		background: none;
+	.npc-level-container,
+	.pc-level-container {
+		label {
+			display: flex;
+			margin: 0 4px;
+			gap: 4px;
+			flex-wrap: nowrap;
+			align-self: center;
+			place-content: flex-end;
+		}
+
+		> .bar {
+			grid-column: span 2;
+			height: 10px;
+		}
+
+		> .resource-inputs {
+			border-radius: 0;
+			min-width: max-content;
+			width: 100%;
+			line-height: normal;
+		}
+	}
+
+	.pc-level-container {
+		.level-field:first-of-type input {
+			border-radius: 0 10px 0 0;
+		}
+		.level-field:last-of-type input {
+			border-radius: 10px 0 0 0;
+		}
+	}
+
+	.npc-level-container {
+		> .spacer {
+			grid-column: span 2;
+			height: 5px;
+		}
+
+		> :nth-child(1 of .resource-inputs),
+		> .spacer + label + .resource-inputs {
+			border-radius: 0 10px 0 0;
+		}
+
+		> :nth-last-child(1 of .resource-inputs),
+		> .resource-inputs:has(+ .spacer) {
+			border-radius: 0 0 0 10px;
+		}
+	}
+
+	&:has(.pc-level-container) .resources {
+		grid-column: span 2;
 	}
 
 	.resources {
 	}
 
 	.derived {
-		background: var(--pfu-color-app-control-active-fill-2);
-		border: 1px solid var(--pfu-color-app-border);
-		border-radius: var(--pfu-border-radius);
+		grid-column: span 2;
+		display: flex;
+		justify-content: space-evenly;
+		padding: 0.5rem;
+
+		> * {
+			display: flex;
+			flex-direction: row;
+			gap: 4px;
+			min-width: 0;
+		}
+
+		i.fas {
+			margin-right: 2px;
+		}
+
+		.fu-icon__container {
+			display: flex;
+			place-items: center;
+
+			a {
+				display: flex;
+				place-items: center;
+
+				&:hover i {
+					filter: drop-shadow(0 0 8px var(--pfu-color-misc-shadow-highlight));
+				}
+			}
+		}
+
+		input {
+			font-size: var(--font-size-large);
+			line-height: var(--font-size-large);
+			font-weight: bold;
+			text-align: center;
+			width: 6ch;
+		}
 	}
 }
 
@@ -145,9 +222,6 @@
 }
 
 .projectfu .sheet-header .header-fields .header-center {
-	border-radius: 0 0 12px 0;
-	padding: 8px;
-	grid-row-gap: 2px;
 	gap: 4px;
 }
 
@@ -168,10 +242,12 @@
 	align-self: baseline;
 }
 
-.projectfu .sheet-header #resources-section {
+.projectfu .sheet-header .resources-section {
+	display: flex;
 	flex-wrap: nowrap;
+	gap: 4px;
 
-	#status-section {
+	.status-section {
 		flex: 1 1 auto;
 		> .grid {
 			flex: 1 1 auto;
@@ -182,7 +258,7 @@
 		}
 	}
 
-	#attribute-section {
+	.attribute-section {
 		display: grid;
 		gap: 1px;
 		grid-template-columns: repeat(2, max-content 1.5fr auto 1fr 1fr);
@@ -204,7 +280,7 @@
 		}
 	}
 
-	#roll-section {
+	.roll-section {
 		border-radius: 0 10px 10px 0;
 		height: 100%;
 		align-items: baseline;
@@ -212,8 +288,8 @@
 	}
 }
 
-.projectfu .sheet-header .header-fields #status-section,
-.projectfu .sheet-header .header-fields #subtype-section {
+.projectfu .sheet-header .header-fields .status-section,
+.projectfu .sheet-header .header-fields .subtype-section {
 	border-radius: 10px 0 0 10px;
 	display: flex;
 	align-items: center;
@@ -235,17 +311,18 @@
 	color: #ebf7af;
 }
 
-.projectfu .sheet-header h2.charname {
+.projectfu .sheet-header .charname {
+	flex: 1 1 auto;
 	background-color: transparent;
 	border-color: transparent;
 	color: #000000;
 	height: 50px;
-	padding-left: 8px;
 	border-bottom: 0;
 	margin: 0;
 }
 
-.projectfu .sheet-header h2.charname input {
+.projectfu .sheet-header .charname input {
+	font-size: var(--font-size-h2);
 	color: #ebf7af;
 	border: 0;
 	background-color: transparent;
@@ -254,16 +331,18 @@
 	height: 100%;
 }
 
-.projectfu .sheet-header h4.pronouns {
+.projectfu .sheet-header .pronouns {
+	flex: 1 0 auto;
 	background-color: transparent;
 	border-color: transparent;
-	color: #000000;
 	height: 50px;
-	border-bottom: 0;
-	margin: 0;
+	> input {
+		font-size: var(--font-size-h4);
+		padding: 0.5rem 0;
+	}
 }
 
-.projectfu .sheet-header h4.pronouns input {
+.projectfu .sheet-header .pronouns input {
 	color: #ebf7af;
 	text-shadow: 1px 1px 1px black;
 	width: 100%;
@@ -273,20 +352,20 @@
 	text-align: center;
 }
 
-.projectfu .sheet-header h4.martials {
+.projectfu .sheet-header .martials {
 	border-bottom: 0;
 	display: flex;
 	align-items: center;
-	/* height: 2em; */
 	text-align: center;
 	-webkit-box-flex: 1;
 	-ms-flex-positive: 1;
-	flex-grow: 1;
+	flex: 0 1 min-content;
+
 	/* Martial & Offensive Icon */
 }
 
-.projectfu .sheet-header h4.martials img#martial-header,
-.projectfu .sheet-header h4.martials img#offensive-header {
+.projectfu .sheet-header .martials img#martial-header,
+.projectfu .sheet-header .martials img#offensive-header {
 	-webkit-box-flex: 0;
 	-ms-flex: 0 0 48px;
 	flex: 0 0 48px;
@@ -303,13 +382,13 @@
 	transition: opacity 0.7s ease;
 }
 
-.projectfu .sheet-header h4.martials img#martial-header.active,
-.projectfu .sheet-header h4.martials img#offensive-header.active {
+.projectfu .sheet-header .martials img#martial-header.active,
+.projectfu .sheet-header .martials img#offensive-header.active {
 	opacity: 1;
 }
 
-.projectfu .sheet-header h4.martials img#martial-header:not(.active):hover,
-.projectfu .sheet-header h4.martials img#offensive-header:not(.active):hover {
+.projectfu .sheet-header .martials img#martial-header:not(.active):hover,
+.projectfu .sheet-header .martials img#offensive-header:not(.active):hover {
 	opacity: 0.8;
 }
 
@@ -576,9 +655,9 @@
 	color: #ebf7af;
 	background-color: var(--color-primary);
 	border: thin solid var(--color-primary);
-	width: 4em;
 	height: auto;
-	padding: 0;
+	padding: 0 0.25em;
+	width: 10ch;
 	justify-content: center;
 	text-align: center;
 	border-color: var(--color-primary);
@@ -653,16 +732,6 @@
 	border-color: transparent;
 }
 
-.projectfu .resource-content input.traitdesc {
-	color: #ebf7af;
-	background-color: var(--color-primary);
-	border: #2b4a42 1px solid;
-	border-radius: 0 10px 0 0;
-	-webkit-box-flex: 4;
-	-ms-flex: 4;
-	flex: 4;
-}
-
 .projectfu .resource-content.traits {
 	margin: 0 5px;
 }
@@ -676,50 +745,7 @@
 	border-radius: 5px;
 }
 
-.projectfu .resource-content.levelup-container {
-	border: none;
-}
-
-.projectfu .resource-content.levelup-container input.resource-inputs-charname {
-	color: #ebf7af;
-	background-color: var(--color-primary);
-	margin: 1px;
-}
-
-.projectfu .resource-content.levelup-container .resource-inputs {
-	width: 100%;
-	padding: 0;
-}
-
-.projectfu .resource-content.levelup-container .side-bar {
-	width: 85%;
-}
-
-.projectfu .resource-content.levelup-container.creature {
-	padding: 0;
-	border-radius: 10px;
-	background: none;
-}
-
-.projectfu .resource-content.levelup-container.creature .resource-inputs {
-	color: #ebf7af;
-	background-color: var(--color-primary);
-	width: 3.5em;
-	padding: 0;
-	justify-content: center;
-	text-align: center;
-	border-radius: 5px;
-}
-
-.projectfu .resource-content.levelup-container .combineBar {
-	background: var(--color-primary);
-	border-radius: 0px;
-	width: 100%;
-	align-items: center;
-}
-
 .projectfu .resource-content .villain-field {
-	margin-bottom: 6px !important;
 	border-radius: 0 0 0 14px;
 	width: 100%;
 	border: 0.125em solid #c7c7c7;

--- a/templates/actor/actor-stash-sheet.hbs
+++ b/templates/actor/actor-stash-sheet.hbs
@@ -7,14 +7,14 @@
 					 data-edit="img" title="{{actor.name}}"
 					 style="height: 52px; width: auto; object-fit: contain;" />
 			</a>
-			<div style="display: flex; align-items: center; justify-content: center; gap:0.5rem;">
-				<div class="charname-container flexrow grid-span-4">
-					<h2 class="charname" style="flex: 3;">
+			<div class="flexgrow-1 flexrow gap-5">
+				<div class="charname-container flexrow">
+					<div class="charname">
 						<input name="name" type="text" value="{{actor.name}}" placeholder="Name" />
-					</h2>
+					</div>
 				</div>
 
-				<label class="icon-toggle" title="{{localize 'FU.Merchant'}}?">
+				<label class="flexshrink icon-toggle" title="{{localize 'FU.Merchant'}}?">
 					<input type="checkbox" name="system.merchant" {{ checked system.merchant }} />
 					<i class="toggle-icon fa fa-balance-scale"></i>
 				</label>

--- a/templates/actor/character/parts/actor-header.hbs
+++ b/templates/actor/character/parts/actor-header.hbs
@@ -1,56 +1,47 @@
 <header class="sheet-header">
-	<div class="profile desc" style="display: flex; align-items: stretch;">
+	<div class="profile desc flexrow">
 		<img class="profile-img"
 			 src="{{ actor.img }}"
 			 data-edit="img"
 			 data-action="editImage"
 			 data-tooltip="{{ actor.name }}" />
 
-		<div class="header-fields"
-			 style="flex-grow: 1; display: flex; flex-direction: column; justify-content: space-between;">
+		<div class="header-fields">
 
 			<!-- Start Header -->
-			<div class="header-start grid grid-6col" style="flex-shrink: 0;">
-				{{>"systems/projectfu/templates/actor/partials/actor-charname.hbs" actor=actor}}
+			{{>"systems/projectfu/templates/actor/partials/actor-charname.hbs" actor=actor}}
+			{{!-- TODO: Simplify Resource partial --}}
+			{{!- HP/MP/IP/FP|UP --}}
+			<div class="resources flexrow flex-group-center">
+				{{>"systems/projectfu/templates/actor/partials/actor-point-bars.hbs" actor=actor}}
 			</div>
 
+
 			<!-- Center Header -->
-			<div class="header-center flexcol gap-8" style="flex-grow: 1;">
-				{{!-- TODO: Simplify Resource partial --}}
-				{{!- HP/MP/IP/FP|UP --}}
-				<div class="resources flexrow flex-group-center">
-					{{>"systems/projectfu/templates/actor/partials/actor-point-bars.hbs" actor=actor}}
-					{{>"systems/projectfu/templates/actor/partials/actor-creatures.hbs" actor=actor}}
-				</div>
+			{{!-- DEF/MDEF/INIT/FU/UP --}}
+			<div class="derived">
 
-				{{!-- DEF/MDEF/INIT/FU/UP --}}
-				<div class="derived grid grid-4col flexgrow-2 flex-group-center">
-					{{>"systems/projectfu/templates/actor/partials/actor-derived-stats.hbs" actor=actor}}
-					<!-- FU Points -->
-					{{#if showMetaCurrency}}
-						<div class="flexrow flex-group-centerb gap-8" style="margin-right: 8px;">
-							<a class="rollable resource-content" data-action="spendMetaCurrency">
-								<label class="fu-icon__container resource-label-l flex-group-center">
-									{{#if (eq actor.type "npc")}}
-										<i class="fu-icon--sm {{pfuIconClass 'up'}}"></i>
-										{{localize 'FU.UltimaAbbr'}}
-									{{/if}}
-									{{#if (eq actor.type "character")}}
-										<i class="fu-icon--sm {{pfuIconClass 'fp'}}"></i>
-										{{localize 'FU.FabulaAbbr'}}
-									{{/if}}
-								</label>
-							</a>
-							<div class="buttons-inc"
-								 style="display: flex; justify-content: center; align-items: center;">
-								<input type="number" name="system.resources.fp.value"
-									   value="{{ system.resources.fp.value }}"
-									   data-dtype="Number" id="fp-input" class="resource-inputs"
-									   style="text-align: center;" />
-							</div>
-						</div>
-					{{/if}}
+				{{>"systems/projectfu/templates/actor/partials/actor-derived-stats.hbs" actor=actor}}
+				<!-- FU Points -->
+				<div class="resource-content flex-group-center">
+				{{#if showMetaCurrency}}
+					<label class="fu-icon__container resource-label-l">
+						<a class="rollable" data-action="spendMetaCurrency">
+							{{#if (eq actor.type "npc")}}
+								<i class="fu-icon--sm {{pfuIconClass 'up'}}"></i>
+								{{localize 'FU.UltimaAbbr'}}
+							{{/if}}
+							{{#if (eq actor.type "character")}}
+								<i class="fu-icon--sm {{pfuIconClass 'fp'}}"></i>
+								{{localize 'FU.FabulaAbbr'}}
+							{{/if}}
+						</a>
+					</label>
 
+					<input type="number" name="system.resources.fp.value"
+						   value="{{ system.resources.fp.value }}"
+						   data-dtype="Number" id="fp-input" class="resource-inputs" />
+				{{/if}}
 				</div>
 			</div>
 		</div>
@@ -59,7 +50,7 @@
 	{{!-- Statuses/Attributes/RollCheck Section --}}
 	{{>"systems/projectfu/templates/actor/partials/actor-resources.hbs" actor=actor}}
 	{{!-- Affinity Section --}}
-	{{>"systems/projectfu/templates/actor/partials/actor-affinities.hbs" actor=actor}}
+	{{>"systems/projectfu/templates/actor/partials/actor-affinities.hbs" actor=actor rollable=true section=true}}
 	{{!-- Pressure Points --}}
 	{{#if pressurePoints}}
 		<div class="desc">

--- a/templates/actor/character/parts/actor-limited.hbs
+++ b/templates/actor/character/parts/actor-limited.hbs
@@ -25,7 +25,7 @@
 				{{!-- Study Level 0 --}}
 				{{#if (eq actor.system.study.value 0)}}
 				<fieldset class="section-container title-fieldset desc resource-content">
-					<span class="label centered-message" style="color: unset;">
+					<span class="label centered-message">
 						{{localize 'FU.AdversaryNotStudied'}}
 					</span>
 				</fieldset>
@@ -62,7 +62,7 @@
 					{{#if actor.system.traits.value}}
 					<li class="flexrow flex-group-center desc-header resource-content" style="margin: 8px;">
 						<label class="resource-label-l">Traits</label>
-						<input class="traitdesc flex3" type="text" name="system.traits.value"
+						<input type="text" name="system.traits.value"
 							value="{{actor.system.traits.value}}" placeholder="Traits" data-dtype="String" readonly>
 					</li>
 					{{/if}}

--- a/templates/actor/partials/actor-affinities.hbs
+++ b/templates/actor/partials/actor-affinities.hbs
@@ -1,20 +1,20 @@
 {{!-- Affinity Template --}}
-<div class="affinities desc">
-    <div class="grid grid-9col">
-        {{#if system.affinities}}
-            {{#each system.affinities as |affinity key|}}
-                <div class="affinity resource-content flex-group-center">
-                    <label class="rollable" style="cursor: pointer; display: flex; align-items: flex-end; justify-content: center; gap: 4px;"
-                        data-label="{{ affinity.label }}"
-                        data-roll-type="affinity-type"
-                        data-affinity='{{key}}'
-                        data-action="roll"
-                        data-tooltip="{{ affinity.label }} <br> {{ affinity.affTypeCurr }}">
-						<i class="fu-icon--s affinity-icon {{pfuIconClass key}}"></i>
-                        <span class="resource-label-l" style="letter-spacing: 0.5px; margin-bottom: -2px;">{{ affinity.affTypeCurrAbbr }}</span>
-                    </label>
-                </div>
-            {{/each}}
-        {{/if}}
-    </div>
+<div class="affinities {{#if section}}desc{{/if}}">
+	{{#if system.affinities}}
+		{{#each system.affinities as |affinity key|}}
+			<div class="affinity resource-content flex-group-center">
+			<label
+			{{#if ../rollable}}class="rollable"
+			 data-roll-type="affinity-type"
+			 data-affinity='{{key}}'
+			 data-action="roll"
+			 data-tooltip="{{ affinity.label }} <br> {{ affinity.affTypeCurr }} "
+			{{/if}}
+			 data-label="{{ affinity.label }}">
+				<i class="fu-icon--s affinity-icon {{pfuIconClass key}}"></i>
+				<span class="resource-label-l">{{ affinity.affTypeCurrAbbr }}</span>
+				</label>
+			</div>
+		{{/each}}
+	{{/if}}
 </div>

--- a/templates/actor/partials/actor-charname.hbs
+++ b/templates/actor/partials/actor-charname.hbs
@@ -1,47 +1,44 @@
-<div class="charname-container flexrow grid-span-4">
-	<h2 class="charname" style="flex: 3;">
+<div class="charname-container">
+	<div class="charname">
 		<input name="name" type="text" value="{{ actor.name }}" placeholder="Name" data-tooltip="{{ actor.name }}"
-			   class="resource-inputs-charname auto-shrink" />
-	</h2>
-	<h4 class="pronouns">
+			   class="resource-inputs-charname" />
+	</div>
+	<div class="pronouns">
 		<input name="system.resources.pronouns.name" type="text" value="{{ system.resources.pronouns.name }}"
 			   placeholder="Pronouns" data-tooltip="{{localize 'FU.Pronouns'}}<br>{{ system.resources.pronouns.name }}"
-			   class="auto-shrink" />
-	</h4>
+			   size="{{#if (gt system.resources.pronouns.name.length 7)}}{{ system.resources.pronouns.name.length }}{{else}}7{{/if}}" oninput="this.size = Math.max(7, this.value.length)"/>
+	</div>
 </div>
 {{#if (eq actor.type "character")}}
-	<span class="flexrow grid grid-2col grid-span-2"
-		  style="border-image: linear-gradient(to right, #bfb4c5, #e6e2e8) 1; border-left: rgb(255, 173, 200) 3px solid;">
-    <!-- Level -->
-    <span class="resource-content levelup-container level-field flexcol flex-group-center">
-        <label class="resource-label-m" data-tooltip="{{localize 'FU.Level'}}" aria-describedby="tooltip">
-            <i class="fas fa-chart-simple icon"></i>{{localize
-		 'FU.LevelAbbr'}} </label>
-        <input name="system.level.value" value="{{ system.level.value }}" type="number" data-dtype="Number"
-			   class="resource-inputs" style="border-radius: 0 12px 0 0;;" />
+	<span class="pc-level-container">
+		<!-- Level -->
+		<span class="resource-content level-field flexcol flex-group-center">
+			<label class="resource-label-m" data-tooltip="{{localize 'FU.Level'}}" aria-describedby="tooltip">
+				<i class="fas fa-chart-simple icon"></i>{{localize
+			 'FU.LevelAbbr'}} </label>
+			<input name="system.level.value" value="{{ system.level.value }}" type="number" data-dtype="Number"
+				   class="resource-inputs" />
+		</span>
+			<!-- Experience -->
+		<span class="resource-content level-field flexcol flex-group-center">
+			<label class="resource-label-m" data-tooltip="{{localize 'FU.Exp'}}" aria-describedby="tooltip">
+				<i class="fas fa-feather-pointed icon"></i>
+				{{localize 'FU.ExpAbbr'}}
+				{{#if (gte system.resources.exp.value 10)}}
+					<i class="fas fa-hand-point-up is-levelup float-text" data-action="levelUp" data-tooltip="{{localize 'FU.LevelUp'}}"
+					   aria-describedby="tooltip"></i>
+				{{/if}}
+			</label>
+			<input name="system.resources.exp.value" value="{{ system.resources.exp.value }}" type="number"
+				   data-dtype="Number" class="resource-inputs" />
     </span>
-		<!-- Experience -->
-    <span class="resource-content levelup-container level-field flexcol flex-group-center"
-		  style="border-top-right-radius: 12px;">
-        <label class="resource-label-m" data-tooltip="{{localize 'FU.Exp'}}" aria-describedby="tooltip">
-            <i class="fas fa-feather-pointed icon"></i>
-			{{localize 'FU.ExpAbbr'}}
-			{{#if (gte system.resources.exp.value 10)}}
-				<i class="fas fa-hand-point-up is-levelup float-text" data-action="levelUp" data-tooltip="{{localize 'FU.LevelUp'}}"
-				   aria-describedby="tooltip"></i>
-			{{/if}}
-        </label>
-        <input name="system.resources.exp.value" value="{{ system.resources.exp.value }}" type="number"
-			   data-dtype="Number" class="resource-inputs" style="border-radius: 10px 0 0;" />
-    </span>
-    <div class="bar bar-progress grid-span-2" style="height: 10px;">
-        <div class="bar-progress-bar bar-level" style="width: {{pfuPercentage system.resources.exp.value 10}};">
-        </div>
+    <div class="bar bar-progress">
+        <div class="bar-progress-bar bar-level"></div>
     </div>
 </span>
 {{/if}}
 {{#if (eq actor.type "npc")}}
-	<div class="grid-span-2 resource-content npc-level-container">
+	<div class="resource-content npc-level-container">
 		<!-- Level -->
 		<label class="resource-label-m align-center backgroundstyle" data-tooltip="{{localize 'FU.Level'}}"
 			   aria-describedby="tooltip">
@@ -49,24 +46,23 @@
 			{{localize 'FU.LevelAbbr'}}
 		</label>
 		<input type="number" name="system.level.value" min="5" max="60" step="5" value="{{ system.level.value }}"
-			   class="resource-inputs grid-span-2 level-input" />
+			   class="resource-inputs level-input" />
 		<!-- Rank -->
 		<label class="resource-label-m align-center backgroundstyle" data-tooltip="{{localize 'FU.Rank'}}"
 			   aria-describedby="tooltip"> <i
 		 class="fas fa-feather-pointed icon"></i>{{localize
 		 'FU.Rank'}} </label>
-		<div class="grid-span-2 flexrow" style="flex-wrap: nowrap;">
-			<select name="system.rank.value" class="resource-inputs rank-select">
-				{{selectOptions FU.rank selected=system.rank.value localize=true}}
-			</select>
+		<select name="system.rank.value" class="resource-inputs rank-select">
+			{{selectOptions FU.rank selected=system.rank.value localize=true}}
+		</select>
 
-			{{#if (eq system.rank.value 'champion')}}
-				<span class="resource-inputs flex0 champion-input">
-                    <input type="number" name="system.rank.replacedSoldiers" min="1" max="6"
-						   value="{{system.rank.replacedSoldiers}}"
-						   class="resource-inputs" />
-                </span>
-			{{/if}}
-		</div>
+		{{#if (eq system.rank.value 'champion')}}
+			<span class="resource-inputs flex0 champion-input">
+				<input type="number" name="system.rank.replacedSoldiers" min="1" max="6"
+					   value="{{system.rank.replacedSoldiers}}"
+					   class="resource-inputs" />
+			</span>
+		{{/if}}
+		{{>"systems/projectfu/templates/actor/partials/actor-creatures.hbs" actor=actor}}
 	</div>
 {{/if}}

--- a/templates/actor/partials/actor-charname.hbs
+++ b/templates/actor/partials/actor-charname.hbs
@@ -52,16 +52,22 @@
 			   aria-describedby="tooltip"> <i
 		 class="fas fa-feather-pointed icon"></i>{{localize
 		 'FU.Rank'}} </label>
+		{{#if (eq system.rank.value 'champion')}}
+		<span class="rank-combined resource-inputs">
+			<select name="system.rank.value" class="resource-inputs rank-select">
+				{{selectOptions FU.rank selected=system.rank.value localize=true}}
+			</select>
+
+				<span class="resource-inputs champion-input">
+					<input type="number" name="system.rank.replacedSoldiers" min="1" max="6"
+						   value="{{system.rank.replacedSoldiers}}"
+						   class="resource-inputs" />
+				</span>
+		</span>
+		{{else}}
 		<select name="system.rank.value" class="resource-inputs rank-select">
 			{{selectOptions FU.rank selected=system.rank.value localize=true}}
 		</select>
-
-		{{#if (eq system.rank.value 'champion')}}
-			<span class="resource-inputs flex0 champion-input">
-				<input type="number" name="system.rank.replacedSoldiers" min="1" max="6"
-					   value="{{system.rank.replacedSoldiers}}"
-					   class="resource-inputs" />
-			</span>
 		{{/if}}
 		{{>"systems/projectfu/templates/actor/partials/actor-creatures.hbs" actor=actor}}
 	</div>

--- a/templates/actor/partials/actor-creatures.hbs
+++ b/templates/actor/partials/actor-creatures.hbs
@@ -1,68 +1,55 @@
 {{#if (eq actor.type "npc")}}
 {{!-- Creature Rank --}}
-	<div class="flexcol gap-1">
-		<div class="resource-content levelup-container creature flex-group-center">
-			<!-- Role -->
-			<span class="flexrow">
-                <label class="resource-label-m backgroundstyle" data-tooltip="{{localize 'FU.Role'}}"
-					   aria-describedby="tooltip">
-                    <i class="fas fa-wrench-simple icon"></i>
-					{{localize 'FU.Role'}}
-                </label>
-                <div class="grid-span-2 flexrow">
-                    <select name="system.role.value" class="resource-inputs">
-						{{selectOptions FU.role selected=system.role.value localize=true}}
-					</select>
-                </div>
-            </span>
+		<!-- Role -->
+	<div class="spacer"></div>
+	<label class="resource-label-m" data-tooltip="{{localize 'FU.Role'}}"
+		   aria-describedby="tooltip">
+		<i class="fas fa-wrench-simple icon"></i>
+		{{localize 'FU.Role'}}
+	</label>
+	<select name="system.role.value" class="resource-inputs">
+		{{selectOptions FU.role selected=system.role.value localize=true}}
+	</select>
 
-			<!-- Species -->
-			<span class="flexrow">
-                <label class="resource-label-m backgroundstyle" data-tooltip="{{localize 'FU.Role'}}"
-					   aria-describedby="tooltip">
-                    <i class="{{pfuIconClass 'species'}} icon"></i>
-					{{localize 'FU.Species'}}
-                </label>
-                <div class="grid-span-2 flexrow">
-					<select name="system.species.value" class="resource-inputs species-select" style="padding: 3px 0">
-						{{#if (eq system.rank.value 'companion')}}
-							{{selectOptions FU.companionSpecies selected=system.species.value localize=true}}
-						{{else}}
-							{{selectOptions FU.species selected=system.species.value localize=true}}
-						{{/if}}
-					</select>
-                </div>
-            </span>
-		</div>
+<!-- Species -->
+	<label class="resource-label-m" data-tooltip="{{localize 'FU.Role'}}"
+		   aria-describedby="tooltip">
+		<i class="{{pfuIconClass 'species'}} icon"></i>
+		{{localize 'FU.Species'}}
+	</label>
+	<select name="system.species.value" class="resource-inputs species-select">
+		{{#if (eq system.rank.value 'companion')}}
+			{{selectOptions FU.companionSpecies selected=system.species.value localize=true}}
+		{{else}}
+			{{selectOptions FU.species selected=system.species.value localize=true}}
+		{{/if}}
+	</select>
 
-		<!-- Villain -->
-		<span class="resource-content levelup-container flexrow flex-group-center">
-			{{#if (eq system.rank.value 'companion')}}
-				<span class="flexrow combineBar villain-field resource-content flex-group-center">
-					<label class="resource-inputs"
-						   data-tooltip="({{localize 'FU.Reference'}}) {{localize 'FU.PlayerLevel'}}">{{ localize
-					 'FU.LevelAbbr' }}</label>
-					<span class="resource-inputs">
-						<label class="resource-inputs">{{refActorLevel}}</label>
-					</span>
-					<label class="resource-inputs"
-						   data-tooltip="({{localize 'FU.Reference'}}) {{localize 'FU.SkillLevel'}}">{{ localize
-					 'FU.SkillLevelAbbr' }}</label>
-					<span class="resource-inputs">
-						<label class="resource-inputs">{{refSkillLevel}}</label>
-					</span>
-				</span>
-			{{else}}
-				<label class="resource-label-m backgroundstyle" data-tooltip="{{localize 'FU.Role'}}"
-					   aria-describedby="tooltip">
-					<i class="{{pfuIconClass 'villain'}} icon"></i>
-					{{localize 'FU.Villain'}}
-				</label>
-				<select name="system.villain.value" data-dtype="String"
-						class="resource-inputs villain-field">
-					{{selectOptions FU.villainTypes selected=system.villain.value blank='FU.VillainNone' localize=true}}
-				</select>
-			{{/if}}
+
+	<!-- Villain -->
+	{{#if (eq system.rank.value 'companion')}}
+
+		<label class="resource-label-m" data-tooltip="({{localize 'FU.Reference'}}) {{localize 'FU.PlayerLevel'}}">{{ localize
+		 'FU.LevelAbbr' }}</label>
+		<span class="resource-inputs">
+			<label>{{refActorLevel}}</label>
 		</span>
-	</div>
+		<label class="resource-label-m" data-tooltip="({{localize 'FU.Reference'}}) {{localize 'FU.SkillLevel'}}">{{ localize
+		 'FU.SkillLevelAbbr' }}</label>
+		<span class="resource-inputs">
+			<label>{{refSkillLevel}}</label>
+		</span>
+
+	{{else}}
+		<label class="resource-label-m data-tooltip="{{localize 'FU.Role'}}"
+			   aria-describedby="tooltip">
+			<i class="{{pfuIconClass 'villain'}} icon"></i>
+			{{localize 'FU.Villain'}}
+		</label>
+		<select name="system.villain.value" data-dtype="String"
+				class="resource-inputs villain-field">
+			{{selectOptions FU.villainTypes selected=system.villain.value blank='FU.VillainNone' localize=true}}
+		</select>
+	{{/if}}
+
 {{/if}}

--- a/templates/actor/partials/actor-resources.hbs
+++ b/templates/actor/partials/actor-resources.hbs
@@ -1,6 +1,6 @@
-<div id="resources-section" class="header-fields flexrow gap-5">
+<div class="resources-section desc">
     <!-- Status Toggle Section -->
-    <div id="status-section">
+    <div class="status-section">
         {{!-- Key Statuses --}}
         <div class="grid grid-8col">
             {{#each statusEffectToggles as |statusEffect|}}
@@ -10,14 +10,13 @@
                 </a>
             {{/each}}
         </div>
-
     </div>
     <!-- Attribute Section -->
-    <div id="attribute-section" class="resource-content">
+    <div class="resource-content attribute-section">
         {{>"systems/projectfu/templates/actor/partials/actor-attributes.hbs"}}
     </div>
     <!-- Roll Section -->
-    <div id="roll-section" class="resource-content flex-group-center grid grid-4col">
+    <div class="roll-section resource-content flex-group-center grid grid-4col">
         {{!-- Group Check --}}
         <div class="flexcol flex-group-center rollable spin2win" data-roll-type="group-check"
              data-tooltip="{{localize 'FU.GroupCheckTooltip'}}" data-action="roll">

--- a/templates/item/parts/item-attributes.hbs
+++ b/templates/item/parts/item-attributes.hbs
@@ -1,4 +1,4 @@
-<div class="tab attributes {{tab.cssClass}}" data-group="primary" data-tab="attributes">
+<div class="tab attributes flexcol gap-5 {{tab.cssClass}}" data-group="primary" data-tab="attributes">
 
 	<div class="item-settings desc resource-content">
 		{{#each attributePartials.settings as |part|}}

--- a/templates/item/parts/item-header.hbs
+++ b/templates/item/parts/item-header.hbs
@@ -1,5 +1,5 @@
 <header class="sheet-header desc">
-	<div class="profile desc" style="display: flex; align-items: stretch;">
+	<div class="profile desc flexrow gap-5">
 		{{!-- <img class="item-profile-img" src="{{ item.img }}" data-edit="img" data-action="editImage" title="{{ item.name }}" /> --}}
 		<img class="item-profile-img"
 			 src="{{ item.img }}"
@@ -8,13 +8,13 @@
 			 data-tooltip="{{ item.name }}" />
 
 		<div class="header-fields">
-			<div class="header-start grid grid-6col">
+			<div class="header-start grid grid-6col gap-5">
 				<div class="charname-container flexrow grid-span-4">
-					<h2 class="charname" style="flex: 4;">
+					<div class="charname">
 						<input name="name" type="text" value="{{ item.name }}" placeholder="Name"
 							   data-tooltip="{{ item.name }}" class="resource-inputs-charname auto-shrink" />
-					</h2>
-					<h4 class="martials">
+					</div>
+					<div class="martials">
 						{{#if showMartial}}
 							<input id="martial-checkbox" type="checkbox" style="display: none;" {{#if
 							 system.isMartial.value}}checked{{/if}}>
@@ -36,7 +36,7 @@
 									 tabindex="0" aria-hidden="true">
 							</label>
 						{{/if}}
-					</h4>
+					</div>
 				</div>
 
 				{{!-- Part --}}

--- a/templates/item/parts/item-tabs.hbs
+++ b/templates/item/parts/item-tabs.hbs
@@ -2,7 +2,7 @@
 
 	{{#if system.schema.fields.subtype}}
 	{{!-- Sub Type --}}
-		<span id="subtype-section" class="resource-content flexrow flex-group-center desc">
+		<span class="subtype-section resource-content flexrow flex-group-center desc">
             <label class="resource-label-sm" for="item.type">
 				<i class="fas fa-chart-simple icon"></i>
 				{{localize 'FU.SubType'}}
@@ -38,7 +38,7 @@
 			{{/if}}
 	</span>
 	{{else if (or (eq item.type "classFeature") (eq item.type "optionalFeature"))}}
-		<span id="subtype-section" class="resource-content flexrow flex-group-center desc">
+		<span class="subtype-section resource-content flexrow flex-group-center desc">
 		<span>
 			<label class="resource-label-m">{{localize subtypeLocalizationKey}}</label>
 			<a data-action="changeSubtype">

--- a/templates/ui/study/npc-profile.hbs
+++ b/templates/ui/study/npc-profile.hbs
@@ -15,7 +15,7 @@
 
 			{{#unless revealStats}}
 			<fieldset class="section-container title-fieldset desc resource-content">
-					<span class="label centered-message" style="color: unset;">
+					<span class="label centered-message">
 						{{localize 'FU.AdversaryNotStudied'}}
 					</span>
 			</fieldset>
@@ -26,7 +26,7 @@
 						{{localize 'FU.Stats'}}
 					</legend>
 					{{#if basic}}
-					<div class="resource-label-l resource-content flexrow flex-group-center" style="padding: 5px;">
+					<div class="resource-label-l resource-content flexrow flex-group-center">
 						<div class="pfu-badge" data-tooltip="{{localize localizedSpecies}}">
 							<i class="fua fu-{{species}}"></i>
 						</div>
@@ -51,16 +51,16 @@
 						</div>
 
 						{{#if system.traits.value}}
-							<li class="flexrow flex-group-center desc-header resource-content" style="margin: 8px;">
-								<label class="resource-label-l">Traits</label>
-								<input class="traitdesc flex3" type="text" name="system.traits.value" value="{{system.traits.value}}" placeholder="Traits" data-dtype="String" readonly>
+							<li class="flexrow gap-5 flex-group-center desc-header resource-content">
+								<label class="flexshrink resource-label-l">Traits</label>
+								<input type="text" name="system.traits.value" value="{{system.traits.value}}" placeholder="Traits" data-dtype="String" readonly>
 							</li>
 						{{/if}}
 					{{else}}
 						{{#if revealed.traits}}
-							<li class="flexrow flex-group-center desc-header resource-content" style="margin: 8px;">
-								<label class="resource-label-l">Traits</label>
-								<input class="traitdesc flex3" type="text" name="revealed.traits" value="{{revealed.traits}}" placeholder="Traits" data-dtype="String" readonly>
+							<li class="flexrow gap-5 flex-group-center desc-header resource-content ">
+								<label class="flexshrink resource-label-l">Traits</label>
+								<input type="text" name="revealed.traits" value="{{revealed.traits}}" placeholder="Traits" data-dtype="String" readonly>
 							</li>
 						{{/if}}
 					{{/if}}
@@ -68,25 +68,14 @@
 			{{/if}}
 		</div>
 	</div>
-
-	<fieldset class="section-container title-fieldset desc resource-content">
-		<legend class="resource-label-m">
-			{{localize 'FU.Affinities'}}
-		</legend>
-
-		<div class="affinities resource-content flex-group-center grid grid-9col" style="display: flex; justify-content: space-between; padding: 0 8px;">
-			{{#each affinities}}
-				<div class="affinities resource-content flex-group-center grid grid-9col" style="display: flex; justify-content: space-between; padding: 0 8px;">
-					<div class="affinity resource-content flex-group-center" style="opacity: {{this.opacity}}; display: flex; justify-content: space-between; margin: 2px; gap: 5px; line-height: 1;">
-						<i class="fu-icon--s {{this.iconClass}}"></i>
-						<label class="resource-label-xl" style="cursor: pointer;" data-tooltip="{{this.fullName}}: {{localize this.acronymValue}}">
-							{{localize this.acronymValue}}
-						</label>
-					</div>
-				</div>
-			{{/each}}
-		</div>
-	</fieldset>
+	{{#if complete}}
+		<fieldset class="section-container title-fieldset desc resource-content">
+			<legend class="resource-label-m">
+				{{localize 'FU.Affinities'}}
+			</legend>
+			{{> "systems/projectfu/templates/actor/partials/actor-affinities.hbs" actor=actor}}
+		</fieldset>
+	{{/if}}
 
 	{{#if revealPressurePoints}}
 		<fieldset class="section-container title-fieldset desc resource-content">


### PR DESCRIPTION
Addresses various issues raised in #1047, plus a number of related fixes that became necessary as a result of the initial changes. For example:
- Reduced class re-use in completely unrelated parts of the system
- Updated the actor affinities partial to be reusable in the NPC profile without the send-to-chat functionality on the main sheet.
- Replaced inline styling with targeted styles wherever possible, either via utility or semantic classes as appropriate.
- General touchup of various sheet headers to use a more responsive layout.
- Updated actor sheet name section pronouns field to dynamically size based on input text using cross-browser compatible Javascript (a CSS solution exists but is not fully supported by all major browsers).