### PR TITLE
Fixed Up Expenses for Verses, Invocations, and Dances

### DIFF
--- a/module/checks/common-events.mjs
+++ b/module/checks/common-events.mjs
@@ -718,13 +718,15 @@ async function renderMessage(renderData, actor, document = undefined) {
  * @property
  */
 
-async function feature(actor, item, traits, renderData) {
+async function feature(actor, item, traits, targetData, renderData) {
 	const source = CharacterInfo.fromActor(actor);
+	const targets = CharacterInfo.fromTargetData(targetData);
 	/** @type FeatureEvent  **/
 	const event = {
 		source: source,
 		item: item,
 		traits: traits,
+		targets: targets,
 		renderData: renderData,
 	};
 	return AsyncHooks.callSequential(FUHooks.FEATURE_EVENT, event);

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -504,8 +504,13 @@ const spendResource = (data, actor, item, cost, targets, flags) => {
 
 		// This can be modified here...
 		await CommonEvents.calculateExpense(actor, item, targets, expense);
+
+		if (expense.amount <= 0) {
+			return;
+		}
+
 		return {
-			order: ChatSectionOrder.actions + 500,
+			order: ChatSectionOrder.expenses,
 			partial: 'systems/projectfu/templates/chat/partials/chat-item-spend-resource.hbs',
 			data: {
 				name: item.name,
@@ -533,7 +538,7 @@ const spendResourceV2 = (data, actor, item, updateData, targets, flags) => {
 		updateData = new UpdateResourceData(updateData);
 	}
 
-	if (updateData.total === 0) {
+	if (updateData.total <= 0) {
 		return;
 	}
 
@@ -552,7 +557,7 @@ const spendResourceV2 = (data, actor, item, updateData, targets, flags) => {
 	Pipeline.toggleFlag(flags, Flags.ChatMessage.ResourceLoss);
 	data.sections.push(async () => {
 		return {
-			order: ChatSectionOrder.actions + 500,
+			order: ChatSectionOrder.expenses,
 			partial: 'systems/projectfu/templates/chat/partials/chat-item-spend-resource.hbs',
 			data: {
 				name: item.name,
@@ -575,11 +580,15 @@ const spendResourceV2 = (data, actor, item, updateData, targets, flags) => {
  * @param {ResourceExpense} expense
  */
 const expense = (data, actor, item, targets, flags, expense) => {
+	if (expense.amount <= 0) {
+		return;
+	}
+
 	Pipeline.toggleFlag(flags, Flags.ChatMessage.ResourceLoss);
 	data.postRenderActions.push(() => CommonEvents.expense(actor, item, targets, expense, data));
 	data.sections.push(async () => {
 		return {
-			order: ChatSectionOrder.actions + 100,
+			order: ChatSectionOrder.expenses,
 			partial: 'systems/projectfu/templates/chat/partials/chat-item-spend-resource.hbs',
 			data: {
 				name: item.name,

--- a/module/checks/default-section-order.mjs
+++ b/module/checks/default-section-order.mjs
@@ -21,4 +21,5 @@ export const ChatSectionOrder = Object.freeze({
 	addendum: -900,
 	result: 1000,
 	actions: 2000,
+	expenses: 2500,
 });

--- a/module/documents/items/classFeature/chanter/verses-application.mjs
+++ b/module/documents/items/classFeature/chanter/verses-application.mjs
@@ -289,6 +289,7 @@ export class VersesApplication extends FUApplication {
 			perTarget: false,
 		});
 		const expense = await ResourcePipeline.calculateExpense(cost, actor, item, targets);
+		await CommonEvents.calculateExpense(actor, item, targets, expense);
 
 		// Data for the template
 		const enriched = await enrichDescription(this.#verse);
@@ -325,10 +326,10 @@ export class VersesApplication extends FUApplication {
 		};
 
 		CommonSections.itemFlavor(renderData.sections, this.#verse.parent.parent);
-		CommonSections.genericText(renderData.sections, enriched);
+		CommonSections.description(renderData.sections, enriched);
 		CommonSections.expense(renderData, actor, item, targets, flags, expense);
 
-		await CommonEvents.feature(actor, item, [FeatureTraits.Verse], renderData);
+		await CommonEvents.feature(actor, item, [FeatureTraits.Verse], targets, renderData);
 
 		const builder = new FUChatBuilder(actor, item);
 		builder.withFlags(flags);
@@ -336,5 +337,7 @@ export class VersesApplication extends FUApplication {
 		await builder.create();
 
 		CommonEvents.skill(actor, item);
+
+		this.close();
 	}
 }

--- a/module/documents/items/classFeature/dancer/dance-data-model.mjs
+++ b/module/documents/items/classFeature/dancer/dance-data-model.mjs
@@ -9,6 +9,9 @@ import { FUChatBuilder } from '../../../../helpers/chat-builder.mjs';
 import { StringUtils } from '../../../../helpers/string-utils.mjs';
 import { Effects } from '../../../../pipelines/effects.mjs';
 import { systemId } from '../../../../helpers/system-utils.mjs';
+import { Targeting } from '../../../../helpers/targeting.mjs';
+import { ActionCostDataModel } from '../../common/action-cost-data-model.mjs';
+import { ResourcePipeline } from '../../../../pipelines/resource-pipeline.mjs';
 
 const durations = {
 	instant: 'FU.ClassFeatureDanceDurationInstant',
@@ -64,26 +67,30 @@ export class DanceDataModel extends RollableClassFeatureDataModel {
 		const actor = item.parent;
 		CommonSections.itemFlavor(renderData.sections, item);
 		const description = await TextEditor.enrichHTML(model.description);
-		CommonSections.genericText(renderData.sections, description);
+		CommonSections.description(renderData.sections, description);
 		const flags = {
 			[SYSTEM]: { [Flags.ChatMessage.Item]: item.uuid },
 		};
 
 		/** @type ResourceExpense **/
-		const expense = {
-			source: 'skill',
-			resource: 'mp',
-			amount: 10,
-		};
-
+		let mpCost = 10;
 		const currentDance = item.system.fuid;
 		const previousDance = actor?.getFlag(systemId, Flags.State.PreviousDance);
 		if (previousDance && currentDance !== previousDance) {
-			expense.amount = 5;
+			mpCost = 5;
 		}
 
-		CommonSections.expense(renderData, actor, item, [], flags, expense);
-		await CommonEvents.feature(actor, item, [FeatureTraits.Dance], renderData);
+		const targets = Targeting.getSerializedTargetData();
+		const cost = new ActionCostDataModel({
+			resource: 'mp',
+			amount: mpCost,
+			perTarget: false,
+		});
+		const expense = await ResourcePipeline.calculateExpense(cost, actor, item, targets);
+		await CommonEvents.calculateExpense(actor, item, targets, expense);
+		CommonSections.expense(renderData, actor, item, targets, flags, expense);
+
+		await CommonEvents.feature(actor, item, [FeatureTraits.Dance], targets, renderData);
 
 		const effectName = 'Previous Dance (' + item.name + ')';
 		const effectDescription = '<p>The last dance you performed was the <strong>' + item.name + '</strong>.</p>';

--- a/module/documents/items/classFeature/invoker/invocations-data-model.mjs
+++ b/module/documents/items/classFeature/invoker/invocations-data-model.mjs
@@ -9,6 +9,8 @@ import { TextEditor } from '../../../../helpers/text-editor.mjs';
 import { CommonEvents } from '../../../../checks/common-events.mjs';
 import { FeatureTraits } from '../../../../pipelines/traits.mjs';
 import { CheckConfiguration } from '../../../../checks/check-configuration.mjs';
+import { ActionCostDataModel } from '../../common/action-cost-data-model.mjs';
+import { ResourcePipeline } from '../../../../pipelines/resource-pipeline.mjs';
 
 const BASIC = 'FU.ClassFeatureInvocationsBasicName';
 const ADVANCED = 'FU.ClassFeatureInvocationsAdvancedName';
@@ -74,13 +76,18 @@ const onRenderCheck = async (data, check, actor, item, flags) => {
 				break;
 		}
 		/** @type ResourceExpense **/
-		const expense = {
-			source: 'skill',
+		const inspector = CheckConfiguration.inspect(check);
+		const targets = inspector.getTargetsOrDefault();
+		const cost = new ActionCostDataModel({
 			resource: 'mp',
 			amount: 5,
-		};
-		CommonSections.expense(data, actor, item, [], flags, expense);
-		await CommonEvents.feature(actor, item, [FeatureTraits.Invocation], data);
+			perTarget: false,
+		});
+		const expense = await ResourcePipeline.calculateExpense(cost, actor, item, targets);
+		await CommonEvents.calculateExpense(actor, item, targets, expense);
+		CommonSections.expense(data, actor, item, targets, flags, expense);
+
+		await CommonEvents.feature(actor, item, [FeatureTraits.Invocation], targets, data);
 	}
 };
 Hooks.on(CheckHooks.renderCheck, onRenderCheck);

--- a/module/pipelines/rule-elements.mjs
+++ b/module/pipelines/rule-elements.mjs
@@ -287,7 +287,7 @@ async function onEffectToggledEvent(event) {
  * @returns {Promise<void>}
  */
 async function onFeatureEvent(event) {
-	await evaluate(FUHooks.FEATURE_EVENT, event, event.source, [], {
+	await evaluate(FUHooks.FEATURE_EVENT, event, event.source, event.targets, {
 		renderData: event.renderData,
 	});
 }

--- a/src/packs/skills/skill_Hypercognition_P0oD7KQA9ipYWU8o.json
+++ b/src/packs/skills/skill_Hypercognition_P0oD7KQA9ipYWU8o.json
@@ -209,6 +209,141 @@
                   "amount": "-$sl"
                 }
               }
+            },
+            "mXw9rjwnzlnCKaUG": {
+              "type": "ruleElement",
+              "trigger": {
+                "_id": "XVqdSl8dLPxEFTct",
+                "type": "calculateExpenseRuleTrigger",
+                "eventRelation": "source",
+                "resource": "mp",
+                "expenseSource": "skill",
+                "threshold": {
+                  "operator": "",
+                  "amount": 0
+                },
+                "traits": {
+                  "entries": [],
+                  "quantifier": "any"
+                },
+                "identifier": "verse"
+              },
+              "_id": "mXw9rjwnzlnCKaUG",
+              "predicates": {
+                "iDgzj12MiIb1rhbB": {
+                  "type": "targetEffectRulePredicate",
+                  "_id": "iDgzj12MiIb1rhbB",
+                  "effect": "focus"
+                },
+                "QE9dWopG2165TFwb": {
+                  "type": "targetingRulePredicate",
+                  "_id": "QE9dWopG2165TFwb"
+                }
+              },
+              "actions": {
+                "RhMesE1Xyp0IWniC": {
+                  "type": "modifyExpenseRuleAction",
+                  "_id": "RhMesE1Xyp0IWniC",
+                  "amount": "-$sl*2"
+                }
+              }
+            },
+            "b5tf92xGllF7K1w4": {
+              "type": "ruleElement",
+              "trigger": {
+                "_id": "091qN0WTDCQf526R",
+                "type": "calculateExpenseRuleTrigger",
+                "eventRelation": "source",
+                "resource": "mp",
+                "expenseSource": "skill",
+                "threshold": {
+                  "operator": "",
+                  "amount": 0
+                },
+                "traits": {
+                  "entries": [],
+                  "quantifier": "any"
+                },
+                "identifier": "verse"
+              },
+              "_id": "b5tf92xGllF7K1w4",
+              "predicates": {
+                "AGtoIgnDgapJqnox": {
+                  "type": "targetingRulePredicate",
+                  "_id": "AGtoIgnDgapJqnox",
+                  "rule": "multiple"
+                },
+                "EPus8Nnghx38cuxJ": {
+                  "type": "targetEffectRulePredicate",
+                  "_id": "EPus8Nnghx38cuxJ",
+                  "effect": "focus"
+                }
+              },
+              "actions": {
+                "roKAnIwFzkK9gSmj": {
+                  "type": "modifyExpenseRuleAction",
+                  "_id": "roKAnIwFzkK9gSmj",
+                  "amount": "-$sl"
+                }
+              }
+            },
+            "DfzsyLhzTpnrktKy": {
+              "type": "ruleElement",
+              "trigger": {
+                "_id": "kCAxEMXfgzMvVnnZ",
+                "type": "renderCheckRuleTrigger",
+                "eventRelation": "source",
+                "checkTypes": [],
+                "itemGroups": [
+                  "spell"
+                ],
+                "local": false,
+                "identifier": ""
+              },
+              "_id": "DfzsyLhzTpnrktKy",
+              "predicates": {
+                "nAJc81EHNkJB1q9P": {
+                  "type": "targetEffectRulePredicate",
+                  "_id": "nAJc81EHNkJB1q9P",
+                  "effect": "focus"
+                }
+              },
+              "actions": {
+                "Mc6mhxIA6N9kf0mf": {
+                  "type": "messageRuleAction",
+                  "_id": "Mc6mhxIA6N9kf0mf",
+                  "message": "<p>The cost of this spell has been reduced.</p>"
+                }
+              }
+            },
+            "JOM6TOxESvvtwjpG": {
+              "type": "ruleElement",
+              "trigger": {
+                "_id": "xcNSHTNOD9kc4VCH",
+                "type": "featureRuleTrigger",
+                "eventRelation": "source",
+                "traits": {
+                  "entries": [
+                    "verse"
+                  ],
+                  "quantifier": "any"
+                }
+              },
+              "_id": "JOM6TOxESvvtwjpG",
+              "predicates": {
+                "xneWC23XF7bd4UoX": {
+                  "type": "targetEffectRulePredicate",
+                  "_id": "xneWC23XF7bd4UoX",
+                  "effect": "focus"
+                }
+              },
+              "actions": {
+                "2EJg2UDoRG2uAKvs": {
+                  "type": "messageRuleAction",
+                  "_id": "2EJg2UDoRG2uAKvs",
+                  "message": "<p>The cost of this verse has been reduced.</p>"
+                }
+              }
             }
           },
           "progress": {
@@ -218,6 +353,11 @@
             "current": 0,
             "max": 6,
             "style": "basic"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
           }
         }
       },
@@ -244,7 +384,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1767266062677,
-        "modifiedTime": 1771833920722,
+        "modifiedTime": 1778182496505,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!P0oD7KQA9ipYWU8o.KfTNS2FY3rStlm5m"

--- a/src/packs/skills/skill_Wellspring_Expansion_HlSeaheZt8969qI7.json
+++ b/src/packs/skills/skill_Wellspring_Expansion_HlSeaheZt8969qI7.json
@@ -118,7 +118,8 @@
                     "flail",
                     "sword",
                     "thrown"
-                  ]
+                  ],
+                  "selector": "self"
                 }
               },
               "actions": {
@@ -181,7 +182,7 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1774600495618,
-        "modifiedTime": 1774632860016,
+        "modifiedTime": 1778185971212,
         "lastModifiedBy": "mA8SNY2rY4X5tOHa"
       },
       "_key": "!items.effects!HlSeaheZt8969qI7.BE7hRoMlSX5MrQXw"


### PR DESCRIPTION
- Verses, Invocations, and Dances properly evaluate expenses against attribute keys and rule elements.
- Expense button no longer are added if the expenses has been reduced to 0 or less.
- Verses properly display the details of the verse in the correct order.
- Added targets to the feature event.
- Updated the Hypercognition Skill to work with Verses.
- Updated the Wellspring Expansion Skill to properly check "self" for the Invoker's equipped weapon.