### PR TITLE
bugfix: Malformed HTML in Zero Power descriptions can break preview in feature table

### DIFF
--- a/templates/optional/zeropower/feature-zeroPower-preview.hbs
+++ b/templates/optional/zeropower/feature-zeroPower-preview.hbs
@@ -1,4 +1,4 @@
-<div class="item-lg" data-tooltip="{{{system.data.zeroTrigger.description}}}">{{ item.system.data.zeroTrigger.value }}</div>
-<div class="item-lg" data-tooltip="{{{system.data.zeroEffect.description}}}">{{ item.system.data.zeroEffect.value }}</div>
+<div class="item-lg" data-tooltip="<aside>{{{system.data.zeroTrigger.description}}}</aside>">{{ item.system.data.zeroTrigger.value }}</div>
+<div class="item-lg" data-tooltip="<aside>{{{system.data.zeroEffect.description}}}</aside>">{{ item.system.data.zeroEffect.value }}</div>
 {{!-- Clocks --}}
 {{pfuProgress item 'system.data.progress' type='featureCounter'}}


### PR DESCRIPTION
- wrap tooltips in `<aside>` to mitigate malformed HTML. While `<aside>` is a legal tag for prosemirror content there is no way to create them through the editor UI as far as I know.