### PR TITLE
bugfix: "Check" rule predicate triggers when it should not

### DIFF
--- a/module/documents/effects/predicates/check-rule-predicate.mjs
+++ b/module/documents/effects/predicates/check-rule-predicate.mjs
@@ -159,14 +159,14 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 		}
 
 		// Check attributes
-		const a = [this.attributes.primary.value, this.attributes.secondary.value];
-		const b = context.eventType === FUHooks.PERFORM_CHECK_EVENT ? [check.primary, check.secondary] : [check.primary.attribute, check.secondary.attribute];
-		for (let i = 0; i < a.length; i++) {
-			const attribute = a[i];
+		const predicateAttributes = [this.attributes.primary.value, this.attributes.secondary.value];
+		const checkAttributes = context.eventType === FUHooks.PERFORM_CHECK_EVENT ? [check.primary, check.secondary] : [check.primary.attribute, check.secondary.attribute];
+		for (let i = 0; i < predicateAttributes.length; i++) {
+			const attribute = predicateAttributes[i];
 			if (attribute) {
-				const idx = b.findIndex((value) => value === attribute);
+				const idx = checkAttributes.findIndex((value) => value === attribute);
 				if (idx >= 0) {
-					b.splice(idx, 1);
+					checkAttributes.splice(idx, 1);
 				} else {
 					return false;
 				}

--- a/module/documents/effects/predicates/check-rule-predicate.mjs
+++ b/module/documents/effects/predicates/check-rule-predicate.mjs
@@ -159,18 +159,25 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 		}
 
 		// Check attributes
-		const a = [this.attributes.primary.value, this.attributes.secondary.value].filter(Boolean);
+		const a = [this.attributes.primary.value, this.attributes.secondary.value];
 		const b = context.eventType === FUHooks.PERFORM_CHECK_EVENT ? [check.primary, check.secondary] : [check.primary.attribute, check.secondary.attribute];
-		if (a.length > 0) {
-			if (!a.every((v) => b.includes(v))) {
-				return false;
+		for (let i = 0; i < a.length; i++) {
+			const attribute = a[i];
+			if (attribute) {
+				const idx = b.findIndex((value) => value === attribute);
+				if (idx >= 0) {
+					b.splice(idx, 1);
+				} else {
+					return false;
+				}
 			}
 		}
 
-		// Check result
-		if (this.result != null && check.result <= this.result) {
-			return false;
-		}
+		// FIXME: Rule element workflow cannot access check results because the check has not yet been rolled when the predicate is checked
+		// // Check result
+		// if (this.result != null && check.result <= this.result) {
+		// 	return false;
+		// }
 
 		return true;
 	}

--- a/module/documents/effects/predicates/check-rule-predicate.mjs
+++ b/module/documents/effects/predicates/check-rule-predicate.mjs
@@ -173,11 +173,10 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 			}
 		}
 
-		// FIXME: Rule element workflow cannot access check results because the check has not yet been rolled when the predicate is checked
-		// // Check result
-		// if (this.result != null && check.result <= this.result) {
-		// 	return false;
-		// }
+		// Check result
+		if (this.result != null && check.result <= this.result) {
+			return false;
+		}
 
 		return true;
 	}

--- a/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
+++ b/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
@@ -144,12 +144,15 @@
               "type": "ruleElement",
               "_id": "5qIf7IG9ZAkwVt9R",
               "trigger": {
-                "_id": "gkqkk1BJmj01J9jB",
-                "type": "resolveCheckRuleTrigger",
+                "_id": "N7OFfFMpeQInn2lL",
+                "type": "renderCheckRuleTrigger",
                 "eventRelation": "source",
                 "checkTypes": [
                   "open"
-                ]
+                ],
+                "itemGroups": [],
+                "local": false,
+                "identifier": ""
               },
               "predicates": {
                 "udvpE739WHduDidd": {
@@ -182,6 +185,11 @@
             "current": 0,
             "max": 6,
             "style": "basic"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
           }
         }
       },
@@ -208,8 +216,8 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1770415635015,
-        "modifiedTime": 1770417674691,
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa"
+        "modifiedTime": 1778874903057,
+        "lastModifiedBy": "VpDy3go69LzoCFsX"
       },
       "_key": "!items.effects!J5KbrSiczxizbdM3.45F7umTTsKZUmmgj"
     }

--- a/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
+++ b/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
@@ -145,7 +145,7 @@
               "_id": "5qIf7IG9ZAkwVt9R",
               "trigger": {
                 "_id": "gkqkk1BJmj01J9jB",
-                "type": "renderCheckRuleTrigger",
+                "type": "resolveCheckRuleTrigger",
                 "eventRelation": "source",
                 "checkTypes": [
                   "open"
@@ -170,7 +170,7 @@
                 "OqeboGimrr953F0i": {
                   "type": "messageRuleAction",
                   "_id": "OqeboGimrr953F0i",
-                  "message": "<p>If this was to investigate a creature, item or location <strong>and</strong> you rolled a <strong>13 or higher</strong>, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+                  "message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
                 }
               }
             }

