### PR TITLE
Disabled Status Immunity Setting When Overridden

### DIFF
--- a/templates/actor/character/parts/actor-section-settings.hbs
+++ b/templates/actor/character/parts/actor-section-settings.hbs
@@ -245,7 +245,10 @@
 								<span class="resource-label-sm">{{immunity.label}}</span>
 								<input type="checkbox"
 									   id="immunity-{{key}}"
-									   name="system.immunities.{{key}}.base"
+									   name="system.immunities.{{key}}.base"  
+									{{#if (lookup @root.actor.overrides.system.immunities key)}}
+									   disabled data-tooltip="{{localize "FU.DisabledByActiveEffect"}}"
+									{{/if}}
 									   {{#if immunity.base}}checked{{/if}}
 									{{checked immunity.base}}>
 							</label>


### PR DESCRIPTION
Added a conditional to the Status Immunity checkboxes of the actor settings. It disables the checkbox if the Status Immunity is currently being overridden by an active effect. That way the state of the Status Immunity is not being saved to the actor while it's being controlled by an active effect.

This fixes #1019 