### PR TITLE
bugfix: Inspect button in study chat message only works once

### DIFF
--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -1615,15 +1615,11 @@ async function onRenderChatMessage(message, html) {
 	// Find all elements with data-action="revealNpc"
 	const elements = html.querySelectorAll('[data-action="revealNpc"]');
 	for (const el of elements) {
-		el.addEventListener(
-			'click',
-			async () => {
-				const uuid = el.dataset.uuid;
-				const party = await FUPartySheet.getActive();
-				return party.sheet.revealNpc(uuid);
-			},
-			{ once: true },
-		); // Optionally ensure it only attaches once
+		el.addEventListener('click', async () => {
+			const uuid = el.dataset.uuid;
+			const party = await FUPartySheet.getActive();
+			return party.sheet.revealNpc(uuid);
+		});
 	}
 }
 


### PR DESCRIPTION
- remove `once` option from click listener

This is a safe change because the `renderChatMessageHTML` hook is only called once for each message, except when the message document is mutated.
When the message document is mutated the entire HTML subtree for the message (including event listeners) is replaced with a new one and `renderChatMessageHTML` is called again.