### PR TITLE
Levels and Spells PC Tab Names

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -124,6 +124,7 @@
 		"ExpMax": "Maximum Experience Needed",
 		"ExpMaxHint": "Sets the maximum amount of EXP required to level up (default is 10).",
 		"Level": "Level",
+		"Levels": "Levels",
 		"LevelAbbr": "LV",
 		"LevelUp": "LEVEL UP!",
 		"Role": "Role",

--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -164,7 +164,7 @@ export class FUStandardActorSheet extends FUActorSheet {
 				{ id: 'stats', label: 'FU.Overview' },
 				{ id: 'classes', label: 'FU.Classes' },
 				{ id: 'features', label: 'FU.Features' },
-				{ id: 'spells', label: 'FU.Spell' },
+				{ id: 'spells', label: 'FU.Spells' },
 				{ id: 'items', label: 'FU.Items' },
 
 				{ id: 'combat', label: 'FU.Combat' },
@@ -172,7 +172,7 @@ export class FUStandardActorSheet extends FUActorSheet {
 
 				{ id: 'notes', label: 'FU.Notes' },
 				{ id: 'effects', label: 'FU.Effects' },
-				{ id: 'advancements', label: 'FU.Advancements' },
+				{ id: 'advancements', label: 'FU.Levels' },
 				{ id: 'settings', label: 'FU.Settings' },
 			],
 			initial: 'stats',


### PR DESCRIPTION
Updated the name of the "Advancements" tab to now be the "Levels" tab. Also, made the "Spell" tab name plural, making it "Spells".

<img width="728" height="59" alt="image" src="https://github.com/user-attachments/assets/77f25d79-9388-43cd-b47c-289a2025856c" />