### PR TITLE
Item transfer via Drag&Drop

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -6,6 +6,7 @@ import { ObjectUtils } from '../helpers/object-utils.mjs';
 import { HTMLUtils } from '../helpers/html-utils.mjs';
 import { createMenuTool, SETTINGS } from '../settings.js';
 import { SYSTEM } from '../helpers/config.mjs';
+import { InventoryPipeline } from '../pipelines/inventory-pipeline.mjs';
 
 const { api, sheets } = foundry.applications;
 
@@ -143,6 +144,11 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 		if (item instanceof PseudoDocument && item.parentFoundryDocument?.parent === this.actor) {
 			const result = await this._onSortItem(event, item);
 			return result?.length ? item : null;
+		}
+
+		if (item instanceof foundry.documents.Item && item.parent && item.parent !== this.actor) {
+			const isShop = item.parent.type === 'stash' && item.parent.system.merchant;
+			return InventoryPipeline.requestTrade(item.parent.uuid, item.uuid, isShop, this.actor.uuid);
 		}
 
 		return super._onDropItem(event, item);


### PR DESCRIPTION
It's a bit of a niche situation but I had several instances where players are owners of both their character and the party actor and trying to transfer items via drag&drop caused the item to be duplicated. With this change the drag&drop workflow causes the item to get traded through the inventory pipeline as usual.