### PR TITLE
bugfix: Party sheet does not update properly when contained actors are updated

### DIFF
--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -154,6 +154,13 @@ export class FUPartySheet extends FUActorSheet {
 		if (FU.sheetExtensions.party) {
 			this.#extensions = FU.sheetExtensions.party;
 		}
+		Hooks.on('updateActor', (actor) => {
+			const actorUuid = actor.uuid;
+			const { characters, companions } = this.party;
+			if (characters.has(actorUuid) || companions.has(actorUuid)) {
+				this.render();
+			}
+		});
 	}
 
 	/**


### PR DESCRIPTION
- add 'updateActor' hook to rerender party sheet as needed