### PR TITLE
bugfix: Damage customizer dialog has incorrect title

### DIFF
--- a/module/pipelines/damage-customizer.mjs
+++ b/module/pipelines/damage-customizer.mjs
@@ -31,7 +31,7 @@ export async function DamageCustomizer(damage, targets, callback, onCancel) {
 	// Create and render the dialog
 	const result = await foundry.applications.api.DialogV2.input({
 		window: {
-			title: game.i18n.localize('FU.AutomationApplyDamage'),
+			title: game.i18n.localize('FU.DamageCustomizer'),
 		},
 		position: {
 			width: 440,

--- a/module/ui/damage-customizer-v2.mjs
+++ b/module/ui/damage-customizer-v2.mjs
@@ -34,7 +34,7 @@ export class DamageCustomizerV2 {
 
 		const result = await foundry.applications.api.DialogV2.input({
 			window: {
-				title: game.i18n.localize('FU.ChatApplyDamage'),
+				title: game.i18n.localize('FU.DamageCustomizer'),
 				icon: 'fas fa-heartbeat',
 			},
 			position: {


### PR DESCRIPTION
- fix damage customizer dialog titles

Both me and my players have been confused by this dialog popping up titled "Apply Damage" when we had not even rolled yet.
This change causes the dialog to be titled "Damage Customizer" or the localized equivalent instead and should cause less confusion going forward.