### PR TITLE
FU.RuleActionNotify i18n key

### DIFF
--- a/templates/effects/actions/update-track-rule-action.hbs
+++ b/templates/effects/actions/update-track-rule-action.hbs
@@ -12,7 +12,7 @@
 	</label>
 
 	<label class="fu-form__property">
-		<span>{{localize 'FU.Notify'}}</span>
+		<span>{{localize 'FU.RuleActionNotify'}}</span>
 		{{formGroup action.schema.fields.notify value=action.notify name=(pfuConcat path ".notify") }}
 	</label>
 </div>


### PR DESCRIPTION
`update-track-rule-action.hbs` was using the incorrect i18n key for its Notify label

<img width="462" height="190" alt="image" src="https://github.com/user-attachments/assets/f313e485-1570-4411-bb15-2047b2e984eb" />
