### PR TITLE
Various sheet rendering improvements and fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1125,6 +1125,7 @@
 		"AlwaysFavoriteSettingsHint": "Enable this option to always favorite an item during creation.",
 		"NotesTabSettings": "Enable NPC Notes Tab",
 		"NotesTabSettingsHint": "Add the biography & info notes tab into the NPC Sheet.",
+		"BondsSectionSettings": "Enable PC Bonds Section",
 		"EffectCrisisInteraction": "Crisis Interaction",
 		"EffectCrisisInteractionNone": "None",
 		"EffectCrisisInteractionActive": "Active while in Crisis",

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -285,6 +285,7 @@ export const FUHandlebars = Object.freeze({
  * @property {Boolean} compact If true, will present the controls in a more compact way.
  * @property action
  * @property {"clock"|"basic"} style
+ * @property {String} classes
  */
 
 const progressStyleTemplates = Object.freeze({
@@ -346,6 +347,7 @@ function renderProgress(progress, document, path, options, index = undefined) {
 					controls: controls,
 					action: action,
 					prompt: options.prompt,
+					classes: options.classes ?? '',
 					compact: options.compact,
 					displayName: options.displayName && (progress.name || document.name),
 				})

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -96,7 +96,10 @@ export const FUHandlebars = Object.freeze({
 			return str;
 		});
 
-		Handlebars.registerHelper('pfuAcronym', function (str) {
+		Handlebars.registerHelper('pfuAcronym', function (str, threshold) {
+			if (str.length <= threshold) {
+				return str;
+			}
 			const split = str.trim().split(' ');
 			if (split.length > 1) {
 				return split.map((word) => word[0].toUpperCase()).join('.');

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -96,6 +96,14 @@ export const FUHandlebars = Object.freeze({
 			return str;
 		});
 
+		Handlebars.registerHelper('pfuAcronym', function (str) {
+			const split = str.trim().split(' ');
+			if (split.length > 1) {
+				return split.map((word) => word[0].toUpperCase()).join('.');
+			}
+			return split[0];
+		});
+
 		Handlebars.registerHelper('pfuHalf', function (value) {
 			var num = Number(value);
 			if (isNaN(num)) {

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -35,6 +35,7 @@ export const preloadHandlebarsTemplates = async function () {
 			'systems/projectfu/templates/actor/partials/actor-favorite.hbs',
 			'systems/projectfu/templates/actor/partials/actor-bonds.hbs',
 			'systems/projectfu/templates/actor/partials/actor-temporary-effects.hbs',
+			'systems/projectfu/templates/actor/partials/actor-npc-widgets.hbs',
 
 			'systems/projectfu/templates/actor/partials/actor-progress-clock.hbs',
 			'systems/projectfu/templates/actor/partials/actor-progress-clock-xl.hbs',

--- a/module/settings.js
+++ b/module/settings.js
@@ -82,6 +82,7 @@ export const SETTINGS = Object.freeze({
 	showAssociatedTherioforms: 'showAssociatedTherioforms',
 	showAdvancementTracker: 'showAdvancementTracker',
 	optionNPCNotesTab: 'optionNPCNotesTab',
+	optionPCBondsSection: 'optionPCBondsSection',
 	optionAlwaysFavorite: 'optionAlwaysFavorite',
 	optionAutomaticAdversaryRegistration: 'optionRegisterAdversaries',
 	partySheetTheme: 'optionPartySheetTheme',
@@ -170,6 +171,7 @@ export const registerSystemSettings = async function () {
 		icon: 'fas fa-book',
 		type: createConfigurationApp('FU.SheetOptions', [
 			SETTINGS.optionNPCNotesTab,
+			SETTINGS.optionPCBondsSection,
 			SETTINGS.optionAlwaysFavorite,
 			SETTINGS.showAssociatedTherioforms,
 			SETTINGS.showAdvancementTracker,
@@ -200,6 +202,15 @@ export const registerSystemSettings = async function () {
 	game.settings.register(SYSTEM, SETTINGS.optionNPCNotesTab, {
 		name: game.i18n.localize('FU.NotesTabSettings'),
 		hint: game.i18n.localize('FU.NotesTabSettingsHint'),
+		scope: 'world',
+		config: false,
+		type: Boolean,
+		default: false,
+		requiresReload: true,
+	});
+
+	game.settings.register(SYSTEM, SETTINGS.optionPCBondsSection, {
+		name: game.i18n.localize('FU.BondsSectionSettings'),
 		scope: 'world',
 		config: false,
 		type: Boolean,

--- a/module/settings.js
+++ b/module/settings.js
@@ -214,7 +214,7 @@ export const registerSystemSettings = async function () {
 		scope: 'world',
 		config: false,
 		type: Boolean,
-		default: false,
+		default: true,
 		requiresReload: true,
 	});
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -4,6 +4,8 @@ import { StringUtils } from '../helpers/string-utils.mjs';
 import { ItemSelectionDialog } from '../ui/features/item-selection-dialog.mjs';
 import { ObjectUtils } from '../helpers/object-utils.mjs';
 import { HTMLUtils } from '../helpers/html-utils.mjs';
+import { createMenuTool, SETTINGS } from '../settings.js';
+import { SYSTEM } from '../helpers/config.mjs';
 
 const { api, sheets } = foundry.applications;
 
@@ -30,6 +32,15 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 					label: 'FU.CompendiumMigrateActorItems',
 					ownership: 'OWNER',
 				},
+				{
+					action: 'configureSheetOptions',
+					icon: 'fas fa-book',
+					label: 'FU.SheetOptions',
+					ownership: 'OWNER',
+					visible: () => {
+						return game.user.isGM;
+					},
+				},
 			],
 		},
 		form: {
@@ -37,6 +48,7 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 		},
 		actions: {
 			migrateItems: this.#migrateItems,
+			configureSheetOptions: this.#configureSheetOptions,
 			addArrayElement: this.#addArrayElement,
 			removeArrayElement: this.#removeArrayElement,
 		},
@@ -252,5 +264,16 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 				});
 			}
 		}
+	}
+
+	/**
+	 * @this FUActorSheet
+	 * @param {PointerEvent} event   The originating click event
+	 * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+	 * @returns {Promise<void>}
+	 */
+	static async #configureSheetOptions(event, target) {
+		const tool = createMenuTool(`${SYSTEM}.${SETTINGS.sheetOptions}`);
+		tool.click();
 	}
 }

--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -164,7 +164,7 @@ export class FUStandardActorSheet extends FUActorSheet {
 	static TABS = {
 		primary: {
 			tabs: [
-				{ id: 'stats', label: 'FU.Stats' },
+				{ id: 'stats', label: 'FU.Overview' },
 				{ id: 'classes', label: 'FU.Classes' },
 				{ id: 'features', label: 'FU.Features' },
 				{ id: 'spells', label: 'FU.Spell' },
@@ -460,6 +460,8 @@ export class FUStandardActorSheet extends FUActorSheet {
 							}),
 						};
 					}
+					const favorites = Array.from(this.actor.allItems().filter((item) => item.isFavorite));
+					context.hasFavorites = favorites.length > 0;
 					context.favoritesTable = await this.#favoritesTable.renderTable(this.document);
 					context.temporaryEffects = this.actor.temporaryEffects.filter((e) => e.hasDuration);
 				}

--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -461,7 +461,13 @@ export class FUStandardActorSheet extends FUActorSheet {
 						};
 					}
 					const favorites = Array.from(this.actor.allItems().filter((item) => item.isFavorite));
-					context.hasFavorites = favorites.length > 0;
+					const hasFavorites = favorites.length > 0;
+					context.hasFavorites = hasFavorites;
+					context.showBonds = getSystemSetting(SETTINGS.optionPCBondsSection);
+					const showNPCNotes = !getSystemSetting(SETTINGS.optionNPCNotesTab);
+					context.showNPCNotes = showNPCNotes;
+					context.useMultiColumnLayout = !hasFavorites && !showNPCNotes;
+
 					context.favoritesTable = await this.#favoritesTable.renderTable(this.document);
 					context.temporaryEffects = this.actor.temporaryEffects.filter((e) => e.hasDuration);
 				}

--- a/styles/css/actor/party.css
+++ b/styles/css/actor/party.css
@@ -1,7 +1,7 @@
 .projectfu .pfu-sheet__party {
 	display: grid;
 	height: 100%;
-	padding: 0;
+	padding: 4px;
 
 	section {
 		height: 100%;
@@ -9,6 +9,9 @@
 
 	.tab {
 		.content {
+			display: flex;
+			flex-direction: column;
+			gap: 4px;
 		}
 	}
 

--- a/styles/css/components/buttons.css
+++ b/styles/css/components/buttons.css
@@ -1,0 +1,9 @@
+.pfu-action {
+	justify-content: center;
+	flex: 0;
+	color: var(--pfu-color-app-control-fill-2);
+
+	i {
+		font-size: 12px;
+	}
+}

--- a/styles/css/components/progress.css
+++ b/styles/css/components/progress.css
@@ -3,12 +3,17 @@
  /* ----------------------------------------- */
 .pfu-progress {
 	display: grid;
-	gap: 1px;
+	gap: 4px;
 	grid-template-columns: auto 1fr;
 
 	span,
 	i {
 		color: var(--pfu-color-app-control-content);
+	}
+
+	&.--stack {
+		display: flex;
+		flex-direction: column;
 	}
 
 	:is(.desc) & span,
@@ -28,6 +33,7 @@
 .pfu-progress__name__container {
 	display: flex;
 	flex-direction: column;
+	flex: 0;
 	label {
 		vertical-align: middle;
 	}
@@ -169,7 +175,7 @@
 
 .pfu-progress__bar {
 	font-size: 18px;
-	height: 20px;
+	max-height: 20px;
 	width: 100px;
 	border: 1px solid #c7c7c7;
 	background-color: #656565;
@@ -195,9 +201,11 @@
 	background: var(--pfu-color-app-control-fill);
 	color: var(--pfu-color-app-control-content);
 	border-radius: 3px;
+	border: 2px solid var(--pfu-color-app-control-content);
 	padding: 0 0.35rem;
 	font-weight: bold;
 	min-width: 1.5rem;
+	max-height: 20px;
 	text-align: center;
 }
 

--- a/styles/css/components/progress.css
+++ b/styles/css/components/progress.css
@@ -175,6 +175,7 @@
 
 .pfu-progress__bar {
 	font-size: 18px;
+	height: 20px;
 	max-height: 20px;
 	width: 100px;
 	border: 1px solid #c7c7c7;

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -380,15 +380,32 @@
 			min-height: 0;
 
 			&.multi-column {
+				max-width: unset;
 				flex: unset;
 				flex-wrap: wrap;
 				width: auto;
-				max-width: unset;
-				align-items: start;
-				justify-content: space-between;
+				flex-direction: column;
+				height: 100%;
+				gap: 12px;
 
-				.section-container {
-					min-width: 170px;
+				.widgets {
+					display: flex;
+					flex-direction: row;
+					align-items: start;
+					justify-content: space-between;
+					flex-wrap: wrap;
+
+					.section-container {
+						min-width: 170px;
+					}
+				}
+
+				.fill {
+					flex: 1;
+					box-shadow: inset 0 0 0 4px color-mix(in srgb, var(--pfu-color-app-control-highlight-border) 40%, transparent);
+					background-image: var(--pfu-app-bg-image);
+					background-color: var(--pfu-color-app-control-fill-1);
+					background-blend-mode: color-dodge;
 				}
 			}
 

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -446,6 +446,24 @@
 						white-space: nowrap;
 					}
 				}
+
+				.effect-shortcut {
+					display: flex;
+					flex-direction: row;
+					justify-content: space-between;
+					align-items: center;
+					flex: 0;
+
+					a {
+						flex: 0 1 max-content;
+					}
+					.effect-name {
+						max-width: 5ch;
+						overflow: hidden;
+						text-overflow: ellipsis;
+						white-space: nowrap;
+					}
+				}
 			}
 
 			.favorites-section {

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -380,22 +380,14 @@
 			min-height: 0;
 
 			&.multi-column {
-				&:has(main .favorites-section):not(:has(main .favorites-section .item)) {
-					> main {
-						flex: 0 1 auto;
-						.favorites-section {
-							display: none;
-						}
-					}
+				flex: unset;
+				flex-wrap: wrap;
+				width: auto;
+				max-width: unset;
+				align-items: start;
 
-					> aside.sidebar {
-						flex: 1 1 auto;
-						max-width: unset;
-					}
-				}
-				.sidebar-container {
-					flex-wrap: wrap;
-					width: auto;
+				.section-container {
+					min-width: 170px;
 				}
 			}
 

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -399,14 +399,6 @@
 						min-width: 170px;
 					}
 				}
-
-				.fill {
-					flex: 1;
-					box-shadow: inset 0 0 0 4px color-mix(in srgb, var(--pfu-color-app-control-highlight-border) 40%, transparent);
-					background-image: var(--pfu-app-bg-image);
-					background-color: var(--pfu-color-app-control-fill-1);
-					background-blend-mode: color-dodge;
-				}
 			}
 
 			> aside.sidebar {

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -385,6 +385,7 @@
 				width: auto;
 				max-width: unset;
 				align-items: start;
+				justify-content: space-between;
 
 				.section-container {
 					min-width: 170px;

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -458,7 +458,7 @@
 						flex: 0 1 max-content;
 					}
 					.effect-name {
-						max-width: 5ch;
+						max-width: 8ch;
 						overflow: hidden;
 						text-overflow: ellipsis;
 						white-space: nowrap;

--- a/styles/css/global/theme.css
+++ b/styles/css/global/theme.css
@@ -243,7 +243,7 @@ h4.divider::after {
 		border-radius: var(--pfu-border-radius-medium);
 		background: var(--pfu-color-control-fill);
 		&:hover {
-			/*color: var(--pfu-color-control-highlight-content);*/
+			color: var(--pfu-color-app-control-highlight-content);
 			border-color: var(--pfu-color-control-highlight-border);
 			background: var(--pfu-color-control-highlight-fill);
 		}

--- a/styles/css/global/theme.css
+++ b/styles/css/global/theme.css
@@ -242,11 +242,13 @@ h4.divider::after {
 		border-color: var(--pfu-color-control-border);
 		border-radius: var(--pfu-border-radius-medium);
 		background: var(--pfu-color-control-fill);
+
 		&:hover {
 			color: var(--pfu-color-app-control-highlight-content);
 			border-color: var(--pfu-color-control-highlight-border);
 			background: var(--pfu-color-control-highlight-fill);
 		}
+
 		&.active,
 		&[aria-pressed='true'] {
 			border-color: var(--pfu-color-control-active-border);

--- a/styles/projectfu.css
+++ b/styles/projectfu.css
@@ -31,6 +31,7 @@
 @import 'css/components/items.css';
 @import 'css/components/progress.css';
 @import 'css/components/barmeter.css';
+@import 'css/components/buttons.css';
 @import 'css/components/combat.css';
 @import 'css/components/effects.css';
 @import 'css/components/resource.css';

--- a/templates/actor/character/parts/actor-section-stats.hbs
+++ b/templates/actor/character/parts/actor-section-stats.hbs
@@ -133,8 +133,11 @@
 					{{/if~}}
 					</div>
 				</fieldset>
-				<!-- Favorite Section -->
-				{{> "systems/projectfu/templates/actor/partials/actor-favorite.hbs"}}
+
+				{{#if hasFavorites}}
+					<!-- Favorite Section -->
+					{{> "systems/projectfu/templates/actor/partials/actor-favorite.hbs"}}
+				{{/if}}
 			</main>
 		</section>
 	{{/if}}

--- a/templates/actor/character/parts/actor-section-stats.hbs
+++ b/templates/actor/character/parts/actor-section-stats.hbs
@@ -80,63 +80,43 @@
 	{{/if}}
 
 	{{#if isNPC}}
-		<section class="body-section">
-			<aside class="sidebar">
-				<div class="sidebar-container">
-					{{!-- Action Buttons --}}
-					{{>"systems/projectfu/templates/actor/partials/actor-actions.hbs" actor=actor}}
-					{{!-- Therioform Section --}}
-					{{#if (pfuGetSetting 'showAssociatedTherioforms')}}
-						<fieldset class="desc resource-content title-fieldset associated-therioforms">
-							<legend class="resource-label-m">
-								<label>{{localize 'FU.ClassFeatureTherioformAssociatedTherioforms'}}</label>
-							</legend>
-							<label>
-								<input type="text" name="system.associatedTherioforms"
-									   value="{{system.associatedTherioforms}}"
-									   class="resource-inputs select-dropdown-full resource-text-m">
-							</label>
-						</fieldset>
-					{{/if}}
-					{{!-- Traits Section --}}
-					<fieldset class="section-container traits-section title-fieldset desc resource-content">
-						<legend class="resource-label-m">
-							<label>{{localize 'FU.Traits'}}</label>
-						</legend>
-						<label>
-							<input class="traitdesc flex3" type="text" name="system.traits.value"
-								   value="{{ system.traits.value }}" placeholder="{{localize 'FU.Traits'}}"
-								   data-dtype="String" />
-						</label>
-					</fieldset>
-					{{!-- Effects Section --}}
-					{{> "systems/projectfu/templates/actor/partials/actor-temporary-effects.hbs" actor=actor}}
-					{{!-- Clock Section --}}
-					{{> "systems/projectfu/templates/actor/partials/actor-clocks.hbs" actor=actor}}
-				</div>
-			</aside>
-			<main>
-				<!-- Description Section -->
-				{{~#unless (eq (pfuGetSetting 'optionNPCNotesTab') true)~}}
-				<fieldset class="section-container biography-section title-fieldset desc resource-content">
-					<legend class="resource-label-m" aria-describedby="tooltip">
-						<a class="resource-label-m">
-							{{localize 'FU.BiographyInfo'}}
-						</a>
-					</legend>
-					<div>
-						<prose-mirror name="system.description" value="{{~system.description~}}" class="fit" toggled>
-							{{{enrichedHtml.description}}}
-						</prose-mirror>
-					</div>
-				</fieldset>
-				{{/unless}}
-				<!-- Favorite Section -->
-				{{#if hasFavorites}}
-					{{> "systems/projectfu/templates/actor/partials/actor-favorite.hbs"}}
-				{{/if}}
-			</main>
+		{{#if useMultiColumnLayout}}
+		<section class="body-section multi-column">
+			{{>"systems/projectfu/templates/actor/partials/actor-npc-widgets.hbs"}}
 		</section>
+		{{else}}
+			<section class="body-section standard">
+				<aside class="sidebar">
+					<div class="sidebar-container">
+						{{!-- Favorite Section --}}
+						{{>"systems/projectfu/templates/actor/partials/actor-npc-widgets.hbs"}}
+					</div>
+				</aside>
+				{{#unless useMultiColumnLayout}}
+					<main>
+						<!-- Description Section -->
+						{{#if showNPCNotes}}
+							<fieldset class="section-container biography-section title-fieldset desc resource-content">
+								<legend class="resource-label-m" aria-describedby="tooltip">
+									<a class="resource-label-m">
+										{{localize 'FU.BiographyInfo'}}
+									</a>
+								</legend>
+								<div>
+									<prose-mirror name="system.description" value="{{~system.description~}}" class="fit" toggled>
+										{{{enrichedHtml.description}}}
+									</prose-mirror>
+								</div>
+							</fieldset>
+						{{/if}}
+						<!-- Favorite Section -->
+						{{#if hasFavorites}}
+							{{> "systems/projectfu/templates/actor/partials/actor-favorite.hbs"}}
+						{{/if}}
+					</main>
+				{{/unless}}
+			</section>
+		{{/if}}
 	{{/if}}
 </div>
 

--- a/templates/actor/character/parts/actor-section-stats.hbs
+++ b/templates/actor/character/parts/actor-section-stats.hbs
@@ -85,8 +85,6 @@
 			<div class="widgets">
 				{{>"systems/projectfu/templates/actor/partials/actor-npc-widgets.hbs"}}
 			</div>
-			<div class="fill">
-			</div>
 		</section>
 		{{else}}
 			<section class="body-section standard">

--- a/templates/actor/character/parts/actor-section-stats.hbs
+++ b/templates/actor/character/parts/actor-section-stats.hbs
@@ -117,6 +117,7 @@
 			</aside>
 			<main>
 				<!-- Description Section -->
+				{{~#unless (eq (pfuGetSetting 'optionNPCNotesTab') true)~}}
 				<fieldset class="section-container biography-section title-fieldset desc resource-content">
 					<legend class="resource-label-m" aria-describedby="tooltip">
 						<a class="resource-label-m">
@@ -124,18 +125,14 @@
 						</a>
 					</legend>
 					<div>
-					{{~#if (eq (pfuGetSetting 'optionNPCNotesTab') true)~}}
-						{{~{enrichedHtml.description}~}}
-					{{~else}}
 						<prose-mirror name="system.description" value="{{~system.description~}}" class="fit" toggled>
 							{{{enrichedHtml.description}}}
 						</prose-mirror>
-					{{/if~}}
 					</div>
 				</fieldset>
-
+				{{/unless}}
+				<!-- Favorite Section -->
 				{{#if hasFavorites}}
-					<!-- Favorite Section -->
 					{{> "systems/projectfu/templates/actor/partials/actor-favorite.hbs"}}
 				{{/if}}
 			</main>

--- a/templates/actor/character/parts/actor-section-stats.hbs
+++ b/templates/actor/character/parts/actor-section-stats.hbs
@@ -82,7 +82,11 @@
 	{{#if isNPC}}
 		{{#if useMultiColumnLayout}}
 		<section class="body-section multi-column">
-			{{>"systems/projectfu/templates/actor/partials/actor-npc-widgets.hbs"}}
+			<div class="widgets">
+				{{>"systems/projectfu/templates/actor/partials/actor-npc-widgets.hbs"}}
+			</div>
+			<div class="fill">
+			</div>
 		</section>
 		{{else}}
 			<section class="body-section standard">

--- a/templates/actor/character/parts/actor-section-stats.hbs
+++ b/templates/actor/character/parts/actor-section-stats.hbs
@@ -31,39 +31,41 @@
 					{{!-- Garden Section --}}
 					{{> "systems/projectfu/templates/actor/partials/actor-garden.hbs"}}
 					{{!-- Bond Section --}}
-					<fieldset class="section-container title-fieldset desc resource-content">
-						<legend class="resource-label-m">
-							{{localize 'FU.Bonds'}}
-						</legend>
-						<div class="bonds">
-							{{#each system.bonds as |bond bondIndex|}}
-								<div class="bond-row flexrow mb-2">
-									<label class="resource-text-sm flex-group-left flex-grow">
-										<strong>
-											{{#if bond.name}}
-												{{bond.name}}
-											{{else}}
-												{{localize 'FU.NoItem'}}
-											{{/if}}
-										</strong>
-									</label>
-									<label class="resource-text-sm bond-strength flex0" data-tooltip="
+					{{~#if (eq (pfuGetSetting 'optionPCBondsSection') true)~}}
+						<fieldset class="section-container title-fieldset desc resource-content">
+							<legend class="resource-label-m">
+								{{localize 'FU.Bonds'}}
+							</legend>
+							<div class="bonds">
+								{{#each system.bonds as |bond bondIndex|}}
+									<div class="bond-row flexrow mb-2">
+										<label class="resource-text-sm flex-group-left flex-grow">
+											<strong>
+												{{#if bond.name}}
+													{{bond.name}}
+												{{else}}
+													{{localize 'FU.NoItem'}}
+												{{/if}}
+											</strong>
+										</label>
+										<label class="resource-text-sm bond-strength flex0" data-tooltip="
                                             {{#if (lookup @root.FU.bonds.admInf bond.admInf)}}
-										{{localize (lookup @root.FU.bonds.admInf bond.admInf)}}<br>
+											{{localize (lookup @root.FU.bonds.admInf bond.admInf)}}<br>
                                             {{/if}}
-										{{#if (lookup @root.FU.bonds.loyMis bond.loyMis)}}
-											{{localize (lookup @root.FU.bonds.loyMis bond.loyMis)}}<br>
+											{{#if (lookup @root.FU.bonds.loyMis bond.loyMis)}}
+												{{localize (lookup @root.FU.bonds.loyMis bond.loyMis)}}<br>
                                             {{/if}}
-										{{#if (lookup @root.FU.bonds.affHat bond.affHat)}}
-											{{localize (lookup @root.FU.bonds.affHat bond.affHat)}}
-										{{/if}}
+											{{#if (lookup @root.FU.bonds.affHat bond.affHat)}}
+												{{localize (lookup @root.FU.bonds.affHat bond.affHat)}}
+											{{/if}}
                                         ">
-										{{ bond.strength }}
-									</label>
-								</div>
-							{{/each}}
-						</div>
-					</fieldset>
+											{{ bond.strength }}
+										</label>
+									</div>
+								{{/each}}
+							</div>
+						</fieldset>
+					{{/if}}
 					{{!-- Effects Section --}}
 					{{> "systems/projectfu/templates/actor/partials/actor-temporary-effects.hbs" actor=actor}}
 					{{!-- Clock Section --}}

--- a/templates/actor/partials/actor-npc-widgets.hbs
+++ b/templates/actor/partials/actor-npc-widgets.hbs
@@ -1,0 +1,30 @@
+{{!-- Action Buttons --}}
+{{>"systems/projectfu/templates/actor/partials/actor-actions.hbs" actor=actor}}
+{{!-- Therioform Section --}}
+{{#if (pfuGetSetting 'showAssociatedTherioforms')}}
+	<fieldset class="section-container desc resource-content title-fieldset associated-therioforms">
+		<legend class="resource-label-m">
+			<label>{{localize 'FU.ClassFeatureTherioformAssociatedTherioforms'}}</label>
+		</legend>
+		<label>
+			<input type="text" name="system.associatedTherioforms"
+				   value="{{system.associatedTherioforms}}"
+				   class="resource-inputs select-dropdown-full resource-text-m">
+		</label>
+	</fieldset>
+{{/if}}
+{{!-- Traits Section --}}
+<fieldset class="section-container traits-section title-fieldset desc resource-content">
+	<legend class="resource-label-m">
+		<label>{{localize 'FU.Traits'}}</label>
+	</legend>
+	<label>
+		<input class="traitdesc flex3" type="text" name="system.traits.value"
+			   value="{{ system.traits.value }}" placeholder="{{localize 'FU.Traits'}}"
+			   data-dtype="String" />
+	</label>
+</fieldset>
+{{!-- Effects Section --}}
+{{> "systems/projectfu/templates/actor/partials/actor-temporary-effects.hbs" actor=actor}}
+{{!-- Clock Section --}}
+{{> "systems/projectfu/templates/actor/partials/actor-clocks.hbs" actor=actor}}

--- a/templates/actor/partials/actor-temporary-effects.hbs
+++ b/templates/actor/partials/actor-temporary-effects.hbs
@@ -2,16 +2,18 @@
 	<legend class="resource-label-m">
 		{{localize 'FU.Effects'}}
 	</legend>
-	<div class="flexcol gap-4">
+	<div class="grid grid-2col gap-4">
 		{{#each temporaryEffects as |effect|}}
-			<div class="effect flexrow flex-between" data-effect-id="{{effect.id}}">
-					<span class="flexrow flex-group-left gap-5">
-						{{pfuItemAnchor effect}}
-						<span class="effect-name">{{effect.name}}</span>
+			<div class="effect-shortcut" data-effect-id="{{effect.id}}">
+				<span class="flexrow flex-group-left gap-5">
+					{{pfuItemAnchor effect}}
+					<span class="effect-name" data-tooltip="{{effect.name}}">
+						{{pfuAcronym effect.name}}
 					</span>
-				<button data-action="deleteEffect" style="flex: 0; width: 1.5rem; height: 1.5rem;">
+				</span>
+				<a class="pfu-action" data-action="deleteEffect">
 					<i class="fa fa-trash"></i>
-				</button>
+				</a>
 			</div>
 		{{/each}}
 	</div>

--- a/templates/actor/partials/actor-temporary-effects.hbs
+++ b/templates/actor/partials/actor-temporary-effects.hbs
@@ -2,13 +2,13 @@
 	<legend class="resource-label-m">
 		{{localize 'FU.Effects'}}
 	</legend>
-	<div class="grid grid-2col gap-4">
+	<div class="grid grid-2col gap-2">
 		{{#each temporaryEffects as |effect|}}
 			<div class="effect-shortcut" data-effect-id="{{effect.id}}">
 				<span class="flexrow flex-group-left gap-5">
-					{{pfuItemAnchor effect}}
+					{{pfuItemAnchor effect delete=true}}
 					<span class="effect-name" data-tooltip="{{effect.name}}">
-						{{pfuAcronym effect.name}}
+						{{pfuAcronym effect.name 8}}
 					</span>
 				</span>
 				<a class="pfu-action" data-action="deleteEffect">

--- a/templates/actor/party/actor-party-section-adversaries.hbs
+++ b/templates/actor/party/actor-party-section-adversaries.hbs
@@ -1,6 +1,6 @@
 {{!-- Adversaries  --}}
 <section class="tab {{tab.cssClass}}" data-tab="adversaries" data-group="primary">
-	<section class="adversaries">
+	<section class="adversaries content">
 		{{#unless (gt adversaries.length 0)}}
 			<div class="label centered-message">
 				{{localize 'FU.AdversariesEmpty'}}

--- a/templates/actor/party/actor-party-section-widgets.hbs
+++ b/templates/actor/party/actor-party-section-widgets.hbs
@@ -3,7 +3,7 @@
 	<div class="tracks resource-content flex-group-center">
 		<div class="pfu-progress__collection" style="background: unset;">
 			{{#each system.tracks }}
-				{{pfuProgressCollection ../document 'system.tracks' @index displayName=true compact=true prompt=true controls=../isGM }}
+				{{pfuProgressCollection ../document 'system.tracks' @index displayName=true compact=true prompt=true controls=../isGM classes="--stack"}}
 			{{/each}}
 		</div>
 	</div>

--- a/templates/common/progress/progress-bar.hbs
+++ b/templates/common/progress/progress-bar.hbs
@@ -1,4 +1,4 @@
-<div class="pfu-progress inline-desc flexrow flex-group-center">
+<div class="pfu-progress inline-desc flexrow flex-group-center {{classes}}">
 
 	<div class="pfu-progress__bar frame" data-tooltip="{{data.current}}/{{data.max}}">
 		<div class="bar"
@@ -7,7 +7,7 @@
 	</div>
 
 		{{#if displayName}}
-		<div>
+		<div class="pfu-progress__name__container">
 			{{#if compact}}
 				<a data-action="openTrackMenu" data-id="{{id}}"
 				   {{#if dataPath}}data-data-path="{{dataPath}}"{{/if}}

--- a/templates/common/progress/progress-basic.hbs
+++ b/templates/common/progress/progress-basic.hbs
@@ -1,4 +1,4 @@
-<div class="pfu-progress inline-desc flexrow flex-group-center">
+<div class="pfu-progress inline-desc flexrow flex-group-center {{classes}}">
 	<div class="pfu-progress__basic">
 		<span data-resource="item.rp">{{ data.current }}</span>
 		{{#if (gt data.max 0)}}
@@ -8,7 +8,7 @@
 	</div>
 
 	{{#if displayName}}
-		<div>
+		<div class="pfu-progress__name__container">
 			{{#if compact}}
 				<a data-action="openTrackMenu" data-id="{{id}}"
 				   {{#if dataPath}}data-data-path="{{dataPath}}"{{/if}}

--- a/templates/common/progress/progress-clock.hbs
+++ b/templates/common/progress/progress-clock.hbs
@@ -1,4 +1,4 @@
-<div class="pfu-progress inline-desc flexrow flex-group-center resource-content" data-item-id="{{id}}">
+<div class="pfu-progress inline-desc flexrow flex-group-center resource-content {{classes}}" data-item-id="{{id}}">
 
 	<div class="pfu-progress__segments__container" data-tooltip="{{data.current}}/{{data.max}}">
 		<div class="pfu-progress__segments" style="--segments: {{data.max}};" data-segments="{{data.max}}" data-index="{{index}}"


### PR DESCRIPTION
- Fix up track rendering on party sheet
- Update effect shortcuts
- Add bonds section option for PC sheet (true by default)
- Hide favorites from NPCs when not used
- Hide biography and notes on NPCs when its tab is enabled
- Add sheet option to open the PFU specific sheet settings
- Fix progress bar height on actor sheets
- Fix up multi column layout when main section is not rendered (still needs work)