### PR TITLE
Fix for attribute select display issue with 2-digit dice values

### DIFF
--- a/styles/css/actor/actor.css
+++ b/styles/css/actor/actor.css
@@ -624,6 +624,7 @@
 .projectfu .status-effect-toggle img {
 	height: 32px;
 	width: 32px;
+	object-fit: contain;
 	display: block;
 	margin-top: -1px;
 	border-radius: 4px;

--- a/styles/css/actor/actor.css
+++ b/styles/css/actor/actor.css
@@ -622,11 +622,8 @@
 }
 
 .projectfu .status-effect-toggle img {
-	-webkit-box-flex: 0 !important;
-	-ms-flex: 0 0 32px !important;
-	flex: 0 0 32px !important;
-	height: 32px !important;
-	width: 32px !important;
+	height: 32px;
+	width: 32px;
 	display: block;
 	margin-top: -1px;
 	border-radius: 4px;

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -245,10 +245,11 @@
 .projectfu .sheet-header .resources-section {
 	display: flex;
 	flex-wrap: nowrap;
+	justify-content: space-evenly;
 	gap: 4px;
 
 	.status-section {
-		flex: 1 1 auto;
+		flex: 0 1 auto;
 		place-content: center;
 		> .grid {
 			height: 100%;
@@ -260,6 +261,7 @@
 	}
 
 	.attribute-section {
+		flex: 0 1 auto;
 		display: grid;
 		gap: 1px;
 		grid-template-columns: repeat(2, max-content 1.5fr auto 1fr 1fr);
@@ -268,7 +270,6 @@
 		justify-self: center;
 		align-self: center;
 		align-items: center;
-		flex: 1 1 auto;
 		border-radius: 0;
 		height: 100%;
 
@@ -277,17 +278,16 @@
 
 			select {
 				width: min-content;
-				padding: 0;
 				margin: 2px;
 			}
 		}
 	}
 
 	.roll-section {
+		flex: 0 1 auto;
 		border-radius: 0 10px 10px 0;
 		height: 100%;
 		align-items: baseline;
-		flex: 1 1 auto;
 	}
 }
 

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -249,8 +249,9 @@
 
 	.status-section {
 		flex: 1 1 auto;
+		place-content: center;
 		> .grid {
-			flex: 1 1 auto;
+			height: 100%;
 			.status-effect-toggle img {
 				margin-right: -1px;
 				margin-bottom: -1px;
@@ -275,7 +276,9 @@
 			display: contents;
 
 			select {
-				width: 2.7rem;
+				width: min-content;
+				padding: 0;
+				margin: 2px;
 			}
 		}
 	}


### PR DESCRIPTION
Somewhere in the layout changes I did for the actor sheet header, I introduced an issue wherein the attribute die select element doesn't show the 2nd digit in the case of 2-digit values. This PR resolves that issue.
Before:
<img width="226" height="70" alt="image" src="https://github.com/user-attachments/assets/e99199d4-ec03-4fda-b32e-8337021d99c6" />
After:
<img width="263" height="73" alt="image" src="https://github.com/user-attachments/assets/b0efedc4-6d3a-4146-b81b-90c9fccc19f1" />
