### PR TITLE
Modify Consumable Rule Fix

### DIFF
--- a/module/documents/effects/actions/modify-consumable-rule-action.mjs
+++ b/module/documents/effects/actions/modify-consumable-rule-action.mjs
@@ -45,17 +45,13 @@ export class ModifyConsumableRuleAction extends RuleActionDataModel {
 	async execute(context, selected) {
 		// TODO: Do different things based on the item traits?
 		if (context.event.builder) {
-			let amount = Number.parseInt(context.event.builder.amount);
 			const expressionContext = ExpressionContext.fromSourceInfo(context.sourceInfo, context.targetActors);
 			if (this.bonus) {
-				const evalBonus = await Expressions.evaluateAsync(this.bonus, expressionContext);
-				amount += evalBonus;
+				context.event.builder.bonus += await Expressions.evaluateAsync(this.bonus, expressionContext);
 			}
 			if (this.multiplier) {
-				const evalMultiplier = await Expressions.evaluateAsync(this.multiplier, expressionContext, false);
-				amount *= evalMultiplier;
+				context.event.builder.multiplier *= await Expressions.evaluateAsync(this.multiplier, expressionContext, false);
 			}
-			context.event.builder.amount = amount;
 		}
 	}
 }

--- a/module/documents/items/consumable/consumable-data-model.mjs
+++ b/module/documents/items/consumable/consumable-data-model.mjs
@@ -57,10 +57,28 @@ export class BasicDamageDataModel extends foundry.abstract.DataModel {
  */
 
 /**
+ * @property {string} action
  * @property {Number} amount
- * @property {FUResourceType} resourceType
+ * @property {Number} bonus
+ * @property {Number} multiplier
+ * @property {FUResourceType} type
  */
-export class ConsumableBuilder {}
+export class ConsumableBuilder {
+	constructor(action, amount, type) {
+		this.action = action;
+		this.amount = Number.parseInt(amount);
+		this.bonus = 0;
+		this.multiplier = 1;
+		this.type = type;
+	}
+
+	/**
+	 * @returns {Number}
+	 */
+	totalAmount() {
+		return Math.floor((this.amount + this.bonus) * this.multiplier);
+	}
+}
 
 /**
  * @property {string} subtype.value
@@ -111,22 +129,17 @@ export class ConsumableDataModel extends FUSubTypedItemDataModel {
 			const cost = new ActionCostDataModel({ resource: 'ip', amount: item.system.ipCost.value, perTarget: false });
 			await ResourcePipeline.configureExpense(config, actor, item, cost);
 
-			let builder = new ConsumableBuilder();
 			if (consumable.resource.enabled) {
-				builder.action = 'resource';
-				builder.amount = consumable.resource.amount;
-				builder.resourceType = consumable.resource.type;
+				let builder = new ConsumableBuilder('resource', consumable.resource.amount, consumable.resource.type);
 				await CommonEvents.createConsumable(actor, item, targets, builder);
-				config.setResource(consumable.resource.type, builder.amount);
+				config.setResource(consumable.resource.type, builder.totalAmount());
 			}
 			if (consumable.damage.enabled) {
-				builder.action = 'damage';
-				builder.amount = consumable.damage.amount;
 				const sourceInfo = InlineSourceInfo.fromInstance(actor, item);
-
-				await CommonEvents.createConsumable(actor, item, targets, builder);
 				for (const type of consumable.damage.types) {
-					const data = DamageData.construct(type, builder.amount);
+					let builder = new ConsumableBuilder('damage', consumable.damage.amount, type);
+					await CommonEvents.createConsumable(actor, item, targets, builder);
+					const data = DamageData.construct(type, builder.totalAmount());
 					const action = DamagePipeline.getTargetedAction(data, sourceInfo);
 					config.addTargetedAction(action);
 				}


### PR DESCRIPTION
Changed the Consumable builder to collect all bonuses and multipliers. Then, applied them all at once to handle proper operation order and rounding. Altered the Modify Consumable Rule Action to use these variables.

This fixes #708 and #722 