### PR TITLE
bugfix: Retarget does not revert automatically applied damage

### DIFF
--- a/module/checks/check-retarget.mjs
+++ b/module/checks/check-retarget.mjs
@@ -4,6 +4,8 @@ import { Checks } from './checks.mjs';
 import { getTargeted } from '../helpers/target-handler.mjs';
 import { Targeting } from '../helpers/targeting.mjs';
 import { Pipeline } from '../pipelines/pipeline.mjs';
+import { Flags } from '../helpers/flags.mjs';
+import { SETTINGS } from '../settings.js';
 
 function addRetargetEntry(application, menuItems) {
 	menuItems.unshift({
@@ -41,6 +43,10 @@ async function retarget(messageId) {
 	if (isCheck) {
 		const checkId = CheckConfiguration.inspect(message).getCheck().id;
 		let shouldDelete = false;
+		const relatedMessages = game.messages.filter((message) => {
+			const flag = message.getFlag(SYSTEM, Flags.ChatMessage.Source);
+			return flag && flag.checkId === checkId;
+		});
 		await Checks.modifyCheck(checkId, (check, actor, item) => {
 			/** @type Token[] */
 			const targets = getTargeted(true);
@@ -52,6 +58,11 @@ async function retarget(messageId) {
 			return hasTargets;
 		});
 		if (shouldDelete) {
+			if (game.settings.get(SYSTEM, SETTINGS.automationApplyDamage)) {
+				for (const message of relatedMessages) {
+					ui.chat.element.querySelectorAll(`.chat-log .chat-message[data-message-id="${message.id}"] a[data-action="revertDamage"]`).forEach((el) => el.click());
+				}
+			}
 			// Delete the existing message
 			await message.delete();
 		}

--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -402,8 +402,10 @@ const actions = (data, actor, item, targetData, flags, inspector = undefined) =>
 						if (damageData && game.settings.get(SYSTEM, SETTINGS.automationApplyDamage)) {
 							const traits = inspector.getTraits();
 							setTimeout(() => {
+								const sourceInfo = InlineSourceInfo.fromInstance(actor, item);
+								sourceInfo.checkId = checkData?.id;
 								game.projectfu.socket.requestPipeline('damage', {
-									sourceInfo: InlineSourceInfo.fromInstance(actor, item),
+									sourceInfo: sourceInfo,
 									targets: hitTargets,
 									damageData,
 									traits,

--- a/module/helpers/inline-helper.mjs
+++ b/module/helpers/inline-helper.mjs
@@ -13,14 +13,16 @@ import FoundryUtils from './foundry-utils.mjs';
  * @property {String} actorUuid
  * @property {String} effectUuid
  * @property {String} fuid If an item is provided, used for referencing it from the compendium.
+ * @property {String} checkId
  */
 export class InlineSourceInfo {
-	constructor(name, actorUuid, itemUuid, effectUuid, fuid) {
+	constructor(name, actorUuid, itemUuid, effectUuid, fuid, checkId) {
 		this.name = name;
 		this.actorUuid = actorUuid;
 		this.itemUuid = itemUuid;
 		this.effectUuid = effectUuid;
 		this.fuid = fuid;
+		this.checkId = checkId;
 	}
 
 	/**
@@ -65,7 +67,7 @@ export class InlineSourceInfo {
 	 * @returns {InlineSourceInfo}
 	 */
 	static fromObject(obj) {
-		return new InlineSourceInfo(obj.name, obj.actorUuid, obj.itemUuid);
+		return new InlineSourceInfo(obj.name, obj.actorUuid, obj.itemUuid, obj.effectUuid, obj.fuid, obj.checkId);
 	}
 
 	/**
@@ -167,6 +169,7 @@ function determineSource(document, element) {
 	let itemUuid = null;
 	let actorUuid = null;
 	let effectUuid = null;
+	let checkId = null;
 	let fuid = element?.dataset?.fuid;
 
 	// ACTOR SHEET
@@ -241,6 +244,7 @@ function determineSource(document, element) {
 		else {
 			const check = document.getFlag(SYSTEM, Flags.ChatMessage.Check);
 			if (check) {
+				checkId = check.id;
 				itemUuid = check.itemUuid;
 				if (check.itemName) {
 					name = check.itemName;
@@ -268,7 +272,7 @@ function determineSource(document, element) {
 			}
 		}
 	}
-	return new InlineSourceInfo(name, actorUuid, itemUuid, effectUuid, fuid);
+	return new InlineSourceInfo(name, actorUuid, itemUuid, effectUuid, fuid, checkId);
 }
 
 /**


### PR DESCRIPTION
- add auto-revert logic to check-retarget.mjs
- add 'checkId' field to InlineSourceInfo

fixes #1089 

I know this is a bit of a hacky solution with the `element.click()` but I did not want to start refactoring the pipelines for this.