### PR TITLE
Invocation Wellspring Preview Display Fix

### DIFF
--- a/templates/feature/invoker/invocations-description.hbs
+++ b/templates/feature/invoker/invocations-description.hbs
@@ -2,7 +2,9 @@
 <div class="flexrow wellspring-preview">
     {{#each additionalData.activeWellsprings as | active |}}
         {{#with (lookup ../additionalData.wellsprings @key)}}
-            <i class="wellspring {{icon}} {{#unless active}}inactive{{/unless}}" data-tooltip="{{name}}"></i>
+            <i class="wellspring fu-icon__container {{#unless active}}inactive{{/unless}}" data-tooltip="{{name}}" data-wellspring="{{@key}}">
+				<i class="fu-icon--s {{icon}}"></i>
+            </i>
         {{/with}}
     {{/each}}
 </div>

--- a/templates/feature/invoker/invocations-preview.hbs
+++ b/templates/feature/invoker/invocations-preview.hbs
@@ -1,7 +1,9 @@
 <div class="wellspring-preview">
     {{#each additionalData.activeWellsprings as | active |}}
         {{#with (lookup ../additionalData.wellsprings @key)}}
-            <i class="wellspring {{icon}} {{#unless active}}inactive{{/unless}}" data-tooltip="{{name}}"></i>
+            <i class="wellspring fu-icon__container {{#unless active}}inactive{{/unless}}" data-tooltip="{{name}}" data-wellspring="{{@key}}">
+				<i class="fu-icon--s {{icon}}"></i>
+            </i>
         {{/with}}
     {{/each}}
 </div>


### PR DESCRIPTION
Updated the class and layout for the Invocations Class Feature preview so that the icons for all the Wellsprings display properly.

This fixes #1099 

<img width="720" height="76" alt="image" src="https://github.com/user-attachments/assets/272554f7-7eb0-4f3e-b883-d38f754332f9" />