### PR TITLE
Compendium browser class list localization

### DIFF
--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -45,7 +45,9 @@ class SkillsCompendiumTableRenderer extends CompendiumTableRenderer {
 			name: CommonColumns.itemAnchorColumn({ columnName: 'FU.Name' }),
 			sl: CommonColumns.propertyColumn('FU.SkillLevel', 'system.level.max'),
 			class: CommonColumns.propertyColumn('FU.Class', 'system.class.value', {
-				mapFunction: (value) => StringUtils.titleToKebab(value),
+				mapFunction: (value) => {
+					return CompendiumIndex.instance.getItemByFuidSync(value)?.name ?? StringUtils.titleToKebab(value);
+				},
 			}),
 		},
 	};
@@ -62,7 +64,11 @@ class SpellsCompendiumTableRenderer extends CompendiumTableRenderer {
 				localizationRecord: FU.duration,
 			}),
 			cost: CommonColumns.propertyColumn('FU.Cost', 'system.cost.amount'),
-			class: CommonColumns.propertyColumn('FU.Class', 'system.class.value'),
+			class: CommonColumns.propertyColumn('FU.Class', 'system.class.value', {
+				mapFunction: (value) => {
+					return CompendiumIndex.instance.getItemByFuidSync(value)?.name ?? StringUtils.titleToKebab(value);
+				},
+			}),
 		},
 	};
 }

--- a/module/ui/compendium/compendium-index.mjs
+++ b/module/ui/compendium/compendium-index.mjs
@@ -189,6 +189,14 @@ export class CompendiumIndex {
 		if (!this.#itemsByType || force) {
 			this.#itemsByType = await this.getEntries('Item', null, Object.values(CompendiumIndex.itemFields));
 		}
+		if (!this.#itemsByFuid || force) {
+			// const entries = await this.getEntries('Item', null, Object.values(CompendiumIndex.itemFields));
+			this.#itemsByFuid = Object.fromEntries(
+				Object.values(this.#itemsByType)
+					.flat()
+					.map((item) => [item.system.fuid, item]),
+			);
+		}
 		return this.#itemsByType;
 	}
 
@@ -210,6 +218,18 @@ export class CompendiumIndex {
 		}
 
 		return this.#itemsByFuid[fuid] ?? null;
+	}
+
+	/**
+	 *
+	 * @param {string} fuid A unique identifier used by the system
+	 * @returns {CompendiumIndexEntry} A compendium index entry
+	 * @remarks This version of the function will *not* load the index if it isn't already.
+	 * @see {@link getItemByFuid}
+	 */
+	getItemByFuidSync(fuid) {
+		if (!this.#itemsByFuid) return undefined;
+		return this.#itemsByFuid[fuid];
 	}
 
 	/**


### PR DESCRIPTION
This change will display the 'class' column for skills and spells with the actual proper name of the class, rather than the fuid
<img width="530" height="364" alt="image" src="https://github.com/user-attachments/assets/c4a5f1c0-d8af-4ab6-932e-7ea516dcb25e" />

It also adds a `getItemByFuidSync` function to the CompendiumIndex class, to facilitate finding items already cached by fuid.

Partly addresses #1037 