### PR TITLE
Migrate Actor Items Dialog Cleanup

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1795,7 +1795,7 @@
 		"CompendiumMigrateItem": "Migrate Item",
 		"CompendiumMigrateItemMessage": "Would you like to migrate the data in the item <strong>{name}</strong> to that of the compendium?",
 		"CompendiumMigrateActorItems": "Migrate Actor Items",
-		"CompendiumMigrateActorItemsMessage": "Would you like to migrate the data in the selected items of the actor to that of the compendiums?",
+		"CompendiumMigrateActorItemsMessage": "Would you like to migrate the data in the selected items of the actor to that of the compendiums?<br><strong>WARNING: Migrating an item will overwrite any local changes to that item. This includes the name, summary, description, and image. Please migrate at your own risk.</strong>",
 		"CompendiumMigrateSuccess": "Successfully migrated {count} compendium items!",
 		"CompendiumBrowserPacksHint": "What compendium packs to display on the browser.",
 		"CompendiumBrowserOpen": "Open Compendium Browser",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -182,7 +182,7 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 	 */
 	static async #migrateItems(event, target) {
 		/** @type FUItem[] **/
-		let items = Array.from(this.actor.items.values());
+		let items = Array.from(this.actor.items.values()).sort((a, b) => a.name.localeCompare(b.name));
 		/** @type ItemMigrationAction[] **/
 		const updates = await FoundryUtils.getItemMigrationActions(items);
 
@@ -203,7 +203,6 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 				style: 'list',
 				items: items,
 				compendiumItems: compendiumItems,
-				initial: items,
 				getDescription: async (item) => {
 					const text = item.system?.description ?? '';
 					return text;

--- a/templates/dialog/dialog-item-selection.hbs
+++ b/templates/dialog/dialog-item-selection.hbs
@@ -92,6 +92,7 @@
 						<th></th>
 						<th>{{localize 'FU.Entry'}}</th>
 						{{#if compendiumItems}}
+							<th></th>
 							<th>{{localize 'FU.CompendiumItem'}}</th>
 						{{/if}}
 						{{#each columns as |col|}}
@@ -114,19 +115,21 @@
 							<td class="fu-selection-dialog__entry-cell">
 								<div class="fu-selection-dialog__entry-content">
 									{{pfuItemAnchor item}}
-									<span class="fu-selection-dialog__entry-name" data-tooltip="{{lookup ../descriptions @index}}">{{item.name}}</span>
+									<span class="fu-selection-dialog__entry-name align-left" data-tooltip="{{lookup ../descriptions @index}}">{{item.name}}</span>
 								</div>
 							</td>
 							{{#if @root.compendiumItems}}
-								<td>
-									{{#with (lookup ../compendiumItems @index) as |item|}}
+								{{#with (lookup ../compendiumItems @index) as |item|}}
+									<td>
 										{{pfuItemAnchor item}}
+									</td>
+									<td class="align-left">
 										<span>{{item.name}}</span>
-									{{/with}}
-								</td>
+									</td>
+								{{/with}}
 							{{/if}}
 							{{#each @root.columns as |col|}}
-								<td>
+								<td class="align-left">
 									<span>
 										{{lookup (lookup @root.columnData col.label) @../index}}
 									</span>


### PR DESCRIPTION
- Added warning message to migrate items dialog.
- The items now start unselected.
- Sorted items alphabetically by name.
- Cleaned up layout to align compendium item icons and align the text to the left.

<img width="603" height="681" alt="image" src="https://github.com/user-attachments/assets/865d163e-6c98-4f68-ac56-2a768ef31252" />