### PR TITLE
Convert Class Attributes to Fuid

### DIFF
--- a/module/documents/actors/character/character-skill-tracker.mjs
+++ b/module/documents/actors/character/character-skill-tracker.mjs
@@ -37,12 +37,13 @@ export class CharacterSkillTracker {
 	}
 
 	/**
-	 * @param {String} className
+	 * @param {FUItem} classItem
 	 * @returns {Number|number}
 	 */
-	getClassLevel(className) {
-		if (this.#classSkills[className]) {
-			return this.#classSkills[className];
+	getClassLevel(classItem) {
+		const fuid = classItem.system?.fuid;
+		if (fuid && this.#classSkills[fuid]) {
+			return this.#classSkills[fuid];
 		}
 		return 0;
 	}

--- a/module/documents/items/class-fuid-converter.mjs
+++ b/module/documents/items/class-fuid-converter.mjs
@@ -2,29 +2,7 @@ import { SYSTEM } from '../../helpers/config.mjs';
 import { Flags } from '../../helpers/flags.mjs';
 import { CompendiumIndex } from '../../ui/compendium/compendium-index.mjs';
 
-function getMatchingClassFuid(className, classes) {
-	if (className) {
-		// Search for a class with the same name. If found, set the skill's class attribute to match its fu-id
-		const classFound = classes.find((classItem) => {
-			return classItem.name === className;
-		});
-		if (classFound?.system?.fuid) {
-			return classFound.system.fuid;
-		}
-
-		// Search for a class with a fuid that matches the slugified attribute.
-		const classNameSlug = game.projectfu.util.slugify(className);
-		const classFoundWithFuid = classes.find((classItem) => {
-			return classItem.system?.fuid === classNameSlug;
-		});
-		if (classFoundWithFuid?.system?.fuid) {
-			return classFoundWithFuid.system.fuid;
-		}
-	}
-	return false;
-}
-
-async function convertClassAttributeFromClassLists(item, actorClasses, worldClasses, compendiumClasses) {
+async function convertClassAttributeFromClassLists(item, classes) {
 	let updates = {
 		flags: {
 			[SYSTEM]: {
@@ -32,7 +10,6 @@ async function convertClassAttributeFromClassLists(item, actorClasses, worldClas
 			},
 		},
 	};
-	//await item.setFlag(SYSTEM, Flags.ClassConverted, true);
 
 	const classAttribute = item.system?.class?.value;
 	if (classAttribute) {
@@ -47,29 +24,13 @@ async function convertClassAttributeFromClassLists(item, actorClasses, worldClas
 			}
 
 			// Search for a class with the same name or fuid and replace its class attribute
-			// Search the actor first
-			if (actorClasses) {
-				const fuid = getMatchingClassFuid(className, actorClasses);
-				if (fuid) {
-					fuids.push(fuid);
-					continue;
-				}
-			}
-
-			// Search the world
-			if (worldClasses) {
-				const fuid = getMatchingClassFuid(className, worldClasses);
-				if (fuid) {
-					fuids.push(fuid);
-					continue;
-				}
-			}
-
-			// Search the compendium
-			if (compendiumClasses) {
-				const fuid = getMatchingClassFuid(className, compendiumClasses);
-				if (fuid) {
-					fuids.push(fuid);
+			if (classes) {
+				// Search for a class with the same name or with a fuid that matches the slugified name. If found, set the skill's class attribute to match its fu-id
+				const classFound = classes.find((classItem) => {
+					return classItem.name === className || classItem.system?.fuid === classNameSlug;
+				});
+				if (classFound?.system?.fuid) {
+					fuids.push(classFound.system.fuid);
 					continue;
 				}
 			}
@@ -77,11 +38,9 @@ async function convertClassAttributeFromClassLists(item, actorClasses, worldClas
 
 		if (fuids.length > 0) {
 			let newClassAttribute = fuids[0];
-
 			for (let i = 1; i < fuids.length; ++i) {
 				newClassAttribute += ', ' + fuids[i];
 			}
-			//await item.update({ 'system.class.value': newClassAttribute });
 			updates['system.class.value'] = newClassAttribute;
 			console.log(`Converted ${item.name} Class Attribute from ${classAttribute} to ${newClassAttribute}`);
 		}
@@ -107,9 +66,10 @@ async function convertActorItemsClassAttributes(actorSource) {
 		return item.type === 'class';
 	});
 	const compendiumClasses = await CompendiumIndex.instance.getClasses();
+	const allClasses = actorClasses.concat(worldClasses, compendiumClasses.class);
 
 	for (const itemToConvert of itemsToConvert) {
-		await convertClassAttributeFromClassLists(itemToConvert, actorClasses, worldClasses, compendiumClasses?.class);
+		await convertClassAttributeFromClassLists(itemToConvert, allClasses);
 	}
 }
 

--- a/module/documents/items/class-fuid-converter.mjs
+++ b/module/documents/items/class-fuid-converter.mjs
@@ -1,0 +1,122 @@
+import { SYSTEM } from '../../helpers/config.mjs';
+import { Flags } from '../../helpers/flags.mjs';
+import { CompendiumIndex } from '../../ui/compendium/compendium-index.mjs';
+
+function getMatchingClassFuid(className, classes) {
+	if (className) {
+		// Search for a class with the same name. If found, set the skill's class attribute to match its fu-id
+		const classFound = classes.find((classItem) => {
+			return classItem.name === className;
+		});
+		if (classFound?.system?.fuid) {
+			return classFound.system.fuid;
+		}
+
+		// Search for a class with a fuid that matches the slugified attribute.
+		const classNameSlug = game.projectfu.util.slugify(className);
+		const classFoundWithFuid = classes.find((classItem) => {
+			return classItem.system?.fuid === classNameSlug;
+		});
+		if (classFoundWithFuid?.system?.fuid) {
+			return classFoundWithFuid.system.fuid;
+		}
+	}
+	return false;
+}
+
+async function convertClassAttributeFromClassLists(item, actorClasses, worldClasses, compendiumClasses) {
+	let updates = {
+		flags: {
+			[SYSTEM]: {
+				[Flags.ClassConverted]: true,
+			},
+		},
+	};
+	//await item.setFlag(SYSTEM, Flags.ClassConverted, true);
+
+	const classAttribute = item.system?.class?.value;
+	if (classAttribute) {
+		const classNames = classAttribute.includes(',') ? classAttribute.split(',').map((v) => v.trim()) : [classAttribute];
+		let fuids = [];
+		for (const className of classNames) {
+			// If the class attribute matches the slugified version, we can assume it's already the intended value
+			const classNameSlug = game.projectfu.util.slugify(className);
+			if (className === classNameSlug) {
+				fuids.push(classNameSlug);
+				continue;
+			}
+
+			// Search for a class with the same name or fuid and replace its class attribute
+			// Search the actor first
+			if (actorClasses) {
+				const fuid = getMatchingClassFuid(className, actorClasses);
+				if (fuid) {
+					fuids.push(fuid);
+					continue;
+				}
+			}
+
+			// Search the world
+			if (worldClasses) {
+				const fuid = getMatchingClassFuid(className, worldClasses);
+				if (fuid) {
+					fuids.push(fuid);
+					continue;
+				}
+			}
+
+			// Search the compendium
+			if (compendiumClasses) {
+				const fuid = getMatchingClassFuid(className, compendiumClasses);
+				if (fuid) {
+					fuids.push(fuid);
+					continue;
+				}
+			}
+		}
+
+		if (fuids.length > 0) {
+			let newClassAttribute = fuids[0];
+
+			for (let i = 1; i < fuids.length; ++i) {
+				newClassAttribute += ', ' + fuids[i];
+			}
+			//await item.update({ 'system.class.value': newClassAttribute });
+			updates['system.class.value'] = newClassAttribute;
+			console.log(`Converted ${item.name} Class Attribute from ${classAttribute} to ${newClassAttribute}`);
+		}
+	}
+
+	item.update(updates);
+}
+
+async function convertActorItemsClassAttributes(actorSource) {
+	const items = actorSource.items;
+	const itemsToConvert = items.filter((item) => {
+		return (item.type === 'skill' || item.type === 'spell' || item.type === 'heroic') && !item.flags?.projectfu?.classConverted;
+	});
+
+	if (itemsToConvert.length == 0) {
+		return;
+	}
+
+	const actorClasses = items.filter((item) => {
+		return item.type === 'class';
+	});
+	const worldClasses = game.items?.filter((item) => {
+		return item.type === 'class';
+	});
+	const compendiumClasses = await CompendiumIndex.instance.getClasses();
+
+	for (const itemToConvert of itemsToConvert) {
+		await convertClassAttributeFromClassLists(itemToConvert, actorClasses, worldClasses, compendiumClasses?.class);
+	}
+}
+
+export class ClassFuidConverter {
+	static run() {
+		for (const actor of game.actors) {
+			convertActorItemsClassAttributes(actor);
+		}
+	}
+}

--- a/module/documents/items/class-fuid-converter.mjs
+++ b/module/documents/items/class-fuid-converter.mjs
@@ -62,11 +62,31 @@ async function convertActorItemsClassAttributes(actorSource) {
 	const actorClasses = items.filter((item) => {
 		return item.type === 'class';
 	});
-	const worldClasses = game.items?.filter((item) => {
+	const worldClasses = game.items.filter((item) => {
 		return item.type === 'class';
 	});
 	const compendiumClasses = await CompendiumIndex.instance.getClasses();
 	const allClasses = actorClasses.concat(worldClasses, compendiumClasses.class);
+
+	for (const itemToConvert of itemsToConvert) {
+		await convertClassAttributeFromClassLists(itemToConvert, allClasses);
+	}
+}
+
+async function convertGameItemsClassAttributes() {
+	const itemsToConvert = game.items.filter((item) => {
+		return (item.type === 'skill' || item.type === 'spell' || item.type === 'heroic') && !item.flags?.projectfu?.classConverted;
+	});
+
+	if (itemsToConvert.length == 0) {
+		return;
+	}
+
+	const worldClasses = game.items.filter((item) => {
+		return item.type === 'class';
+	});
+	const compendiumClasses = await CompendiumIndex.instance.getClasses();
+	const allClasses = worldClasses.concat(compendiumClasses.class);
 
 	for (const itemToConvert of itemsToConvert) {
 		await convertClassAttributeFromClassLists(itemToConvert, allClasses);
@@ -78,5 +98,6 @@ export class ClassFuidConverter {
 		for (const actor of game.actors) {
 			convertActorItemsClassAttributes(actor);
 		}
+		convertGameItemsClassAttributes();
 	}
 }

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -64,6 +64,7 @@ export const Flags = Object.freeze({
 	Modifier: Object.freeze({
 		ScaleIncomingDamage: 'scaleIncomingDamage',
 	}),
+	ClassConverted: 'classConverted',
 });
 
 export const FlagUtility = Object.freeze({

--- a/module/helpers/tables/classes-table-renderer.mjs
+++ b/module/helpers/tables/classes-table-renderer.mjs
@@ -48,7 +48,7 @@ export class ClassesTableRenderer extends FUTableRenderer {
 		if (item.type === 'class') {
 			const actor = item.parent;
 			const skillTracker = new CharacterSkillTracker(actor.system);
-			const current = skillTracker.getClassLevel(item.name);
+			const current = skillTracker.getClassLevel(item);
 			data = { current: current, max: ClassDataModel.MAX_LEVEL };
 		}
 		if (item.type === 'mnemosphere') {

--- a/module/helpers/tables/common-descriptions.mjs
+++ b/module/helpers/tables/common-descriptions.mjs
@@ -17,8 +17,9 @@ function simpleDescription(descriptionKey) {
  * @return {(FUItem) => Promise<string>}
  */
 function descriptionWithTags(getTags, descriptionKey) {
-	return function (item) {
-		return renderDescription(item, descriptionKey, getTags.call(this, item));
+	return async function (item) {
+		const tags = await getTags.call(this, item);
+		return renderDescription(item, descriptionKey, tags);
 	};
 }
 

--- a/module/helpers/tables/skills-table-renderer.mjs
+++ b/module/helpers/tables/skills-table-renderer.mjs
@@ -4,6 +4,7 @@ import { CommonColumns } from './common-columns.mjs';
 import { FU } from '../config.mjs';
 import { systemTemplatePath } from '../system-utils.mjs';
 import { ExpressionContext, Expressions } from '../../expressions/expressions.mjs';
+import { CompendiumIndex } from '../../ui/compendium/compendium-index.mjs';
 
 export class SkillsTableRenderer extends FUTableRenderer {
 	/** @type TableConfig */
@@ -34,6 +35,11 @@ export class SkillsTableRenderer extends FUTableRenderer {
 			FU,
 			class: item.system.class.value,
 		};
+
+		const foundClass = await SkillsTableRenderer.findMatchingClass(item);
+		if (foundClass) {
+			data.class = foundClass.name;
+		}
 
 		let mainWeapon;
 		if ((item.system.useWeapon.accuracy || item.system.useWeapon.damage) && item.actor && item.actor.isCharacterType) {
@@ -136,5 +142,57 @@ export class SkillsTableRenderer extends FUTableRenderer {
 				reached: current > index,
 			}));
 		return foundry.applications.handlebars.renderTemplate(systemTemplatePath('table/cell/cell-skill-level'), { skillArr: skillArr });
+	}
+
+	static findMatchingClassInArray(item, classes) {
+		const className = item.system?.class?.value;
+		if (className) {
+			// Search for a class with the same name. If found, set the skill's class attribute to match its fu-id
+			const classFound = classes.find((classItem) => {
+				return classItem.name === className;
+			});
+			if (classFound?.system?.fuid) {
+				return classFound;
+			}
+
+			// Search for a class with a fuid that matches the slugified attribute.
+			const classNameSlug = game.projectfu.util.slugify(className);
+			const classFoundWithFuid = classes.find((classItem) => {
+				return classItem.system?.fuid === classNameSlug;
+			});
+			if (classFoundWithFuid?.system?.fuid) {
+				return classFoundWithFuid;
+			}
+		}
+		return;
+	}
+
+	static async findMatchingClass(item) {
+		if (item.system.class.value) {
+			const actorClasses = item.actor.items.filter((arrayItem) => {
+				return arrayItem.type === 'class';
+			});
+			const foundActorClass = SkillsTableRenderer.findMatchingClassInArray(item, actorClasses);
+			if (foundActorClass) {
+				return foundActorClass;
+			}
+
+			const worldClasses = game.items.filter((arrayItem) => {
+				return arrayItem.type === 'class';
+			});
+			const foundWorldClass = SkillsTableRenderer.findMatchingClassInArray(item, worldClasses);
+			if (foundWorldClass) {
+				return foundWorldClass;
+			}
+
+			const compendiumClasses = await CompendiumIndex.instance.getClasses();
+			if (compendiumClasses?.class) {
+				const foundCompendiumClass = SkillsTableRenderer.findMatchingClassInArray(item, compendiumClasses.class);
+				if (foundCompendiumClass) {
+					return foundCompendiumClass;
+				}
+			}
+		}
+		return;
 	}
 }

--- a/module/helpers/tables/spells-table-renderer.mjs
+++ b/module/helpers/tables/spells-table-renderer.mjs
@@ -4,19 +4,26 @@ import { CommonColumns } from './common-columns.mjs';
 import { FU } from '../config.mjs';
 import { systemTemplatePath } from '../system-utils.mjs';
 import { BonusesDataModel } from '../../documents/actors/common/bonuses-data-model.mjs';
+import { CompendiumIndex } from '../../ui/compendium/compendium-index.mjs';
 
 export class SpellsTableRenderer extends FUTableRenderer {
 	/** @type TableConfig */
 	static TABLE_CONFIG = {
 		cssClass: 'spells-table',
 		getItems: (d) => d.itemTypes.spell,
-		renderDescription: CommonDescriptions.descriptionWithTags((item) => {
+		renderDescription: CommonDescriptions.descriptionWithTags(async (item) => {
 			const tags = [];
 			if (item.system.class.value && item.system.class.value.trim()) {
+				let className = item.system.class.value.trim();
+				const foundClass = await SpellsTableRenderer.findMatchingClass(item);
+				if (foundClass) {
+					className = foundClass.name;
+				}
+
 				tags.push({
 					tag: 'FU.Class',
 					separator: ':',
-					value: item.system.class.value.trim(),
+					value: className,
 				});
 			}
 			if (item.system.opportunity) {
@@ -102,5 +109,56 @@ export class SpellsTableRenderer extends FUTableRenderer {
 			classes.push('before-spell-icon');
 		}
 		return classes.join(' ');
+	}
+	static findMatchingClassInArray(item, classes) {
+		const className = item.system?.class?.value;
+		if (className) {
+			// Search for a class with the same name. If found, set the skill's class attribute to match its fu-id
+			const classFound = classes.find((classItem) => {
+				return classItem.name === className;
+			});
+			if (classFound?.system?.fuid) {
+				return classFound;
+			}
+
+			// Search for a class with a fuid that matches the slugified attribute.
+			const skillClassSlug = game.projectfu.util.slugify(className);
+			const classFoundWithFuid = classes.find((classItem) => {
+				return classItem.system?.fuid === skillClassSlug;
+			});
+			if (classFoundWithFuid?.system?.fuid) {
+				return classFoundWithFuid;
+			}
+		}
+		return;
+	}
+
+	static async findMatchingClass(item) {
+		if (item.system.class.value) {
+			const actorClasses = item.actor.items.filter((arrayItem) => {
+				return arrayItem.type === 'class';
+			});
+			const foundActorClass = SpellsTableRenderer.findMatchingClassInArray(item, actorClasses);
+			if (foundActorClass) {
+				return foundActorClass;
+			}
+
+			const worldClasses = game.items.filter((arrayItem) => {
+				return arrayItem.type === 'class';
+			});
+			const foundWorldClass = SpellsTableRenderer.findMatchingClassInArray(item, worldClasses);
+			if (foundWorldClass) {
+				return foundWorldClass;
+			}
+
+			const compendiumClasses = await CompendiumIndex.instance.getClasses();
+			if (compendiumClasses?.class) {
+				const foundCompendiumClass = SpellsTableRenderer.findMatchingClassInArray(item, compendiumClasses.class);
+				if (foundCompendiumClass) {
+					return foundCompendiumClass;
+				}
+			}
+		}
+		return;
 	}
 }

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -117,6 +117,7 @@ import { AutomationPipeline } from './pipelines/automation.mjs';
 import { Themes } from './ui/themes/theme-options.mjs';
 import { FUSidebar, FUSidebarApplication } from './ui/sidebar.mjs';
 import { SheetExtensions } from './sheets/sheet-extension.mjs';
+import { ClassFuidConverter } from './documents/items/class-fuid-converter.mjs';
 
 globalThis.projectfu = {
 	ClassFeatureDataModel,
@@ -527,6 +528,8 @@ Hooks.once('ready', async function () {
 		if (item.isFavorite === true) return; // Already favored
 		item.toggleFavorite(true);
 	});
+
+	ClassFuidConverter.run();
 });
 
 /* -------------------------------------------- */

--- a/src/packs/game-master/spell_Area_Status_1JaRWZz48d1dtVN0.json
+++ b/src/packs/game-master/spell_Area_Status_1JaRWZz48d1dtVN0.json
@@ -122,7 +122,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Breath_SSfB2SP3DVfwslhv.json
+++ b/src/packs/game-master/spell_Breath_SSfB2SP3DVfwslhv.json
@@ -120,7 +120,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Curse_XL_S291phTQNL0qbGYa.json
+++ b/src/packs/game-master/spell_Curse_XL_S291phTQNL0qbGYa.json
@@ -122,7 +122,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Curse_rEWv1yWQHse3soqn.json
+++ b/src/packs/game-master/spell_Curse_rEWv1yWQHse3soqn.json
@@ -122,7 +122,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Cursed_Breath_e5IBMtSXDyfWo0kb.json
+++ b/src/packs/game-master/spell_Cursed_Breath_e5IBMtSXDyfWo0kb.json
@@ -125,7 +125,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Devastation_32sA6nb1MVPzP8lc.json
+++ b/src/packs/game-master/spell_Devastation_32sA6nb1MVPzP8lc.json
@@ -117,7 +117,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Lick_Wounds_Up14pnEa8pWzGkDD.json
+++ b/src/packs/game-master/spell_Lick_Wounds_Up14pnEa8pWzGkDD.json
@@ -117,7 +117,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Life_Theft_MEp2lJPOwnmHvDwk.json
+++ b/src/packs/game-master/spell_Life_Theft_MEp2lJPOwnmHvDwk.json
@@ -122,7 +122,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Mind_Theft_Jr3T9bVRZdWMmAIw.json
+++ b/src/packs/game-master/spell_Mind_Theft_Jr3T9bVRZdWMmAIw.json
@@ -123,7 +123,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Poison_PYXh4QmqJDiA2tqy.json
+++ b/src/packs/game-master/spell_Poison_PYXh4QmqJDiA2tqy.json
@@ -119,7 +119,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Quicken_w93PJbDwQ2WvkXvK.json
+++ b/src/packs/game-master/spell_Quicken_w93PJbDwQ2WvkXvK.json
@@ -120,7 +120,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Rage_dSlyecqTxIXXSa1l.json
+++ b/src/packs/game-master/spell_Rage_dSlyecqTxIXXSa1l.json
@@ -119,7 +119,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Shell_zf8HeDLrqXVMhGt4.json
+++ b/src/packs/game-master/spell_Shell_zf8HeDLrqXVMhGt4.json
@@ -119,7 +119,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_War_Cry_sJc4OnOFGBTiQEzs.json
+++ b/src/packs/game-master/spell_War_Cry_sJc4OnOFGBTiQEzs.json
@@ -119,7 +119,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/game-master/spell_Weaken_AUIhgG59yCsNnaT4.json
+++ b/src/packs/game-master/spell_Weaken_AUIhgG59yCsNnaT4.json
@@ -131,7 +131,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Adversity_MoUQhgRVKo5HTqhl.json
+++ b/src/packs/heroic-skills/heroic_Adversity_MoUQhgRVKo5HTqhl.json
@@ -187,7 +187,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_All_You_Can_Eat_562YcXPjzRCWpeLh.json
+++ b/src/packs/heroic-skills/heroic_All_You_Can_Eat_562YcXPjzRCWpeLh.json
@@ -126,7 +126,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Ambidextrous_wr1if7rQttzxelbV.json
+++ b/src/packs/heroic-skills/heroic_Ambidextrous_wr1if7rQttzxelbV.json
@@ -176,7 +176,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Anatomist_yfJzxbsgRbI0LCpt.json
+++ b/src/packs/heroic-skills/heroic_Anatomist_yfJzxbsgRbI0LCpt.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Arcane_Echoes_m5uGvbpdVfRmALod.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Echoes_m5uGvbpdVfRmALod.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Arcane_Mark_hH6SHCiX0HAdXugI.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Mark_hH6SHCiX0HAdXugI.json
@@ -231,7 +231,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Arcane_Sacrifice_uDjrET5eZnO6yaoQ.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Sacrifice_uDjrET5eZnO6yaoQ.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Arcane_Soldier_E3OppAz7I4f0g19B.json
+++ b/src/packs/heroic-skills/heroic_Arcane_Soldier_E3OppAz7I4f0g19B.json
@@ -105,7 +105,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Auramancer_s_Refraction_DVaiA90aHgq9gPYI.json
+++ b/src/packs/heroic-skills/heroic_Auramancer_s_Refraction_DVaiA90aHgq9gPYI.json
@@ -68,7 +68,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Bend_Magic_HsdYyIcbdvcleXQP.json
+++ b/src/packs/heroic-skills/heroic_Bend_Magic_HsdYyIcbdvcleXQP.json
@@ -170,7 +170,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Bimagus_sx1dhJqczTT4UkYw.json
+++ b/src/packs/heroic-skills/heroic_Bimagus_sx1dhJqczTT4UkYw.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Birth_of_the_Cruel_iTh63cnp8IVawDwH.json
+++ b/src/packs/heroic-skills/heroic_Birth_of_the_Cruel_iTh63cnp8IVawDwH.json
@@ -109,7 +109,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Black___White_OSJ4PCp6GmSnLaS3.json
+++ b/src/packs/heroic-skills/heroic_Black___White_OSJ4PCp6GmSnLaS3.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Blade_Adept_s316rQUTr3lgeTx7.json
+++ b/src/packs/heroic-skills/heroic_Blade_Adept_s316rQUTr3lgeTx7.json
@@ -182,7 +182,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Brainwave_Discharge_iZIhU35ZCZ1zrbfL.json
+++ b/src/packs/heroic-skills/heroic_Brainwave_Discharge_iZIhU35ZCZ1zrbfL.json
@@ -225,7 +225,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Brambleheart_FvqC34UYxD3O2bFt.json
+++ b/src/packs/heroic-skills/heroic_Brambleheart_FvqC34UYxD3O2bFt.json
@@ -188,7 +188,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Brave_Bash_eOGrMEqq2sBta0AN.json
+++ b/src/packs/heroic-skills/heroic_Brave_Bash_eOGrMEqq2sBta0AN.json
@@ -175,7 +175,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Broken_Wing_Tactic_qDXaDmoLcasT2o37.json
+++ b/src/packs/heroic-skills/heroic_Broken_Wing_Tactic_qDXaDmoLcasT2o37.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Bullet_Break_ap1qHpIHqNFIKTsT.json
+++ b/src/packs/heroic-skills/heroic_Bullet_Break_ap1qHpIHqNFIKTsT.json
@@ -106,7 +106,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Bullet_Time_RD8MoXlaZMNolEnN.json
+++ b/src/packs/heroic-skills/heroic_Bullet_Time_RD8MoXlaZMNolEnN.json
@@ -184,7 +184,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Card_Vanguard_6xjSns6UPuZcIbXs.json
+++ b/src/packs/heroic-skills/heroic_Card_Vanguard_6xjSns6UPuZcIbXs.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Ceaseless_Battlefield_sSq9Z065pczkdBLZ.json
+++ b/src/packs/heroic-skills/heroic_Ceaseless_Battlefield_sSq9Z065pczkdBLZ.json
@@ -242,7 +242,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Cheer_Up__cSzzcGmQur0Zo6R5.json
+++ b/src/packs/heroic-skills/heroic_Cheer_Up__cSzzcGmQur0Zo6R5.json
@@ -181,7 +181,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Chimeric_Mastery_S64viyPBB8VsH9cQ.json
+++ b/src/packs/heroic-skills/heroic_Chimeric_Mastery_S64viyPBB8VsH9cQ.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Chimeric_Soul_nmeZ2ukzybP0lpR9.json
+++ b/src/packs/heroic-skills/heroic_Chimeric_Soul_nmeZ2ukzybP0lpR9.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Clean_Slate_IgteRExMGSKQwg1G.json
+++ b/src/packs/heroic-skills/heroic_Clean_Slate_IgteRExMGSKQwg1G.json
@@ -192,7 +192,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Cleansing_Moonlight_KLo8fztm26jzY2Zn.json
+++ b/src/packs/heroic-skills/heroic_Cleansing_Moonlight_KLo8fztm26jzY2Zn.json
@@ -202,7 +202,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Comet_zggGDIOSuvO8uzHg.json
+++ b/src/packs/heroic-skills/heroic_Comet_zggGDIOSuvO8uzHg.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Decoy_Bait_18sj4s6SHmfIicUj.json
+++ b/src/packs/heroic-skills/heroic_Decoy_Bait_18sj4s6SHmfIicUj.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Deep_Pockets_ca4n2hFwIzfP4F12.json
+++ b/src/packs/heroic-skills/heroic_Deep_Pockets_ca4n2hFwIzfP4F12.json
@@ -203,7 +203,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Disarming_Rhetoric_pcqTER5q2Mrcq0r4.json
+++ b/src/packs/heroic-skills/heroic_Disarming_Rhetoric_pcqTER5q2Mrcq0r4.json
@@ -117,7 +117,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Double_Arrow_ibuohUO9YHDIId4x.json
+++ b/src/packs/heroic-skills/heroic_Double_Arrow_ibuohUO9YHDIId4x.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Dreamslice_jdhnFWPhnFtLRLe8.json
+++ b/src/packs/heroic-skills/heroic_Dreamslice_jdhnFWPhnFtLRLe8.json
@@ -208,7 +208,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Duel_Master_ngt7aBn7AykfzJDg.json
+++ b/src/packs/heroic-skills/heroic_Duel_Master_ngt7aBn7AykfzJDg.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Dynamic_Synchronization_3Fxytf91dQuKMn74.json
+++ b/src/packs/heroic-skills/heroic_Dynamic_Synchronization_3Fxytf91dQuKMn74.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Ephemeral_Tranquility_mYZHKPvfVmvZ4vNy.json
+++ b/src/packs/heroic-skills/heroic_Ephemeral_Tranquility_mYZHKPvfVmvZ4vNy.json
@@ -184,7 +184,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Extra_HP_okxC0Vg7jOXrEg6V.json
+++ b/src/packs/heroic-skills/heroic_Extra_HP_okxC0Vg7jOXrEg6V.json
@@ -176,7 +176,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Extra_IP_RSacdfMknVY24eCH.json
+++ b/src/packs/heroic-skills/heroic_Extra_IP_RSacdfMknVY24eCH.json
@@ -176,7 +176,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Extra_MP_VwPy5u5mcj9xLF6T.json
+++ b/src/packs/heroic-skills/heroic_Extra_MP_VwPy5u5mcj9xLF6T.json
@@ -176,7 +176,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Extra_Spells_eNGAXzS3LaIrSukF.json
+++ b/src/packs/heroic-skills/heroic_Extra_Spells_eNGAXzS3LaIrSukF.json
@@ -117,7 +117,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Fast_Rituals_6bLqejGbDDsGTj93.json
+++ b/src/packs/heroic-skills/heroic_Fast_Rituals_6bLqejGbDDsGTj93.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Fitcast_VUOVB6ej86Ml3d1j.json
+++ b/src/packs/heroic-skills/heroic_Fitcast_VUOVB6ej86Ml3d1j.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Fleeting_Moment_W1UsYgp1MDCKkOV0.json
+++ b/src/packs/heroic-skills/heroic_Fleeting_Moment_W1UsYgp1MDCKkOV0.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Flow_of_Yin_and_Yang_HvneaDgpLe2cAKH7.json
+++ b/src/packs/heroic-skills/heroic_Flow_of_Yin_and_Yang_HvneaDgpLe2cAKH7.json
@@ -154,7 +154,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_For_a_Better_Future_KT1FGhqeq1MYkrtJ.json
+++ b/src/packs/heroic-skills/heroic_For_a_Better_Future_KT1FGhqeq1MYkrtJ.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Forbidden_Rite_UhjNswMk6idkCg0c.json
+++ b/src/packs/heroic-skills/heroic_Forbidden_Rite_UhjNswMk6idkCg0c.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Grand_Summoning_mRwuLhNrlBLPKvoB.json
+++ b/src/packs/heroic-skills/heroic_Grand_Summoning_mRwuLhNrlBLPKvoB.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Great_Cauldron_s_Secret_D0wG80uPK1MmHUf5.json
+++ b/src/packs/heroic-skills/heroic_Great_Cauldron_s_Secret_D0wG80uPK1MmHUf5.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Greater_Akromorphosis_JkU2SSeR5kMcDIXQ.json
+++ b/src/packs/heroic-skills/heroic_Greater_Akromorphosis_JkU2SSeR5kMcDIXQ.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Greater_Chloromancy_Q2Xiuen9jKw7CEpW.json
+++ b/src/packs/heroic-skills/heroic_Greater_Chloromancy_Q2Xiuen9jKw7CEpW.json
@@ -67,7 +67,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Greater_Ecdysis_gMC0t7NhWgv6BTcl.json
+++ b/src/packs/heroic-skills/heroic_Greater_Ecdysis_gMC0t7NhWgv6BTcl.json
@@ -190,7 +190,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Greater_Theriomorphosis_vwygOswBPj5vyiWN.json
+++ b/src/packs/heroic-skills/heroic_Greater_Theriomorphosis_vwygOswBPj5vyiWN.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Green_Thumb_nm6Ec7nbsrNlRZCf.json
+++ b/src/packs/heroic-skills/heroic_Green_Thumb_nm6Ec7nbsrNlRZCf.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Harvester_of_Sorrow_pqT5C8ap91WD7TDf.json
+++ b/src/packs/heroic-skills/heroic_Harvester_of_Sorrow_pqT5C8ap91WD7TDf.json
@@ -259,7 +259,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Heartbreaker_8Djx8D9cU36qHQYz.json
+++ b/src/packs/heroic-skills/heroic_Heartbreaker_8Djx8D9cU36qHQYz.json
@@ -223,7 +223,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Heroic_Companion_BD2TjjMN3s8DfZEu.json
+++ b/src/packs/heroic-skills/heroic_Heroic_Companion_BD2TjjMN3s8DfZEu.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Hit_the_Nerve_IMg6ssWeH5hyBtIi.json
+++ b/src/packs/heroic-skills/heroic_Hit_the_Nerve_IMg6ssWeH5hyBtIi.json
@@ -292,7 +292,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Hope_kAoA3OAXH6E6tt9I.json
+++ b/src/packs/heroic-skills/heroic_Hope_kAoA3OAXH6E6tt9I.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Hoplite_sEXgOpgUF00z55Y3.json
+++ b/src/packs/heroic-skills/heroic_Hoplite_sEXgOpgUF00z55Y3.json
@@ -177,7 +177,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Hunter_s_Trick_C85rsZpRK6htfbv6.json
+++ b/src/packs/heroic-skills/heroic_Hunter_s_Trick_C85rsZpRK6htfbv6.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Impaler_Dragon_0YxqgUTI6wRu7pV8.json
+++ b/src/packs/heroic-skills/heroic_Impaler_Dragon_0YxqgUTI6wRu7pV8.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Inner_Wellspring_FPzCCSJAdIwVLVqB.json
+++ b/src/packs/heroic-skills/heroic_Inner_Wellspring_FPzCCSJAdIwVLVqB.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Iron_Forest_9ga5k07i5o6nEE1c.json
+++ b/src/packs/heroic-skills/heroic_Iron_Forest_9ga5k07i5o6nEE1c.json
@@ -232,7 +232,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_It_Lives__LhE2uHqEfh9L179L.json
+++ b/src/packs/heroic-skills/heroic_It_Lives__LhE2uHqEfh9L179L.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Like_an_Open_Book_bNl3nhk2ULBwLaE4.json
+++ b/src/packs/heroic-skills/heroic_Like_an_Open_Book_bNl3nhk2ULBwLaE4.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Magic_Guard_dwmA3TWb8Ya3VSDZ.json
+++ b/src/packs/heroic-skills/heroic_Magic_Guard_dwmA3TWb8Ya3VSDZ.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Make_it_or_Break_it_p8vmh280ByFh88tK.json
+++ b/src/packs/heroic-skills/heroic_Make_it_or_Break_it_p8vmh280ByFh88tK.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Mathemagic_oedqQdAvlhW6VCPh.json
+++ b/src/packs/heroic-skills/heroic_Mathemagic_oedqQdAvlhW6VCPh.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Mimeoclepsis_8vzHUmPg4Cksad7D.json
+++ b/src/packs/heroic-skills/heroic_Mimeoclepsis_8vzHUmPg4Cksad7D.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Monkey_Grip_zwoUkVKrKQHZzVHV.json
+++ b/src/packs/heroic-skills/heroic_Monkey_Grip_zwoUkVKrKQHZzVHV.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Nebulization_2bYmGoMPJ8jNP8hP.json
+++ b/src/packs/heroic-skills/heroic_Nebulization_2bYmGoMPJ8jNP8hP.json
@@ -235,7 +235,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Nether_Slash_DkaqHnTnEw2eMRDa.json
+++ b/src/packs/heroic-skills/heroic_Nether_Slash_DkaqHnTnEw2eMRDa.json
@@ -191,7 +191,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Ofuda_Mastery_sD7qYF2LZhxfHJ8P.json
+++ b/src/packs/heroic-skills/heroic_Ofuda_Mastery_sD7qYF2LZhxfHJ8P.json
@@ -51,7 +51,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Overload_Burst_nvR7qGeOaTNe4F9n.json
+++ b/src/packs/heroic-skills/heroic_Overload_Burst_nvR7qGeOaTNe4F9n.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Paso_Doble_h8keSqFfvEilNhF7.json
+++ b/src/packs/heroic-skills/heroic_Paso_Doble_h8keSqFfvEilNhF7.json
@@ -218,7 +218,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Perfect_Aim_ZfAZkP1rc6RrFjre.json
+++ b/src/packs/heroic-skills/heroic_Perfect_Aim_ZfAZkP1rc6RrFjre.json
@@ -217,7 +217,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Phagomagus_jHa5MjZpLP8OLSK9.json
+++ b/src/packs/heroic-skills/heroic_Phagomagus_jHa5MjZpLP8OLSK9.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Pillage_ZwYXOZJHtRxsmHXl.json
+++ b/src/packs/heroic-skills/heroic_Pillage_ZwYXOZJHtRxsmHXl.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Power_Chord_2BCHomNzOGzj2SNa.json
+++ b/src/packs/heroic-skills/heroic_Power_Chord_2BCHomNzOGzj2SNa.json
@@ -118,7 +118,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Power_Nap_rlOIe9a68fkv8KS3.json
+++ b/src/packs/heroic-skills/heroic_Power_Nap_rlOIe9a68fkv8KS3.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Powerful_Shot_LDgRVXFVnUdJTvit.json
+++ b/src/packs/heroic-skills/heroic_Powerful_Shot_LDgRVXFVnUdJTvit.json
@@ -170,7 +170,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Powerful_Spell_lYKani6s0f2C8vqA.json
+++ b/src/packs/heroic-skills/heroic_Powerful_Spell_lYKani6s0f2C8vqA.json
@@ -170,7 +170,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Powerful_Strike_BsWM80bfvYRZjbED.json
+++ b/src/packs/heroic-skills/heroic_Powerful_Strike_BsWM80bfvYRZjbED.json
@@ -170,7 +170,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Predictable__r6EWpIcwbMmH3u42.json
+++ b/src/packs/heroic-skills/heroic_Predictable__r6EWpIcwbMmH3u42.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Psychic_Field_3h38Nob5B8AWsexP.json
+++ b/src/packs/heroic-skills/heroic_Psychic_Field_3h38Nob5B8AWsexP.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Pulse_of_the_Maggots_rbs7azAWkb9MwSXi.json
+++ b/src/packs/heroic-skills/heroic_Pulse_of_the_Maggots_rbs7azAWkb9MwSXi.json
@@ -109,7 +109,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Pulverizing_Strike_DppL1AyvffBGbjDM.json
+++ b/src/packs/heroic-skills/heroic_Pulverizing_Strike_DppL1AyvffBGbjDM.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Quantum_Magicannon_7X5Douk1Esbc0LJf.json
+++ b/src/packs/heroic-skills/heroic_Quantum_Magicannon_7X5Douk1Esbc0LJf.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Quick_Scan_6UzPwOYtyU0inH48.json
+++ b/src/packs/heroic-skills/heroic_Quick_Scan_6UzPwOYtyU0inH48.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Rampart_RhoZgyaCPn1IPixe.json
+++ b/src/packs/heroic-skills/heroic_Rampart_RhoZgyaCPn1IPixe.json
@@ -198,7 +198,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Repetition_qi4qlidm2Dg7R99X.json
+++ b/src/packs/heroic-skills/heroic_Repetition_qi4qlidm2Dg7R99X.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Revelation_tY6Y0EW7JPP80flT.json
+++ b/src/packs/heroic-skills/heroic_Revelation_tY6Y0EW7JPP80flT.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Ritual_Seals_kxGTMBIvlLKM50Wa.json
+++ b/src/packs/heroic-skills/heroic_Ritual_Seals_kxGTMBIvlLKM50Wa.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Showstopper_A0NEGshlzb52Tv7h.json
+++ b/src/packs/heroic-skills/heroic_Showstopper_A0NEGshlzb52Tv7h.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Side_by_Side_v2oHTRDdfnDEXURD.json
+++ b/src/packs/heroic-skills/heroic_Side_by_Side_v2oHTRDdfnDEXURD.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Silent_Hunter_1jiLF3jy7eEinL1k.json
+++ b/src/packs/heroic-skills/heroic_Silent_Hunter_1jiLF3jy7eEinL1k.json
@@ -209,7 +209,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Skillful_Dosage_1wnsaeyJ46ElqvPX.json
+++ b/src/packs/heroic-skills/heroic_Skillful_Dosage_1wnsaeyJ46ElqvPX.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Specialty_of_the_House_HMQApiczSy0sas6z.json
+++ b/src/packs/heroic-skills/heroic_Specialty_of_the_House_HMQApiczSy0sas6z.json
@@ -64,7 +64,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Spider_s_Web_8Y5cFfBejJdnj9bb.json
+++ b/src/packs/heroic-skills/heroic_Spider_s_Web_8Y5cFfBejJdnj9bb.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Status_Immunity_aFS46NM5EYoywktL.json
+++ b/src/packs/heroic-skills/heroic_Status_Immunity_aFS46NM5EYoywktL.json
@@ -469,7 +469,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Steel_Witch_m6MWTDpEJqEMAb5a.json
+++ b/src/packs/heroic-skills/heroic_Steel_Witch_m6MWTDpEJqEMAb5a.json
@@ -110,7 +110,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Strength_of_Five_Wellsprings_LaGJKkBP3v61ra1v.json
+++ b/src/packs/heroic-skills/heroic_Strength_of_Five_Wellsprings_LaGJKkBP3v61ra1v.json
@@ -68,7 +68,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Swirling_Swarm_WKJ4ZSPBnlg4U3qt.json
+++ b/src/packs/heroic-skills/heroic_Swirling_Swarm_WKJ4ZSPBnlg4U3qt.json
@@ -248,7 +248,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Symbiotic_Roots_gnyG5SfCFuw0whnu.json
+++ b/src/packs/heroic-skills/heroic_Symbiotic_Roots_gnyG5SfCFuw0whnu.json
@@ -48,7 +48,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Tabula_Rasa_MNSD1FKJfOk8BCKr.json
+++ b/src/packs/heroic-skills/heroic_Tabula_Rasa_MNSD1FKJfOk8BCKr.json
@@ -229,7 +229,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Tempest_Strike_eRWAdOPqb5aU9k9x.json
+++ b/src/packs/heroic-skills/heroic_Tempest_Strike_eRWAdOPqb5aU9k9x.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Theme_Song_HEOsMRPIujE75Sll.json
+++ b/src/packs/heroic-skills/heroic_Theme_Song_HEOsMRPIujE75Sll.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Triple_Slash_awqSSh3rbNZW8L5V.json
+++ b/src/packs/heroic-skills/heroic_Triple_Slash_awqSSh3rbNZW8L5V.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Unbreakable_Njj84qeVxijnlVB9.json
+++ b/src/packs/heroic-skills/heroic_Unbreakable_Njj84qeVxijnlVB9.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Upgrade_xbTcxx4ysOWOamZP.json
+++ b/src/packs/heroic-skills/heroic_Upgrade_xbTcxx4ysOWOamZP.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Vanish_RRKlW2mwN7sA8YJh.json
+++ b/src/packs/heroic-skills/heroic_Vanish_RRKlW2mwN7sA8YJh.json
@@ -121,7 +121,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Volcano_FpTkfuZ5p4zCQKDP.json
+++ b/src/packs/heroic-skills/heroic_Volcano_FpTkfuZ5p4zCQKDP.json
@@ -114,7 +114,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Wise_Counsel_3wlO92LRBQOzfEB7.json
+++ b/src/packs/heroic-skills/heroic_Wise_Counsel_3wlO92LRBQOzfEB7.json
@@ -72,7 +72,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/heroic_Witchvoice_F663zXMwqDGSCfOp.json
+++ b/src/packs/heroic-skills/heroic_Witchvoice_F663zXMwqDGSCfOp.json
@@ -54,7 +54,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/spell_Comet_couQDFDzbxx7tKnx.json
+++ b/src/packs/heroic-skills/spell_Comet_couQDFDzbxx7tKnx.json
@@ -261,7 +261,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/spell_Hope_5Oh7VSxoQuiMbb2r.json
+++ b/src/packs/heroic-skills/spell_Hope_5Oh7VSxoQuiMbb2r.json
@@ -128,7 +128,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/heroic-skills/spell_Volcano_hAys6ZF4mjNMQ9xa.json
+++ b/src/packs/heroic-skills/spell_Volcano_hAys6ZF4mjNMQ9xa.json
@@ -263,7 +263,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/legacy/heroic_Rising_Tide__Legacy__4AJDgvnATiT4fxbO.json
+++ b/src/packs/legacy/heroic_Rising_Tide__Legacy__4AJDgvnATiT4fxbO.json
@@ -103,7 +103,7 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": true
+      "favorite": false
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Absorb_MP_jgGLuOvN8xCSQWLK.json
+++ b/src/packs/skills/skill_Absorb_MP_jgGLuOvN8xCSQWLK.json
@@ -210,7 +210,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Adrenaline_DniA4VMTBNhk5a1v.json
+++ b/src/packs/skills/skill_Adrenaline_DniA4VMTBNhk5a1v.json
@@ -194,7 +194,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Agony_JPVEY9p8zsGidKJq.json
+++ b/src/packs/skills/skill_Agony_JPVEY9p8zsGidKJq.json
@@ -246,7 +246,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Akromorphosis_7ZIT4N07zc2yWsre.json
+++ b/src/packs/skills/skill_Akromorphosis_7ZIT4N07zc2yWsre.json
@@ -248,7 +248,8 @@
   ],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Arcane_Circle_hEj8s21iAOPhDtJN.json
+++ b/src/packs/skills/skill_Arcane_Circle_hEj8s21iAOPhDtJN.json
@@ -220,7 +220,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Arcane_Regeneration_ZTEuKRcX9erp1NDC.json
+++ b/src/packs/skills/skill_Arcane_Regeneration_ZTEuKRcX9erp1NDC.json
@@ -220,7 +220,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Barrage_lCFQMCY4AmDsv6sv.json
+++ b/src/packs/skills/skill_Barrage_lCFQMCY4AmDsv6sv.json
@@ -74,7 +74,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Battle_Gardening_eZxqfORDilZ4mYip.json
+++ b/src/packs/skills/skill_Battle_Gardening_eZxqfORDilZ4mYip.json
@@ -76,7 +76,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Beyond_The_Realms_Of_Death_QwAuh7RXGBQsCb6l.json
+++ b/src/packs/skills/skill_Beyond_The_Realms_Of_Death_QwAuh7RXGBQsCb6l.json
@@ -129,7 +129,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Bind_and_Summon_gbkA1CRgQ9OxPstd.json
+++ b/src/packs/skills/skill_Bind_and_Summon_gbkA1CRgQ9OxPstd.json
@@ -212,7 +212,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Biophagy_kpg23Fs85uniba2A.json
+++ b/src/packs/skills/skill_Biophagy_kpg23Fs85uniba2A.json
@@ -328,7 +328,8 @@
   ],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Bishop_s_Edict_FGihIPfif7yWsBCp.json
+++ b/src/packs/skills/skill_Bishop_s_Edict_FGihIPfif7yWsBCp.json
@@ -145,7 +145,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Bladestorm_IhBCZsilt0bj5RJK.json
+++ b/src/packs/skills/skill_Bladestorm_IhBCZsilt0bj5RJK.json
@@ -133,7 +133,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Bodyguard_ZvZT5jWlBZVm1Gmd.json
+++ b/src/packs/skills/skill_Bodyguard_ZvZT5jWlBZVm1Gmd.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Bone_Crusher_7jWycVYFgZ1BMxch.json
+++ b/src/packs/skills/skill_Bone_Crusher_7jWycVYFgZ1BMxch.json
@@ -246,7 +246,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Breach_WZDdQfw9VF64La2P.json
+++ b/src/packs/skills/skill_Breach_WZDdQfw9VF64La2P.json
@@ -143,7 +143,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Cataclysm_muhtqtJ6av32K34Z.json
+++ b/src/packs/skills/skill_Cataclysm_muhtqtJ6av32K34Z.json
@@ -245,7 +245,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Charging_Cavalry_VhWG5AXdBZ8hL4xr.json
+++ b/src/packs/skills/skill_Charging_Cavalry_VhWG5AXdBZ8hL4xr.json
@@ -140,7 +140,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Cheap_Shot_c2XRt5pvOab25Tbe.json
+++ b/src/packs/skills/skill_Cheap_Shot_c2XRt5pvOab25Tbe.json
@@ -246,7 +246,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Children_Of_The_Grave_kOEljjCw7bS9FyJv.json
+++ b/src/packs/skills/skill_Children_Of_The_Grave_kOEljjCw7bS9FyJv.json
@@ -124,7 +124,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Chloromancy_ZmzDl88kGMvrumoJ.json
+++ b/src/packs/skills/skill_Chloromancy_ZmzDl88kGMvrumoJ.json
@@ -147,7 +147,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Cognitive_Focus_idQdS82bEICiB0zL.json
+++ b/src/packs/skills/skill_Cognitive_Focus_idQdS82bEICiB0zL.json
@@ -318,7 +318,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Compression_Tech_kMQH13lhWY4Mlbh8.json
+++ b/src/packs/skills/skill_Compression_Tech_kMQH13lhWY4Mlbh8.json
@@ -134,7 +134,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Condemn_DtEiCkDsC1amYABn.json
+++ b/src/packs/skills/skill_Condemn_DtEiCkDsC1amYABn.json
@@ -237,7 +237,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Consume_c46SCybV1gtiHbL4.json
+++ b/src/packs/skills/skill_Consume_c46SCybV1gtiHbL4.json
@@ -243,7 +243,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Cooking_SkhjmD8IDm1yff3e.json
+++ b/src/packs/skills/skill_Cooking_SkhjmD8IDm1yff3e.json
@@ -72,7 +72,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Counterattack_XhcTVGtGEk7L2Ddq.json
+++ b/src/packs/skills/skill_Counterattack_XhcTVGtGEk7L2Ddq.json
@@ -235,7 +235,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Crossfire_sIkQa2NzkqsvczBr.json
+++ b/src/packs/skills/skill_Crossfire_sIkQa2NzkqsvczBr.json
@@ -232,7 +232,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Crushing_Chariot_4ymBr3vRdPHNxIKC.json
+++ b/src/packs/skills/skill_Crushing_Chariot_4ymBr3vRdPHNxIKC.json
@@ -259,7 +259,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Dance_y0dACFzoQBBMZOEk.json
+++ b/src/packs/skills/skill_Dance_y0dACFzoQBBMZOEk.json
@@ -140,7 +140,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Dark_Blood_CEP3nER80UBDH7a9.json
+++ b/src/packs/skills/skill_Dark_Blood_CEP3nER80UBDH7a9.json
@@ -203,7 +203,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Defensive_Mastery_7wF1oulk0Zn7ITTF.json
+++ b/src/packs/skills/skill_Defensive_Mastery_7wF1oulk0Zn7ITTF.json
@@ -194,7 +194,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Dodge_ksgKc90MZSpDTka7.json
+++ b/src/packs/skills/skill_Dodge_ksgKc90MZSpDTka7.json
@@ -190,7 +190,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Double_or_Nothing_sfIxI8t0XlJMMVFC.json
+++ b/src/packs/skills/skill_Double_or_Nothing_sfIxI8t0XlJMMVFC.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Dual_Shieldbearer_aPQXTQegswRisA1R.json
+++ b/src/packs/skills/skill_Dual_Shieldbearer_aPQXTQegswRisA1R.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ecdysis_ij6vcA9nnD915bgI.json
+++ b/src/packs/skills/skill_Ecdysis_ij6vcA9nnD915bgI.json
@@ -132,7 +132,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Elemental_Harmony_YZkp0hXK29tfI0MI.json
+++ b/src/packs/skills/skill_Elemental_Harmony_YZkp0hXK29tfI0MI.json
@@ -189,7 +189,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Elemental_Magic_zlmL0suZwTCQYzE5.json
+++ b/src/packs/skills/skill_Elemental_Magic_zlmL0suZwTCQYzE5.json
@@ -138,7 +138,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Emergency_Arcanum_aIbwfdDFTSRgKxxx.json
+++ b/src/packs/skills/skill_Emergency_Arcanum_aIbwfdDFTSRgKxxx.json
@@ -221,7 +221,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Emergency_Item_2MoV74xWJnF5Ru8u.json
+++ b/src/packs/skills/skill_Emergency_Item_2MoV74xWJnF5Ru8u.json
@@ -197,7 +197,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Encourage_04DiGVKhF3DtmJ4n.json
+++ b/src/packs/skills/skill_Encourage_04DiGVKhF3DtmJ4n.json
@@ -151,7 +151,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Entropic_Magic_vtmxLTltA4JvXFXu.json
+++ b/src/packs/skills/skill_Entropic_Magic_vtmxLTltA4JvXFXu.json
@@ -134,7 +134,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Expiration_Date_BW9vyaiaOF5OkIcG.json
+++ b/src/packs/skills/skill_Expiration_Date_BW9vyaiaOF5OkIcG.json
@@ -76,7 +76,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Faithful_Companion_L34pOGhdH0ZwV4Bt.json
+++ b/src/packs/skills/skill_Faithful_Companion_L34pOGhdH0ZwV4Bt.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Fear_Is_The_Key_4TxnpOUnaOaTFCP0.json
+++ b/src/packs/skills/skill_Fear_Is_The_Key_4TxnpOUnaOaTFCP0.json
@@ -129,7 +129,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Feral_Speech_YLWWM3IqnFCAGoUc.json
+++ b/src/packs/skills/skill_Feral_Speech_YLWWM3IqnFCAGoUc.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
+++ b/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
@@ -230,7 +230,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Flexible_Configuration_BuqR9EZDFMn5lDGG.json
+++ b/src/packs/skills/skill_Flexible_Configuration_BuqR9EZDFMn5lDGG.json
@@ -134,7 +134,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Focused_xaNu6plCZfo9dGsX.json
+++ b/src/packs/skills/skill_Focused_xaNu6plCZfo9dGsX.json
@@ -224,7 +224,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Follow_My_Lead_3mqtdzwMU62J1ogW.json
+++ b/src/packs/skills/skill_Follow_My_Lead_3mqtdzwMU62J1ogW.json
@@ -139,7 +139,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_For_Whom_The_Bell_Tolls_oevRD7ES46HQEOKn.json
+++ b/src/packs/skills/skill_For_Whom_The_Bell_Tolls_oevRD7ES46HQEOKn.json
@@ -133,7 +133,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Fortress_X4KdFiQmzikrsM6v.json
+++ b/src/packs/skills/skill_Fortress_X4KdFiQmzikrsM6v.json
@@ -192,7 +192,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Frenetic_Footwork_R0F1K6i1gjNWNklq.json
+++ b/src/packs/skills/skill_Frenetic_Footwork_R0F1K6i1gjNWNklq.json
@@ -231,7 +231,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Frenzy_oi2LgAoLN5IyuBG3.json
+++ b/src/packs/skills/skill_Frenzy_oi2LgAoLN5IyuBG3.json
@@ -212,7 +212,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Gadgets_0ErPA4Q0P97ZPwPE.json
+++ b/src/packs/skills/skill_Gadgets_0ErPA4Q0P97ZPwPE.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Genoclepsis_mWqx8pto9gbbwMoG.json
+++ b/src/packs/skills/skill_Genoclepsis_mWqx8pto9gbbwMoG.json
@@ -132,7 +132,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Graft_0IqVc3nbaYQWh5mm.json
+++ b/src/packs/skills/skill_Graft_0IqVc3nbaYQWh5mm.json
@@ -72,7 +72,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Hawkeye_hmDCgX5OEk5l4uXW.json
+++ b/src/packs/skills/skill_Hawkeye_hmDCgX5OEk5l4uXW.json
@@ -123,7 +123,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Healing_Power_rVM7HhQ5OwdPtFwa.json
+++ b/src/packs/skills/skill_Healing_Power_rVM7HhQ5OwdPtFwa.json
@@ -235,7 +235,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Heart_in_the_Engine_HCzLtYgEWScIeJNq.json
+++ b/src/packs/skills/skill_Heart_in_the_Engine_HCzLtYgEWScIeJNq.json
@@ -244,7 +244,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Heart_of_Darkness_e6ids95gOPher40d.json
+++ b/src/packs/skills/skill_Heart_of_Darkness_e6ids95gOPher40d.json
@@ -184,7 +184,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_High_Speed_tiu0D74YNxirN6Tr.json
+++ b/src/packs/skills/skill_High_Speed_tiu0D74YNxirN6Tr.json
@@ -219,7 +219,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_High_or_Low_tFbGtEfIudpck8vL.json
+++ b/src/packs/skills/skill_High_or_Low_tFbGtEfIudpck8vL.json
@@ -135,7 +135,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Hypercognition_P0oD7KQA9ipYWU8o.json
+++ b/src/packs/skills/skill_Hypercognition_P0oD7KQA9ipYWU8o.json
@@ -399,7 +399,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_I_ve_Heard_of_It__GkFFLkshtNlg0vgV.json
+++ b/src/packs/skills/skill_I_ve_Heard_of_It__GkFFLkshtNlg0vgV.json
@@ -76,7 +76,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Indomitable_Spirit_wezEekAOYfbxrt74.json
+++ b/src/packs/skills/skill_Indomitable_Spirit_wezEekAOYfbxrt74.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Invocation_G5SMsS4TC1glE2VS.json
+++ b/src/packs/skills/skill_Invocation_G5SMsS4TC1glE2VS.json
@@ -77,7 +77,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_King_s_Castle_79xGJD8jn4zGzYpX.json
+++ b/src/packs/skills/skill_King_s_Castle_79xGJD8jn4zGzYpX.json
@@ -145,7 +145,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Knife_and_Fork_GJHaSepRfZZ5TRWN.json
+++ b/src/packs/skills/skill_Knife_and_Fork_GJHaSepRfZZ5TRWN.json
@@ -67,7 +67,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Knowledge_Is_Power_XNAHXFdVPKiABegZ.json
+++ b/src/packs/skills/skill_Knowledge_Is_Power_XNAHXFdVPKiABegZ.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Linked_Invocation_OQaLTvDV59JKnFqO.json
+++ b/src/packs/skills/skill_Linked_Invocation_OQaLTvDV59JKnFqO.json
@@ -165,7 +165,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Lucky_Seven_HgxY0x6jUjS6ppBc.json
+++ b/src/packs/skills/skill_Lucky_Seven_HgxY0x6jUjS6ppBc.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Made_with_Love_VXv8FzCETDsXLeH7.json
+++ b/src/packs/skills/skill_Made_with_Love_VXv8FzCETDsXLeH7.json
@@ -73,7 +73,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Magic_Artillery_b5zzfsWN7h5ugrnW.json
+++ b/src/packs/skills/skill_Magic_Artillery_b5zzfsWN7h5ugrnW.json
@@ -223,7 +223,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Magic_Cards_5zF6JTf6nhKbXr69.json
+++ b/src/packs/skills/skill_Magic_Cards_5zF6JTf6nhKbXr69.json
@@ -134,7 +134,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Magic_Symbols_ffgsQbg3SuWBUUS2.json
+++ b/src/packs/skills/skill_Magic_Symbols_ffgsQbg3SuWBUUS2.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Magichant_bt4jQZ557iLHlazO.json
+++ b/src/packs/skills/skill_Magichant_bt4jQZ557iLHlazO.json
@@ -137,7 +137,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Melee_Weapon_Mastery_ztxLYzo1ADCaRupR.json
+++ b/src/packs/skills/skill_Melee_Weapon_Mastery_ztxLYzo1ADCaRupR.json
@@ -194,7 +194,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Mirage_mqwu1cSVPhWdT2Mt.json
+++ b/src/packs/skills/skill_Mirage_mqwu1cSVPhWdT2Mt.json
@@ -223,7 +223,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Mulligan_ry0CUZsygSpySLBZ.json
+++ b/src/packs/skills/skill_Mulligan_ry0CUZsygSpySLBZ.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_My_Trust_In_You_lK9onKSiMuQEe3zd.json
+++ b/src/packs/skills/skill_My_Trust_In_You_lK9onKSiMuQEe3zd.json
@@ -141,7 +141,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Navigator_51Ws5AS0aD5MTJRI.json
+++ b/src/packs/skills/skill_Navigator_51Ws5AS0aD5MTJRI.json
@@ -221,7 +221,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Painful_Lesson_YkMaFGnNoWMo6k1U.json
+++ b/src/packs/skills/skill_Painful_Lesson_YkMaFGnNoWMo6k1U.json
@@ -210,7 +210,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Pathogenesis_EBbeGD1rgPmN6Y6R.json
+++ b/src/packs/skills/skill_Pathogenesis_EBbeGD1rgPmN6Y6R.json
@@ -240,7 +240,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Personal_Touch_nAX4AsRoQhmO6gnf.json
+++ b/src/packs/skills/skill_Personal_Touch_nAX4AsRoQhmO6gnf.json
@@ -138,7 +138,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Personal_Vehicle_wGzSaXFjLlQIAAxk.json
+++ b/src/packs/skills/skill_Personal_Vehicle_wGzSaXFjLlQIAAxk.json
@@ -134,7 +134,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Persuasive_GjmqoWAJ4szsk0om.json
+++ b/src/packs/skills/skill_Persuasive_GjmqoWAJ4szsk0om.json
@@ -135,7 +135,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Potion_Rain_xzyAHegWwSaysYqV.json
+++ b/src/packs/skills/skill_Potion_Rain_xzyAHegWwSaysYqV.json
@@ -228,7 +228,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Private_Stock_cjo6RghyGPUwvo1N.json
+++ b/src/packs/skills/skill_Private_Stock_cjo6RghyGPUwvo1N.json
@@ -76,7 +76,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Protect_Z4WIA15aR4uLL5ES.json
+++ b/src/packs/skills/skill_Protect_Z4WIA15aR4uLL5ES.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Provoke_XaopYEAay9e86srI.json
+++ b/src/packs/skills/skill_Provoke_XaopYEAay9e86srI.json
@@ -231,7 +231,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Psychic_Gifts_uiXJvj0qK0pVfnwY.json
+++ b/src/packs/skills/skill_Psychic_Gifts_uiXJvj0qK0pVfnwY.json
@@ -231,7 +231,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Psychokinesis_eU0lW3S2AcGj8BoD.json
+++ b/src/packs/skills/skill_Psychokinesis_eU0lW3S2AcGj8BoD.json
@@ -129,7 +129,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Queen_s_Gambit_HC27DMHBE4M54y6Y.json
+++ b/src/packs/skills/skill_Queen_s_Gambit_HC27DMHBE4M54y6Y.json
@@ -139,7 +139,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Quick_Assessment_YiBD86tGOvFSlaZ6.json
+++ b/src/packs/skills/skill_Quick_Assessment_YiBD86tGOvFSlaZ6.json
@@ -223,7 +223,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Quick_Change_DF1eCfsBw1kYOAH6.json
+++ b/src/packs/skills/skill_Quick_Change_DF1eCfsBw1kYOAH6.json
@@ -137,7 +137,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ranged_Weapon_Mastery_0UxTgrag7cE4M1oc.json
+++ b/src/packs/skills/skill_Ranged_Weapon_Mastery_0UxTgrag7cE4M1oc.json
@@ -196,7 +196,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Real_Treasure_lFYCdvybWS7x8e6L.json
+++ b/src/packs/skills/skill_Real_Treasure_lFYCdvybWS7x8e6L.json
@@ -76,7 +76,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Resonance_kdL9oQYefqNlWqyD.json
+++ b/src/packs/skills/skill_Resonance_kdL9oQYefqNlWqyD.json
@@ -138,7 +138,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Resourceful_0n8T7U81oNP7yU5X.json
+++ b/src/packs/skills/skill_Resourceful_0n8T7U81oNP7yU5X.json
@@ -144,7 +144,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ripples_ouhN6A6jFZO10eST.json
+++ b/src/packs/skills/skill_Ripples_ouhN6A6jFZO10eST.json
@@ -77,7 +77,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ritual_Arcanism_Jaxs87P2Q8AfKwWO.json
+++ b/src/packs/skills/skill_Ritual_Arcanism_Jaxs87P2Q8AfKwWO.json
@@ -226,7 +226,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ritual_Chimerism_99bT5ymNnmR60Kmf.json
+++ b/src/packs/skills/skill_Ritual_Chimerism_99bT5ymNnmR60Kmf.json
@@ -224,7 +224,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ritual_Elementalism_qgy43lWGmJ2YGhTp.json
+++ b/src/packs/skills/skill_Ritual_Elementalism_qgy43lWGmJ2YGhTp.json
@@ -224,7 +224,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ritual_Entropism_Ko2QCUw6qbxhufwE.json
+++ b/src/packs/skills/skill_Ritual_Entropism_Ko2QCUw6qbxhufwE.json
@@ -224,7 +224,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Ritual_Spiritism_ek0pzfo1bSWGHfzb.json
+++ b/src/packs/skills/skill_Ritual_Spiritism_ek0pzfo1bSWGHfzb.json
@@ -216,7 +216,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Rondo_Of_Nightmare_VSWCJDqDERswimf0.json
+++ b/src/packs/skills/skill_Rondo_Of_Nightmare_VSWCJDqDERswimf0.json
@@ -129,7 +129,8 @@
     "core": {},
     "cf": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Salt_and_Pepper_y6f7BuTvmefliVVD.json
+++ b/src/packs/skills/skill_Salt_and_Pepper_y6f7BuTvmefliVVD.json
@@ -67,7 +67,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Secret_Formula_S64zqBVdaYA3I5LW.json
+++ b/src/packs/skills/skill_Secret_Formula_S64zqBVdaYA3I5LW.json
@@ -259,7 +259,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_See_You_Later_cHKzZJBYjwLuRfDL.json
+++ b/src/packs/skills/skill_See_You_Later_cHKzZJBYjwLuRfDL.json
@@ -136,7 +136,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Shadow_Strike_W5hE9L8x7AsJI7a1.json
+++ b/src/packs/skills/skill_Shadow_Strike_W5hE9L8x7AsJI7a1.json
@@ -131,7 +131,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Siren_s_Song_huB2uoP2PAHoOp8T.json
+++ b/src/packs/skills/skill_Siren_s_Song_huB2uoP2PAHoOp8T.json
@@ -224,7 +224,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Soul_Steal_bpCv5Vkr1aWZiFSw.json
+++ b/src/packs/skills/skill_Soul_Steal_bpCv5Vkr1aWZiFSw.json
@@ -269,7 +269,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Sound_Barrier_9xjUyytWiDxFhqdV.json
+++ b/src/packs/skills/skill_Sound_Barrier_9xjUyytWiDxFhqdV.json
@@ -138,7 +138,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Spell_Mimic_yiX5sLJLKBh3UMmz.json
+++ b/src/packs/skills/skill_Spell_Mimic_yiX5sLJLKBh3UMmz.json
@@ -228,7 +228,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
+++ b/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
@@ -253,7 +253,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Spiritual_Magic_dwVQpxDTOZeNbcjy.json
+++ b/src/packs/skills/skill_Spiritual_Magic_dwVQpxDTOZeNbcjy.json
@@ -140,7 +140,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Stolen_Time_84JARbmkQ5r0j39r.json
+++ b/src/packs/skills/skill_Stolen_Time_84JARbmkQ5r0j39r.json
@@ -219,7 +219,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Strong_Grip_rTqtsfBemOKLgWuN.json
+++ b/src/packs/skills/skill_Strong_Grip_rTqtsfBemOKLgWuN.json
@@ -134,7 +134,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Support_Magic_pIkEDFcA5pnIpsu3.json
+++ b/src/packs/skills/skill_Support_Magic_pIkEDFcA5pnIpsu3.json
@@ -239,7 +239,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Symbolic_Connection_h6ynrwX1sUsBQYAE.json
+++ b/src/packs/skills/skill_Symbolic_Connection_h6ynrwX1sUsBQYAE.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Symbolism_Twj3wpoMzSpUE3Go.json
+++ b/src/packs/skills/skill_Symbolism_Twj3wpoMzSpUE3Go.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Tavern_Talk_CHMsojkTh3fU8HXg.json
+++ b/src/packs/skills/skill_Tavern_Talk_CHMsojkTh3fU8HXg.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Theriomorphosis_pmwdU2AGU0JtrWw8.json
+++ b/src/packs/skills/skill_Theriomorphosis_pmwdU2AGU0JtrWw8.json
@@ -209,7 +209,8 @@
   ],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Trained_Memory_NseNebtgAwSF7pM6.json
+++ b/src/packs/skills/skill_Trained_Memory_NseNebtgAwSF7pM6.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Trap_Card_dHurcgjvmwVBJPvM.json
+++ b/src/packs/skills/skill_Trap_Card_dHurcgjvmwVBJPvM.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Traveling_Cook_EU5astEIUK1d8Qk3.json
+++ b/src/packs/skills/skill_Traveling_Cook_EU5astEIUK1d8Qk3.json
@@ -72,7 +72,8 @@
   "effects": [],
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Treasure_Hunter_rsGhkElIiEBgN5zA.json
+++ b/src/packs/skills/skill_Treasure_Hunter_rsGhkElIiEBgN5zA.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Tree_of_Life_LldlV87wO5Tqnl4L.json
+++ b/src/packs/skills/skill_Tree_of_Life_LldlV87wO5Tqnl4L.json
@@ -77,7 +77,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Unexpected_Ally_ucCrtRAvv2qX8aJO.json
+++ b/src/packs/skills/skill_Unexpected_Ally_ucCrtRAvv2qX8aJO.json
@@ -136,7 +136,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Verdant_Sway_ilAq8Q2OSE3oCVdi.json
+++ b/src/packs/skills/skill_Verdant_Sway_ilAq8Q2OSE3oCVdi.json
@@ -164,7 +164,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Vibrato_pQVuklFnMKXxHTFr.json
+++ b/src/packs/skills/skill_Vibrato_pQVuklFnMKXxHTFr.json
@@ -127,7 +127,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Visionary_6pJAB6E29I15q1gU.json
+++ b/src/packs/skills/skill_Visionary_6pJAB6E29I15q1gU.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Vismagus_affUHtuCYoDxmO4h.json
+++ b/src/packs/skills/skill_Vismagus_affUHtuCYoDxmO4h.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Wardancer_L4LqyZu7NPjavyaf.json
+++ b/src/packs/skills/skill_Wardancer_L4LqyZu7NPjavyaf.json
@@ -231,7 +231,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Warning_Shot_Ovmw7cMrN6qvagG4.json
+++ b/src/packs/skills/skill_Warning_Shot_Ovmw7cMrN6qvagG4.json
@@ -179,7 +179,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Well_Traveled_fuPzuDHzaKUgbvL2.json
+++ b/src/packs/skills/skill_Well_Traveled_fuPzuDHzaKUgbvL2.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Wellspring_Expansion_HlSeaheZt8969qI7.json
+++ b/src/packs/skills/skill_Wellspring_Expansion_HlSeaheZt8969qI7.json
@@ -196,7 +196,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Winds_of_Trade_zXB7pBEv1JED1xkh.json
+++ b/src/packs/skills/skill_Winds_of_Trade_zXB7pBEv1JED1xkh.json
@@ -76,7 +76,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/skill_Withstand_OW3xxi09kANGy2ZO.json
+++ b/src/packs/skills/skill_Withstand_OW3xxi09kANGy2ZO.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Acceleration_odCKj31VovzmcEUw.json
+++ b/src/packs/skills/spell_Acceleration_odCKj31VovzmcEUw.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Anomaly_ztNmooCW5dwZqwPx.json
+++ b/src/packs/skills/spell_Anomaly_ztNmooCW5dwZqwPx.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Aura_jd9jMsj2PNq99M64.json
+++ b/src/packs/skills/spell_Aura_jd9jMsj2PNq99M64.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Awaken_NfVMYKMJ8Qp1DHJL.json
+++ b/src/packs/skills/spell_Awaken_NfVMYKMJ8Qp1DHJL.json
@@ -135,7 +135,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Barrier_pGDJPfT1bc2vErY9.json
+++ b/src/packs/skills/spell_Barrier_pGDJPfT1bc2vErY9.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Boulder_7i3Zat2ctLyi1z8l.json
+++ b/src/packs/skills/spell_Boulder_7i3Zat2ctLyi1z8l.json
@@ -128,7 +128,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Cleanse_YIxwINZ4z4p04H8n.json
+++ b/src/packs/skills/spell_Cleanse_YIxwINZ4z4p04H8n.json
@@ -211,7 +211,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Dark_Weapon_S5jyPShQHxqZdKZB.json
+++ b/src/packs/skills/spell_Dark_Weapon_S5jyPShQHxqZdKZB.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Divination_AAsEhxIBxlig3hRk.json
+++ b/src/packs/skills/spell_Divination_AAsEhxIBxlig3hRk.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Drain_Spirit_300SqWOqTrc7Qb3L.json
+++ b/src/packs/skills/spell_Drain_Spirit_300SqWOqTrc7Qb3L.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Drain_Vigor_HCknXFHu7q0bJ2Cg.json
+++ b/src/packs/skills/spell_Drain_Vigor_HCknXFHu7q0bJ2Cg.json
@@ -131,7 +131,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Elemental_Shroud_eJMcolfWWUBU4oWA.json
+++ b/src/packs/skills/spell_Elemental_Shroud_eJMcolfWWUBU4oWA.json
@@ -149,7 +149,8 @@
       }
     },
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Elemental_Weapon_GLQMtlajiccDx6oY.json
+++ b/src/packs/skills/spell_Elemental_Weapon_GLQMtlajiccDx6oY.json
@@ -129,7 +129,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Enrage_tUIUOqw8U9flVYFn.json
+++ b/src/packs/skills/spell_Enrage_tUIUOqw8U9flVYFn.json
@@ -133,7 +133,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Flare_WLzrT6tVslNHrQZA.json
+++ b/src/packs/skills/spell_Flare_WLzrT6tVslNHrQZA.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Fulgur_aFLirnrD8OYJOz5O.json
+++ b/src/packs/skills/spell_Fulgur_aFLirnrD8OYJOz5O.json
@@ -129,7 +129,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Glacies_yiIuMcjHsK0ch1Fh.json
+++ b/src/packs/skills/spell_Glacies_yiIuMcjHsK0ch1Fh.json
@@ -129,7 +129,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Hallucination_JTyMViMTOUrc7bms.json
+++ b/src/packs/skills/spell_Hallucination_JTyMViMTOUrc7bms.json
@@ -133,7 +133,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Heal_uQd6aE423mPv12Vc.json
+++ b/src/packs/skills/spell_Heal_uQd6aE423mPv12Vc.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Iceberg_sB647bIQ23qlvgGg.json
+++ b/src/packs/skills/spell_Iceberg_sB647bIQ23qlvgGg.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Ignis_smvo8sxjGdaHFgtl.json
+++ b/src/packs/skills/spell_Ignis_smvo8sxjGdaHFgtl.json
@@ -129,7 +129,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Lux_c73bNM930l9ZUJZh.json
+++ b/src/packs/skills/spell_Lux_c73bNM930l9ZUJZh.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Mercy_puwGwI8mNZeDo7Il.json
+++ b/src/packs/skills/spell_Mercy_puwGwI8mNZeDo7Il.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Mirror_mPwO3kzv6N1P1kiD.json
+++ b/src/packs/skills/spell_Mirror_mPwO3kzv6N1P1kiD.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Omega_XJM910rLM6sj55Uf.json
+++ b/src/packs/skills/spell_Omega_XJM910rLM6sj55Uf.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Reinforce_ZxDpmAqbYQqDULxd.json
+++ b/src/packs/skills/spell_Reinforce_ZxDpmAqbYQqDULxd.json
@@ -137,7 +137,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Soaring_Strike_YNo4gKczuJWRKPJ9.json
+++ b/src/packs/skills/spell_Soaring_Strike_YNo4gKczuJWRKPJ9.json
@@ -128,7 +128,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Soul_Shroud_W2jMFJBOausmpSOY.json
+++ b/src/packs/skills/spell_Soul_Shroud_W2jMFJBOausmpSOY.json
@@ -133,7 +133,8 @@
   },
   "flags": {
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Soul_Weapon_74xXBzLlG5C0hTf9.json
+++ b/src/packs/skills/spell_Soul_Weapon_74xXBzLlG5C0hTf9.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Stop_MWL6NbfZjFkcQ4oC.json
+++ b/src/packs/skills/spell_Stop_MWL6NbfZjFkcQ4oC.json
@@ -132,7 +132,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Terra_VtuW7j5FAIWw56gi.json
+++ b/src/packs/skills/spell_Terra_VtuW7j5FAIWw56gi.json
@@ -131,7 +131,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Thunderbolt_jZRTJfKbjPzSvKV4.json
+++ b/src/packs/skills/spell_Thunderbolt_jZRTJfKbjPzSvKV4.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Torpor_9ENpDMvIOH9FJAka.json
+++ b/src/packs/skills/spell_Torpor_9ENpDMvIOH9FJAka.json
@@ -133,7 +133,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Umbra_q0iHNjkDnWaQJgZN.json
+++ b/src/packs/skills/spell_Umbra_q0iHNjkDnWaQJgZN.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Ventus_czRvhEWniKUB6B1K.json
+++ b/src/packs/skills/spell_Ventus_czRvhEWniKUB6B1K.json
@@ -129,7 +129,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/skills/spell_Vortex_uw114Kvtwea82d2X.json
+++ b/src/packs/skills/spell_Vortex_uw114Kvtwea82d2X.json
@@ -130,7 +130,8 @@
   "flags": {
     "core": {},
     "projectfu": {
-      "favorite": false
+      "favorite": false,
+      "classConverted": true
     }
   },
   "_stats": {

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Chanter_0s0E8qJzRRLtQstc.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Chanter_0s0E8qJzRRLtQstc.json
@@ -95,7 +95,8 @@
         "sort": 100000,
         "flags": {
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -185,7 +186,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "xrFNIw9Qwn9gZskX",
@@ -275,7 +277,8 @@
         "sort": 200000,
         "flags": {
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -363,7 +366,8 @@
         "sort": 500000,
         "flags": {
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       }

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Chimerist_KCXzvuZQnzva9t5Z.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Chimerist_KCXzvuZQnzva9t5Z.json
@@ -195,7 +195,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -284,7 +285,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -471,7 +473,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -641,7 +644,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Commander_RjSF6u0HLGKS3Q2o.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Commander_RjSF6u0HLGKS3Q2o.json
@@ -98,7 +98,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -189,7 +190,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -398,7 +400,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -490,7 +493,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -579,7 +583,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Dancer_hnDaUnmUKiCXBmcV.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Dancer_hnDaUnmUKiCXBmcV.json
@@ -94,7 +94,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "n8liOYfNohtGSGUx",
@@ -183,7 +184,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "ZzkZnbOeEtZGK9gW",
@@ -358,7 +360,8 @@
         "sort": 150000,
         "flags": {
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -446,7 +449,8 @@
         "sort": 200000,
         "flags": {
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -619,7 +623,8 @@
         "sort": 300000,
         "flags": {
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       }

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Elementalist_OPLZ5iJop7M93Lj2.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Elementalist_OPLZ5iJop7M93Lj2.json
@@ -203,7 +203,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 100000
@@ -293,7 +294,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "ZS5VSZoTggQTGWdw",
@@ -467,7 +469,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "VvMO7aYoag7O8mjI",
@@ -672,7 +675,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 500000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Entropist_r0Lrj12njZdHkYFH.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Entropist_r0Lrj12njZdHkYFH.json
@@ -166,7 +166,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "iRCiVzzmTfukf5bf",
@@ -257,7 +258,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "HxJCfEZhjcRdebb2",
@@ -347,7 +349,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 700000
@@ -508,7 +511,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 800000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Esper_JYVcIbnKAIA3m9yw.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Esper_JYVcIbnKAIA3m9yw.json
@@ -277,7 +277,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "EjarmObI7ZhvRqhz",
@@ -499,7 +500,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "XFP606KAwDeeQ7gC",
@@ -680,7 +682,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "yJDa3pqtwkeYYXtZ",
@@ -769,7 +772,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "P7U5SAmR6rKSOON3",

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Fury_mGIGIh8tCtRpjLnE.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Fury_mGIGIh8tCtRpjLnE.json
@@ -154,7 +154,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "8Xd9KbHtSG3PT5YA",
@@ -313,7 +314,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 200000
@@ -402,7 +404,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 300000
@@ -573,7 +576,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 400000
@@ -662,7 +666,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 500000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Guardian_F3CmT3BlrVeByCE1.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Guardian_F3CmT3BlrVeByCE1.json
@@ -95,7 +95,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 100000
@@ -244,7 +245,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 200000
@@ -333,7 +335,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 300000
@@ -479,7 +482,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "PcZ128mqed6ahFlc",
@@ -569,7 +573,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 500000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -376,7 +376,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -465,7 +466,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -630,7 +632,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -719,7 +722,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -186,7 +186,8 @@
 			"flags": {
 				"core": {},
 				"projectfu": {
-					"favorite": false
+					"favorite": false,
+          "classConverted": true
 				}
 			},
 			"sort": 0

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Orator_Sctj8Lkl6vbBYuCR.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Orator_Sctj8Lkl6vbBYuCR.json
@@ -178,7 +178,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -272,7 +273,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -361,7 +363,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -450,7 +453,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0
@@ -539,7 +543,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 0

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Rogue_aw8bgj0XVRXmdTtU.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Rogue_aw8bgj0XVRXmdTtU.json
@@ -197,7 +197,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 100000
@@ -338,7 +339,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -497,7 +499,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 375000
@@ -586,7 +589,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 400000
@@ -822,7 +826,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 500000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Sharpshooter_ghOpW5JUnPFmTuJn.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Sharpshooter_ghOpW5JUnPFmTuJn.json
@@ -95,7 +95,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 100000
@@ -281,7 +282,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 200000
@@ -370,7 +372,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 300000
@@ -520,7 +523,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -709,7 +713,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 600000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Spiritist_pjn2t5eeCW3MsoMD.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Spiritist_pjn2t5eeCW3MsoMD.json
@@ -190,7 +190,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         }
       },
@@ -280,7 +281,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 300000
@@ -466,7 +468,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 400000
@@ -555,7 +558,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 500000

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Weaponmaster_tOrvGzF8CZEZxFBR.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Weaponmaster_tOrvGzF8CZEZxFBR.json
@@ -95,7 +95,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 100000
@@ -285,7 +286,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 200000
@@ -376,7 +378,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 300000
@@ -568,7 +571,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "sort": 400000
@@ -716,7 +720,8 @@
         "flags": {
           "core": {},
           "projectfu": {
-            "favorite": false
+            "favorite": false,
+            "classConverted": true
           }
         },
         "_id": "4X2OZCEOJcy2wpc1",


### PR DESCRIPTION
Since we updated the Class Attributes to be fu-ids instead of Class Names, this is an automated attempt to convert them to the proper values. When an actor prepares data, it will check all of its Skills, Spells, and Heroics for ones that haven't been converted yet. It will compare the given Class Name to classes to find the class that it should change its fu-id to. It will check the actor's classes, the world's class items, and the class items found in the compendium in that priority order. It will then mark the item as converted with a flag to not attempt again on that item.

Fixed classes to now check for the fu-id instead of class name to count levels. Also changed how the Skill and Spell preview displays to show the name of the class with the matching fu-id on the PC sheet.