--- a/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
+++ b/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
@@ -170,7 +170,7 @@
                 "OqeboGimrr953F0i": {
                   "type": "messageRuleAction",
                   "_id": "OqeboGimrr953F0i",
-                  "message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+                  "message": "<p>If this was to investigate a creature, item or location <strong>and</strong> you rolled a <strong>13 or higher</strong>, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
                 }
               }
             }

--- a/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
+++ b/src/packs/skills/skill_Flash_of_Insight_J5KbrSiczxizbdM3.json
@@ -145,7 +145,7 @@
               "_id": "5qIf7IG9ZAkwVt9R",
               "trigger": {
                 "_id": "gkqkk1BJmj01J9jB",
-                "type": "performCheckRuleTrigger",
+                "type": "renderCheckRuleTrigger",
                 "eventRelation": "source",
                 "checkTypes": [
                   "open"

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -141,7 +141,7 @@
                       "OqeboGimrr953F0i": {
                         "type": "messageRuleAction",
                         "_id": "OqeboGimrr953F0i",
-                        "message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+                        "message": "<p>If this was to investigate a creature, item or location <strong>and</strong> you rolled a <strong>13 or higher</strong>, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
                       }
                     },
                     "selector": "initial",

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -11,180 +11,187 @@
     "level": 1,
     "maxLevel": 5,
     "items": [
-      {
-        "name": "Flash of Insight",
-        "type": "skill",
-        "_id": "CAxdWJRKIC60zqQu",
-        "img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
-        "system": {
-          "summary": {
-            "value": ""
-          },
-          "description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location — this includes using the <strong>Study</strong> action during a conflict — you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation. You may ask these questions immediately or save them for later; whenever you ask one of these questions, the Game Master will answer truthfully and you will describe your character's deductive process.</p><p>This Skill may only be used once on the same creature, item or location.</p>",
-          "showTitleCard": {
-            "value": false
-          },
-          "level": {
-            "value": 0,
-            "max": 3,
-            "min": 0
-          },
-          "class": {
-            "value": "loremaster"
-          },
-          "useWeapon": {
-            "accuracy": false,
-            "damage": false,
-            "traits": true
-          },
-          "attributes": {
-            "primary": "dex",
-            "secondary": "dex"
-          },
-          "accuracy": "0",
-          "damage": {
-            "hasDamage": false,
-            "value": 0,
-            "type": "physical",
-            "onRoll": "",
-            "onApply": "",
-            "hrZero": false
-          },
-          "source": "FUCR199",
-          "hasRoll": {
-            "value": false
-          },
-          "hasResource": {
-            "value": false
-          },
-          "rp": {
-            "name": "Name",
-            "current": 0,
-            "step": 1,
-            "max": 6,
-            "enabled": false
-          },
-          "defense": "def",
-          "fuid": "flash-of-insight",
-          "targeting": {
-            "rule": "self",
-            "max": 0
-          },
-          "traits": [],
-          "effects": {
-            "entries": [],
-            "prompt": false,
-            "duration": {
-              "event": "",
-              "tracking": "",
-              "interval": null
-            }
-          },
-          "cost": {
-            "resource": "mp",
-            "amount": "",
-            "perTarget": false
-          },
-          "resource": {
-            "enabled": false,
-            "amount": "",
-            "type": "hp"
-          }
-        },
-        "effects": [
-          {
-            "name": "Flash of Insight",
-            "img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
-            "system": {
-              "duration": {
-                "event": "none",
-                "interval": 1,
-                "tracking": "self",
-                "remaining": 1
-              },
-              "type": "default",
-              "predicate": {
-                "crisisInteraction": "none"
-              },
-              "rules": {
-                "elements": {
-                  "5qIf7IG9ZAkwVt9R": {
-                    "type": "ruleElement",
-                    "_id": "5qIf7IG9ZAkwVt9R",
-                    "trigger": {
-                      "_id": "gkqkk1BJmj01J9jB",
-                      "type": "resolveCheckRuleTrigger",
-                      "eventRelation": "source",
-                      "checkTypes": [
-                        "open"
-                      ]
-                    },
-                    "predicates": {
-                      "udvpE739WHduDidd": {
-                        "type": "checkRulePredicate",
-                        "_id": "udvpE739WHduDidd",
-                        "result": 13,
-                        "attributes": {
-                          "primary": {
-                            "value": "ins"
-                          },
-                          "secondary": {
-                            "value": "ins"
-                          }
-                        },
-                        "parity": "",
-                        "outcome": "",
-                        "quantifier": "any"
-                      }
-                    },
-                    "actions": {
-                      "OqeboGimrr953F0i": {
-                        "type": "messageRuleAction",
-                        "_id": "OqeboGimrr953F0i",
-                        "message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
-                      }
-                    },
-                    "selector": "initial",
-                    "enabled": true
-                  }
-                },
-                "progress": {
-                  "enabled": false,
-                  "id": "",
-                  "name": "",
-                  "current": 0,
-                  "max": 6,
-                  "style": "basic",
-                  "step": 1
-                }
-              }
-            },
-            "duration": {
-              "startTime": null,
-              "combat": null
-            },
-            "disabled": false,
-            "_id": "45F7umTTsKZUmmgj",
-            "type": "base",
-            "changes": [],
-            "description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location, you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation.</p>",
-            "origin": null,
-            "tint": "#ffffff",
-            "transfer": true,
-            "statuses": [],
-            "sort": 0,
-            "flags": {}
-          }
-        ],
-        "flags": {
-          "core": {},
-          "projectfu": {
-            "favorite": false
-          }
-        },
-        "sort": 0
-      },
-      {
+		{
+			"name": "Flash of Insight",
+			"type": "skill",
+			"_id": "D4Al2CatwtTnU5tL",
+			"img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
+			"system": {
+				"summary": {
+					"value": ""
+				},
+				"description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location — this includes using the <strong>Study</strong> action during a conflict — you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation. You may ask these questions immediately or save them for later; whenever you ask one of these questions, the Game Master will answer truthfully and you will describe your character's deductive process.</p><p>This Skill may only be used once on the same creature, item or location.</p>",
+				"showTitleCard": {
+					"value": false
+				},
+				"level": {
+					"value": 0,
+					"max": 3,
+					"min": 0
+				},
+				"class": {
+					"value": "loremaster"
+				},
+				"useWeapon": {
+					"accuracy": false,
+					"damage": false,
+					"traits": true
+				},
+				"attributes": {
+					"primary": "dex",
+					"secondary": "dex"
+				},
+				"accuracy": "0",
+				"damage": {
+					"hasDamage": false,
+					"value": 0,
+					"type": "physical",
+					"onRoll": "",
+					"onApply": "",
+					"hrZero": false
+				},
+				"source": "FUCR199",
+				"hasRoll": {
+					"value": false
+				},
+				"hasResource": {
+					"value": false
+				},
+				"rp": {
+					"name": "Name",
+					"current": 0,
+					"step": 1,
+					"max": 6,
+					"enabled": false
+				},
+				"defense": "def",
+				"fuid": "flash-of-insight",
+				"targeting": {
+					"rule": "self",
+					"max": 0
+				},
+				"traits": [],
+				"effects": {
+					"entries": [],
+					"prompt": false,
+					"duration": {
+						"event": "",
+						"tracking": ""
+					}
+				},
+				"cost": {
+					"resource": "mp",
+					"amount": "",
+					"perTarget": false
+				},
+				"resource": {
+					"enabled": false,
+					"amount": "",
+					"type": "hp"
+				}
+			},
+			"effects": [
+				{
+					"name": "Flash of Insight",
+					"img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
+					"system": {
+						"duration": {
+							"event": "none",
+							"interval": 1,
+							"tracking": "self",
+							"remaining": 1
+						},
+						"type": "default",
+						"predicate": {
+							"crisisInteraction": "none"
+						},
+						"rules": {
+							"elements": {
+								"5qIf7IG9ZAkwVt9R": {
+									"type": "ruleElement",
+									"_id": "5qIf7IG9ZAkwVt9R",
+									"trigger": {
+										"_id": "N7OFfFMpeQInn2lL",
+										"type": "renderCheckRuleTrigger",
+										"eventRelation": "source",
+										"checkTypes": [
+											"open"
+										],
+										"itemGroups": [],
+										"local": false,
+										"identifier": ""
+									},
+									"predicates": {
+										"udvpE739WHduDidd": {
+											"type": "checkRulePredicate",
+											"_id": "udvpE739WHduDidd",
+											"result": 13,
+											"attributes": {
+												"primary": {
+													"value": "ins"
+												},
+												"secondary": {
+													"value": "ins"
+												}
+											},
+											"parity": "",
+											"outcome": "",
+											"quantifier": "any"
+										}
+									},
+									"actions": {
+										"OqeboGimrr953F0i": {
+											"type": "messageRuleAction",
+											"_id": "OqeboGimrr953F0i",
+											"message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+										}
+									},
+									"selector": "initial",
+									"enabled": true
+								}
+							},
+							"progress": {
+								"enabled": false,
+								"id": "",
+								"name": "",
+								"current": 0,
+								"max": 6,
+								"style": "basic",
+								"step": 1
+							},
+							"stacking": {
+								"progress": false,
+								"duration": false,
+								"increment": 1
+							}
+						}
+					},
+					"duration": {
+						"startTime": null,
+						"combat": null
+					},
+					"disabled": false,
+					"_id": "45F7umTTsKZUmmgj",
+					"type": "base",
+					"changes": [],
+					"description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location, you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation.</p>",
+					"origin": null,
+					"tint": "#ffffff",
+					"transfer": true,
+					"statuses": [],
+					"sort": 0,
+					"flags": {}
+				}
+			],
+			"flags": {
+				"core": {},
+				"projectfu": {
+					"favorite": false
+				}
+			},
+			"sort": 0
+		},
+		{
         "name": "Focused",
         "type": "skill",
         "_id": "2qECrNCT1GTwpQIs",
@@ -309,7 +316,8 @@
                       "eventRelation": "source",
                       "checkTypes": [
                         "open"
-                      ]
+                      ],
+                      "local": false
                     },
                     "predicates": {
                       "N5FnDMpHmZ4JA6wb": {
@@ -735,8 +743,8 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1745491348230,
-    "modifiedTime": 1776191983126,
-    "lastModifiedBy": "mA8SNY2rY4X5tOHa",
+    "modifiedTime": 1778875058784,
+    "lastModifiedBy": "VpDy3go69LzoCFsX",
     "exportSource": null
   },
   "_key": "!items!oYgcCTfSe0WY87Vp"

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -141,7 +141,7 @@
                       "OqeboGimrr953F0i": {
                         "type": "messageRuleAction",
                         "_id": "OqeboGimrr953F0i",
-						"message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+                        "message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
                       }
                     },
                     "selector": "initial",

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -113,7 +113,7 @@
                     "_id": "5qIf7IG9ZAkwVt9R",
                     "trigger": {
                       "_id": "gkqkk1BJmj01J9jB",
-                      "type": "performCheckRuleTrigger",
+                      "type": "renderCheckRuleTrigger",
                       "eventRelation": "source",
                       "checkTypes": [
                         "open"

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -113,7 +113,7 @@
                     "_id": "5qIf7IG9ZAkwVt9R",
                     "trigger": {
                       "_id": "gkqkk1BJmj01J9jB",
-                      "type": "renderCheckRuleTrigger",
+                      "type": "resolveCheckRuleTrigger",
                       "eventRelation": "source",
                       "checkTypes": [
                         "open"
@@ -141,7 +141,7 @@
                       "OqeboGimrr953F0i": {
                         "type": "messageRuleAction",
                         "_id": "OqeboGimrr953F0i",
-                        "message": "<p>If this was to investigate a creature, item or location <strong>and</strong> you rolled a <strong>13 or higher</strong>, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+						"message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
                       }
                     },
                     "selector": "initial",

--- a/templates/effects/predicates/check-rule-predicate.hbs
+++ b/templates/effects/predicates/check-rule-predicate.hbs
@@ -16,13 +16,10 @@
 </div>
 
 <div class="fu-form__property-row">
-	{{!--
-	<!-- FIXME: Rule element workflow cannot access check results because the check has not yet been rolled when the predicate is checked -->
 	<label class="fu-form__property">
 		<span>{{localize 'FU.Result'}}</span>
 		<input type="number" name="{{pfuConcat path ".result"}}" value="{{ predicate.result }}" />
 	</label>
-	--}}
 
 	<label class="fu-form__property">
 		<span>{{localize 'FU.CheckParity'}}</span>

--- a/templates/effects/predicates/check-rule-predicate.hbs
+++ b/templates/effects/predicates/check-rule-predicate.hbs
@@ -16,10 +16,13 @@
 </div>
 
 <div class="fu-form__property-row">
+	{{!--
+	<!-- FIXME: Rule element workflow cannot access check results because the check has not yet been rolled when the predicate is checked -->
 	<label class="fu-form__property">
 		<span>{{localize 'FU.Result'}}</span>
 		<input type="number" name="{{pfuConcat path ".result"}}" value="{{ predicate.result }}" />
 	</label>
+	--}}
 
 	<label class="fu-form__property">
 		<span>{{localize 'FU.CheckParity'}}</span>


### PR DESCRIPTION
- temporarily remove "result" functionality from CheckRulePredicate, it does not work anyway
- improve 'check attributes' predicate functionality to properly account for duplicate and single attributes
- adjust 'Flash of Insight' notification wording

Related to #1122, but does not fully fix the problem