### PR TITLE
AE Rules tab and prose-mirror code editor scrolling

### DIFF
--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -90,7 +90,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 				{ id: 'details', icon: 'fa-solid fa-book' },
 				{ id: 'duration', icon: 'fa-solid fa-clock' },
 				{ id: 'predicates', label: 'FU.Predicate', icon: 'fa-solid fa-check' },
-				{ id: 'rules', label: 'FU.Rule', icon: 'fa-solid fa-list' },
+				{ id: 'rules', label: 'FU.Rule', icon: 'fa-solid fa-list', cssClass: 'scrollable' },
 				{ id: 'changes', icon: 'fa-solid fa-gears' },
 			],
 			initial: 'details',

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -1079,3 +1079,12 @@
 		transform: translateY(0);
 	}
 }
+
+.projectfu prose-mirror {
+	max-height: 350px;
+
+	.source-editor {
+		height: 100%;
+		overflow-y: auto;
+	}
+}


### PR DESCRIPTION
- Adds `scrollable` class to the Rules tab of the ActiveEffect sheet, to handle when Rule Elements get long
- Adds a maximum height to `.projectfu prose-mirror`, forces a height of 100% with `overflow-y` auto on prose-mirror source editor, to enforce scrolling when its contents are particularly long