### PR TITLE
Remove Forced Unarmed Strike Special Handling

### DIFF
--- a/module/checks/accuracy-check.mjs
+++ b/module/checks/accuracy-check.mjs
@@ -49,8 +49,6 @@ const critThresholdFlags = {
  * @type CheckCallback
  */
 const handleWeaponTraitAccuracyBonuses = (check, actor, item) => {
-	const weaponTraits = CheckConfiguration.inspect(check).getWeaponTraits();
-
 	{
 		const flag = actor.getFlag(SYSTEM, critThresholdFlags.all);
 		if (flag) {
@@ -58,39 +56,41 @@ const handleWeaponTraitAccuracyBonuses = (check, actor, item) => {
 		}
 	}
 
-	// Weapon Category
-	if (weaponTraits.weaponCategory) {
-		if (actor.system.bonuses.accuracy[weaponTraits.weaponCategory]) {
-			check.modifiers.push({
-				label: `FU.AccuracyCheckBonus${weaponTraits.weaponCategory.capitalize()}`,
-				value: actor.system.bonuses.accuracy[weaponTraits.weaponCategory],
-			});
+	const weaponTraits = CheckConfiguration.inspect(check).getWeaponTraits();
+	if (weaponTraits) {
+		// Weapon Category
+		if (weaponTraits.weaponCategory) {
+			if (actor.system.bonuses.accuracy[weaponTraits.weaponCategory]) {
+				check.modifiers.push({
+					label: `FU.AccuracyCheckBonus${weaponTraits.weaponCategory.capitalize()}`,
+					value: actor.system.bonuses.accuracy[weaponTraits.weaponCategory],
+				});
+			}
+
+			const flag = actor.getFlag(SYSTEM, critThresholdFlags[weaponTraits.weaponCategory]);
+			if (flag) {
+				check.critThreshold = Math.min(check.critThreshold, Number(flag));
+			}
 		}
 
-		const flag = actor.getFlag(SYSTEM, critThresholdFlags[weaponTraits.weaponCategory]);
-		if (flag) {
-			check.critThreshold = Math.min(check.critThreshold, Number(flag));
-		}
-	}
-
-	// Attack Type
-	const attackType = weaponTraits.weaponType;
-	if (attackType === 'melee' && actor.system.bonuses.accuracy.accuracyMelee) {
-		check.modifiers.push({
-			label: 'FU.AccuracyCheckBonusMelee',
-			value: actor.system.bonuses.accuracy.accuracyMelee,
-		});
-	} else if (attackType === 'ranged' && actor.system.bonuses.accuracy.accuracyRanged) {
-		check.modifiers.push({
-			label: 'FU.AccuracyCheckBonusRanged',
-			value: actor.system.bonuses.accuracy.accuracyRanged,
-		});
-	}
-
-	{
-		const flag = actor.getFlag(SYSTEM, critThresholdFlags[weaponTraits.weaponType]);
-		if (flag) {
-			check.critThreshold = Math.min(check.critThreshold, Number(flag));
+		// Attack Type
+		const attackType = weaponTraits.weaponType;
+		if (attackType) {
+			if (attackType === 'melee' && actor.system.bonuses.accuracy.accuracyMelee) {
+				check.modifiers.push({
+					label: 'FU.AccuracyCheckBonusMelee',
+					value: actor.system.bonuses.accuracy.accuracyMelee,
+				});
+			} else if (attackType === 'ranged' && actor.system.bonuses.accuracy.accuracyRanged) {
+				check.modifiers.push({
+					label: 'FU.AccuracyCheckBonusRanged',
+					value: actor.system.bonuses.accuracy.accuracyRanged,
+				});
+			}
+			const flag = actor.getFlag(SYSTEM, critThresholdFlags[attackType]);
+			if (flag) {
+				check.critThreshold = Math.min(check.critThreshold, Number(flag));
+			}
 		}
 	}
 };

--- a/module/documents/items/skill/base-skill-data-model.mjs
+++ b/module/documents/items/skill/base-skill-data-model.mjs
@@ -182,6 +182,14 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	 * @return {Promise<void>}
 	 */
 	async roll(modifiers) {
+		if (this.useWeapon.accuracy || this.useWeapon.damage) {
+			const weapon = await this.getWeapon(this.parent.actor);
+			if (!weapon) {
+				ui.notifications.error(game.i18n.localize('FU.AbilityNoWeaponEquipped'));
+				return;
+			}
+		}
+
 		if (this.hasRoll.value) {
 			if (this.useWeapon.accuracy || this.damage.hasDamage) {
 				return Checks.accuracyCheck(this.parent.actor, this.parent, this.#initializeAccuracyCheck(modifiers));
@@ -207,29 +215,47 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	 */
 	#initializeAccuracyCheck(modifiers) {
 		return async (check, actor, item) => {
+			const config = CheckConfiguration.configure(check);
+			const targets = config.getTargets();
+			const context = ExpressionContext.fromTargetData(actor, item, targets);
 			const weapon = await this.getWeapon(actor);
-			const { check: weaponCheck, error } = await Checks.prepareCheckDryRun('accuracy', actor, weapon.item);
-			if (error) {
-				throw error;
+
+			if (weapon && (this.useWeapon.accuracy || (this.damage.hasDamage && this.useWeapon.damage))) {
+				config.setWeaponReference(weapon.item);
 			}
 
 			if (this.useWeapon.accuracy) {
-				check.primary = weaponCheck.primary;
-				check.secondary = weaponCheck.secondary;
+				if (weapon) {
+					const { check: weaponCheck, error } = await Checks.prepareCheckDryRun('accuracy', actor, weapon.item);
+					if (error) {
+						throw error;
+					}
+					if (weaponCheck) {
+						check.primary = weaponCheck.primary;
+						check.secondary = weaponCheck.secondary;
+						check.modifiers = check.modifiers.concat(weaponCheck.modifiers);
+						if (weaponCheck.additionalData.defense) {
+							config.setTargetedDefense(weaponCheck.accuracy.defense);
+						}
+					}
+				}
 			} else {
 				check.primary = this.attributes.primary;
 				check.secondary = this.attributes.secondary;
 			}
-
-			const config = CheckConfiguration.configure(check);
-			const targets = config.getTargets();
-			const context = ExpressionContext.fromTargetData(actor, item, targets);
-
-			config.setWeaponReference(weapon.item);
-			config.setHrZero(this.damage.hrZero || modifiers.shift);
 			await this.configureCheck(config, actor, item);
-			await this.addSkillDamage(config, item, context, weapon.data);
 			await this.addSkillAccuracy(config, actor, item, context);
+
+			if (this.damage.hasDamage) {
+				if (this.useWeapon.damage) {
+					if (weapon) {
+						await this.addSkillDamage(config, item, context, weapon.data);
+					}
+				} else {
+					await this.addSkillDamage(config, item, context);
+				}
+				config.setHrZero(this.damage.hrZero || modifiers.shift);
+			}
 		};
 	}
 
@@ -243,12 +269,9 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
 
-			config.setWeaponReference(this.parent);
 			config.check.additionalData[skillForAttributeCheck] = this.parent.uuid;
-			config.setHrZero(this.damage.hrZero || modifiers.shift);
 			await this.configureCheck(config, actor, item);
 			await this.addSkillAccuracy(config, actor, item, context);
-			await this.addSkillDamage(config, item, context);
 			if (this.defense && targets.length === 1) {
 				let dl;
 				switch (this.defense) {
@@ -275,14 +298,18 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 			const config = CheckConfiguration.configure(check);
 			const targets = config.getTargets();
 			const context = ExpressionContext.fromTargetData(actor, item, targets);
+
 			await this.configureCheck(config, actor, item);
 			if (this.damage.hasDamage) {
 				if (this.useWeapon.damage) {
 					const weapon = await this.getWeapon(actor);
-					config.setWeaponReference(weapon.item);
-					config.setDamage(this.damage.type || weapon.data.damage.type, weapon.data.damage.value);
+					if (weapon) {
+						config.setWeaponReference(weapon.item);
+						await this.addSkillDamage(config, item, context, weapon.data);
+					}
+				} else {
+					await this.addSkillDamage(config, item, context);
 				}
-				await this.addSkillDamage(config, item, context);
 			}
 		};
 	}
@@ -380,12 +407,6 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 						config.setDamage(this.damage.type || weaponData.damage.type, weaponData.damage.value);
 					}
 				}
-				if (this.useWeapon.accuracy) {
-					config.addModifier('FU.CheckBonus', weaponData.accuracy.bonus);
-					if (weaponData.accuracy.defense) {
-						config.setTargetedDefense(weaponData.accuracy.defense);
-					}
-				}
 			}
 
 			const onRoll = this.damage.onRoll;
@@ -408,16 +429,7 @@ export class BaseSkillDataModel extends FUStandardItemDataModel {
 	 * @returns {Promise<WeaponResolution>}
 	 */
 	async getWeapon(actor) {
-		const getWeapon = await WeaponResolver.prompt(actor, true);
-		if (getWeapon === false) {
-			let message = game.i18n.localize('FU.AbilityNoWeaponEquipped');
-			ui.notifications.error(message);
-			throw new Error(message);
-		}
-		if (getWeapon == null) {
-			throw new Error('no selection');
-		}
-		return getWeapon;
+		return await WeaponResolver.prompt(actor, true);
 	}
 
 	/**

--- a/module/helpers/equipment-handler.mjs
+++ b/module/helpers/equipment-handler.mjs
@@ -46,7 +46,6 @@ export class EquipmentHandler {
 			// unsupported item type
 			return;
 		}
-		EquipmentHandler.autoEquipUnarmedStrike(this.actor, equippedData);
 
 		await this.actor.update({ 'system.equipped': equippedData });
 	}
@@ -218,24 +217,6 @@ export class EquipmentHandler {
 		}
 	}
 
-	/**
-	 * @param {FUActor} actor
-	 * @param {EquipDataModel} equippedData
-	 */
-	static autoEquipUnarmedStrike(actor, equippedData) {
-		const unarmedStrike = actor.getSingleItemByFuid('unarmed-strike');
-		if (!unarmedStrike) return;
-
-		// If main hand is empty, equip unarmed strike
-		if (!equippedData.mainHand) {
-			equippedData.mainHand = unarmedStrike.id;
-		}
-		// If off hand is empty, equip unarmed strike
-		if (!equippedData.offHand) {
-			equippedData.offHand = unarmedStrike.id;
-		}
-	}
-
 	static getHandEquipment(actor) {
 		let items = [];
 		items.push(...actor.getItemsByType('weapon'));
@@ -257,7 +238,7 @@ export class EquipmentHandler {
 		return Object.values(equippedData)
 			.filter(Boolean)
 			.map((value) => actor.items.get(value))
-			.filter((item, index, self) => item?.system.fuid !== 'unarmed-strike' && self.findIndex((i) => i._id === item._id) === index);
+			.filter((item, index, self) => self.findIndex((i) => i._id === item._id) === index);
 	}
 }
 

--- a/module/helpers/tables/skills-table-renderer.mjs
+++ b/module/helpers/tables/skills-table-renderer.mjs
@@ -3,6 +3,7 @@ import { CommonDescriptions } from './common-descriptions.mjs';
 import { CommonColumns } from './common-columns.mjs';
 import { FU } from '../config.mjs';
 import { systemTemplatePath } from '../system-utils.mjs';
+import { ExpressionContext, Expressions } from '../../expressions/expressions.mjs';
 
 export class SkillsTableRenderer extends FUTableRenderer {
 	/** @type TableConfig */
@@ -28,74 +29,98 @@ export class SkillsTableRenderer extends FUTableRenderer {
 	};
 
 	static async #renderCaption(item) {
+		const context = new ExpressionContext(item.actor, item, []);
 		const data = {
 			FU,
 			class: item.system.class.value,
 		};
 
 		let mainWeapon;
-		if (item.actor && item.actor.isCharacterType) {
+		if ((item.system.useWeapon.accuracy || item.system.useWeapon.damage) && item.actor && item.actor.isCharacterType) {
 			const mainHandItem = item.actor.items.get(item.actor.system.equipped.mainHand);
-			if (item.system.useWeapon.accuracy) {
-				data.useWeapon = true;
-
-				if (mainHandItem && mainHandItem.type in FU.weaponItemTypes) {
-					mainWeapon = mainHandItem;
-					data.weapon = mainWeapon.name;
-				}
+			if (mainHandItem && mainHandItem.type in FU.weaponItemTypes) {
+				mainWeapon = mainHandItem;
+				data.weapon = mainWeapon.name;
 			}
 		}
 
 		if (item.system.hasRoll.value) {
-			let weaponDamage;
+			let skillAccuracyBonus = 0;
+			if (item.system.accuracy) {
+				skillAccuracyBonus = await Expressions.evaluateAsync(item.system.accuracy, context);
+			}
 
-			if (item.system.useWeapon.accuracy && mainWeapon) {
-				if (mainWeapon.type === 'weapon') {
-					data.roll = {
-						primary: mainWeapon.system.attributes.primary.value,
-						secondary: mainWeapon.system.attributes.secondary.value,
-						modifier: mainWeapon.system.accuracy.value + item.system.accuracy,
-					};
-					weaponDamage = {
-						value: mainWeapon.system.damage.value,
-						type: mainWeapon.system.damageType.value,
-					};
-				}
-				if (mainWeapon.type === 'customWeapon') {
-					data.roll = {
-						primary: mainWeapon.system.attributes.primary,
-						secondary: mainWeapon.system.attributes.secondary,
-						modifier: mainWeapon.system.accuracy,
-					};
-					weaponDamage = {
-						value: mainWeapon.system.damage.value,
-						type: mainWeapon.system.damage.type,
-					};
+			if (item.system.useWeapon.accuracy) {
+				data.useWeaponAccuracy = true;
+				if (mainWeapon) {
+					if (mainWeapon.type === 'weapon') {
+						let weaponAccuracyBonus = 0;
+						if (mainWeapon.system.accuracy.value) {
+							weaponAccuracyBonus = await Expressions.evaluateAsync(mainWeapon.system.accuracy.value, context);
+						}
+						data.roll = {
+							primary: mainWeapon.system.attributes.primary.value,
+							secondary: mainWeapon.system.attributes.secondary.value,
+							modifier: weaponAccuracyBonus + skillAccuracyBonus,
+						};
+					}
+					if (mainWeapon.type === 'customWeapon') {
+						let weaponAccuracyBonus = 0;
+						if (mainWeapon.system.accuracy) {
+							weaponAccuracyBonus = await Expressions.evaluateAsync(mainWeapon.system.accuracy, context);
+						}
+						data.roll = {
+							primary: mainWeapon.system.attributes.primary,
+							secondary: mainWeapon.system.attributes.secondary,
+							modifier: weaponAccuracyBonus + skillAccuracyBonus,
+						};
+					}
 				}
 			} else {
 				data.roll = {
 					primary: item.system.attributes.primary,
 					secondary: item.system.attributes.secondary,
-					modifier: item.system.accuracy,
+					modifier: skillAccuracyBonus,
 				};
 			}
+		}
 
-			if (item.system.damage.hasDamage) {
-				if (item.system.useWeapon.damage && mainWeapon) {
-					if (!weaponDamage) throw new Error('Missing weapon damage data. This is a bug, please report it to the maintainers of the system.');
-					const { value: damageValue, type: damageType } = weaponDamage;
+		if (item.system.damage.hasDamage) {
+			if (item.system.useWeapon.damage) {
+				data.useWeaponDamage = true;
+				if (mainWeapon) {
+					let weaponDamageValue = 0;
+					let weaponDamageType;
+					if (mainWeapon.type === 'weapon') {
+						if (mainWeapon.system.damage.value) {
+							weaponDamageValue = await Expressions.evaluateAsync(mainWeapon.system.damage.value, context);
+						}
+						weaponDamageType = mainWeapon.system.damageType.value;
+					} else if (mainWeapon.type === 'customWeapon') {
+						if (mainWeapon.system.damage.value) {
+							weaponDamageValue = await Expressions.evaluateAsync(mainWeapon.system.damage.value, context);
+						}
+						weaponDamageType = mainWeapon.system.damage.type;
+					} else {
+						throw new Error('Missing weapon damage data. This is a bug, please report it to the maintainers of the system.');
+					}
+
+					let itemDamageValue = 0;
+					if (item.system.damage.value) {
+						itemDamageValue = await Expressions.evaluateAsync(item.system.damage.value, context);
+					}
 					data.damage = {
-						value: item.system.damage.value + damageValue,
-						type: item.system.damage.type || damageType,
-						hrZero: item.system.damage.hrZero,
-					};
-				} else {
-					data.damage = {
-						value: item.system.damage.value,
-						type: item.system.damage.type,
+						value: itemDamageValue + weaponDamageValue,
+						type: item.system.damage.type || weaponDamageType,
 						hrZero: item.system.damage.hrZero,
 					};
 				}
+			} else {
+				data.damage = {
+					value: item.system.damage.value,
+					type: item.system.damage.type,
+					hrZero: item.system.damage.hrZero,
+				};
 			}
 		}
 

--- a/module/helpers/tables/weapons-table-renderer.mjs
+++ b/module/helpers/tables/weapons-table-renderer.mjs
@@ -66,7 +66,7 @@ export class WeaponsTableRenderer extends FUTableRenderer {
 				renderHeader: () => game.i18n.localize('FU.EquipStatus'),
 				renderCell: WeaponsTableRenderer.#renderEquipStatus,
 			},
-			controls: CommonColumns.itemControlsColumn({ label: 'FU.Weapon', type: 'weapon,customWeapon' }, { disableEdit: WeaponsTableRenderer.#isUnarmedAttack, disableMenu: WeaponsTableRenderer.#isUnarmedAttack }),
+			controls: CommonColumns.itemControlsColumn({ label: 'FU.Weapon', type: 'weapon,customWeapon' }),
 		},
 		actions: {
 			technosphere: WeaponsTableRenderer.#technosphereAction,
@@ -187,10 +187,6 @@ export class WeaponsTableRenderer extends FUTableRenderer {
 		}
 
 		return foundry.applications.handlebars.renderTemplate(systemTemplatePath('table/cell/cell-equip-status'), data);
-	}
-
-	static #isUnarmedAttack(item) {
-		return item.system.fuid === FU.unarmedStrike;
 	}
 
 	static #getCssClasses(item) {

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -521,33 +521,6 @@ Hooks.once('ready', async function () {
 		}
 	});
 
-	Hooks.on('preUpdateActor', async (actor, updateData, options, userId) => {
-		const equipped = foundry.utils.getProperty(updateData, 'system.equipped');
-
-		if (!equipped) return;
-
-		// Check if main hand or off hand is being unequipped
-		const mainHandUnequipped = equipped.mainHand === null;
-		const offHandUnequipped = equipped.offHand === null;
-
-		// If neither hand is unequipped, exit early
-		if (!mainHandUnequipped && !offHandUnequipped) return;
-
-		// Get the Unarmed Strike item
-		const unarmedStrike = actor.getSingleItemByFuid('unarmed-strike');
-		if (!unarmedStrike) return;
-
-		// Prepare updates only if necessary
-		const updates = {};
-		if (mainHandUnequipped) updates['system.equipped.mainHand'] = unarmedStrike.id;
-		if (offHandUnequipped) updates['system.equipped.offHand'] = unarmedStrike.id;
-
-		// Perform the update if there are changes
-		if (Object.keys(updates).length > 0) {
-			await actor.update(updates);
-		}
-	});
-
 	Hooks.on('createItem', (item, options, userId) => {
 		if (!item.parent) return; // Make sure the item belongs to an actor or entity
 		if (!game.settings.get('projectfu', 'optionAlwaysFavorite')) return;

--- a/src/packs/skills/skill_Counterattack_XhcTVGtGEk7L2Ddq.json
+++ b/src/packs/skills/skill_Counterattack_XhcTVGtGEk7L2Ddq.json
@@ -53,9 +53,7 @@
         "value": false
       },
       "value": 0,
-      "type": {
-        "value": "physical"
-      },
+      "type": "",
       "onRoll": "",
       "onApply": ""
     },
@@ -245,7 +243,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706514121336,
-    "modifiedTime": 1775597183183,
+    "modifiedTime": 1778089801732,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/templates/table/caption/caption-skill.hbs
+++ b/templates/table/caption/caption-skill.hbs
@@ -1,14 +1,42 @@
 {{class~}}
+
 {{#if roll~}}
-	{{#if class}} ⬥&#xFEFF;{{/if~}}
-	{{#if useWeapon}}&nbsp;{{#if weapon}}{{weapon}}{{else}}{{localize 'FU.AbilityNoWeaponEquipped'}}{{/if}} ⬥&#xFEFF;{{/if~}}
-
-	【{{localize (lookup FU.attributeAbbreviations roll.primary)}}&nbsp;+&nbsp;{{localize (lookup FU.attributeAbbreviations roll.secondary)}}】
-	{{~#if (gt roll.modifier 0)}}+&nbsp;{{roll.modifier}}{{/if}}
-	{{~#if (lt roll.modifier 0)}}-&nbsp;{{pfuMathAbs roll.modifier}}{{/if}}
-
-	{{#if damage}}
-		⬥&#xFEFF;【{{#if damage.hrZero}}{{localize 'FU.HRZero'}}{{else}}{{localize 'FU.HighRollAbbr'}}{{/if}}&nbsp;+&nbsp;{{damage.value}}】&#xFEFF;
-		{{~localize (lookup FU.damageTypes damage.type)}}
-	{{/if}}
+	{{~#if useWeaponAccuracy}}
+		{{#if weapon}}
+			{{#if class}} ⬥&#xFEFF;{{/if~}}
+			{{#if weapon}} {{weapon}} ⬥&#xFEFF;{{~/if~}}
+			<span style="white-space: nowrap;">【{{localize (lookup FU.attributeAbbreviations roll.primary)}}&nbsp;+&nbsp;{{localize (lookup FU.attributeAbbreviations roll.secondary)}}】
+				{{~#if (gt roll.modifier 0)}}+{{roll.modifier}}{{/if~}}
+				{{~#if (lt roll.modifier 0)}}-{{pfuMathAbs roll.modifier}}{{/if~}}
+			</span>
+		{{~/if~}}
+	{{else}}
+		{{#if class}} ⬥&#xFEFF;{{/if~}}
+		<span style="white-space: nowrap;">【{{localize (lookup FU.attributeAbbreviations roll.primary)}}&nbsp;+&nbsp;{{localize (lookup FU.attributeAbbreviations roll.secondary)}}】
+			{{~#if (gt roll.modifier 0)}}+{{roll.modifier}}{{/if}}
+			{{~#if (lt roll.modifier 0)}}-{{pfuMathAbs roll.modifier}}{{/if}}
+		</span>
+	{{~/if~}}
 {{~/if}}
+
+{{#if damage}}
+	{{#if useWeaponDamage}}
+		{{#if weapon}}
+			{{#if (or roll class)}} ⬥&#xFEFF;{{/if~}}
+			【{{#if roll}}{{#if damage.hrZero}}{{localize 'FU.HRZero'}}{{else}}{{localize 'FU.HighRollAbbr'}}{{/if}}&nbsp;+&nbsp;{{/if}}{{damage.value}}】&#xFEFF;
+			{{~localize (lookup FU.damageTypes damage.type)}}
+		{{~/if}}
+	{{else}}
+		{{#if (or roll class)}} ⬥&#xFEFF;{{/if~}}
+		【{{#if roll}}{{#if damage.hrZero}}{{else}}{{localize 'FU.HighRollAbbr'}}&nbsp;+&nbsp;{{/if}}{{/if}}{{damage.value}}】&#xFEFF;
+		{{~localize (lookup FU.damageTypes damage.type)}}
+	{{~/if}}
+{{~/if}}
+
+{{#if weapon}}
+{{else}}
+	{{#if (or useWeaponAccuracy useWeaponDamage)}}
+		{{#if (or roll (or class damage))}} ⬥&#xFEFF;{{/if~}}
+		<span style="white-space: nowrap;">&nbsp;{{localize 'FU.AbilityNoWeaponEquipped'}}</span>
+	{{/if}}
+{{/if}}


### PR DESCRIPTION
- No longer auto equip the Unarmed Strike when a hand slot has nothing equipped.
- Removed exclusions for Unarmed Strike that disabled editing of it.
- Removed the errors around having no weapon in an equipped slot.
- Make all equipped weapon references check for null weapon.
- Properly add accuracy bonuses from skill and weapon in Skill preview.
- Evaluated accuracy and damage bonuses for expressions to show properly in preview.
- Fixed up performing Skills to properly added bonuses from skill and weapon.
- Fixed layout of Skill Preview Caption to handle having no weapon equipped when required, and displaying various combinations of Weapon Accuracy, Weapon Damage, No Accuracy Roll, and High Roll 0.
- Fixed caption layout to not line break in the middle of the Accuracy formula or the "No weapons equipped!" message.
- Counterattack Skill properly inherits damage type from weapon.

Skill Preview Caption on different Skills with Katana weapon. (Shadow Strike replaces damage type with Dark, Counterattack has HR0, Ripples adds SL to accuracy)
<img width="615" height="249" alt="image" src="https://github.com/user-attachments/assets/b81e51eb-1733-4994-a504-760e1b06edb6" />

