### PR TITLE
Removed Old Inaccurate Data From Use Weapon Skills

### DIFF
--- a/src/packs/skills/skill_Breach_WZDdQfw9VF64La2P.json
+++ b/src/packs/skills/skill_Breach_WZDdQfw9VF64La2P.json
@@ -5,19 +5,10 @@
   "_id": "WZDdQfw9VF64La2P",
   "img": "systems/projectfu/styles/static/compendium/classes/weaponmaster/weaponmaster_breach.png",
   "system": {
-    "subtype": {
-      "value": ""
-    },
     "summary": {
       "value": ""
     },
-    "description": "<p>You may use an action and spend 5 Mind Points to perform a <strong>free attack</strong> with a <strong>melee</strong> weapon you have equipped. This attack must target <strong>a single creature</strong>. If the attack is successful, it deals no damage and you choose one option:</p><ul><li><p>You destroy one <strong>shield</strong> equipped by the target.</p></li><li><p>You destroy the target’s equipped <strong>armor</strong>.</p></li><li><p>All sources deal <strong>【SL × 2】</strong> extra damage to the target until the start of your next turn.</p></li></ul>",
-    "isFavored": {
-      "value": false
-    },
-    "showTitleCard": {
-      "value": false
-    },
+    "description": "<p>You may use an action and spend 5 Mind Points to perform a <strong>free attack</strong> with a <strong>melee</strong> weapon you have equipped. This attack must target <strong>a single creature</strong>. If the attack is successful, it deals no damage and you choose one option:</p><ul><li><p>You destroy one <strong>shield</strong> equipped by the target.</p></li><li><p>You destroy the target's equipped <strong>armor</strong>.</p></li><li><p>All sources deal <strong>【SL × 2】</strong> extra damage to the target until the start of your next turn.</p></li></ul>",
     "level": {
       "value": 1,
       "max": 3,
@@ -27,84 +18,20 @@
       "value": "weaponmaster"
     },
     "useWeapon": {
-      "accuracy": {
-        "value": false
-      },
-      "damage": {
-        "value": false
-      },
-      "hrZero": {
-        "value": false
-      }
-    },
-    "attributes": {
-      "primary": {
-        "value": "mig"
-      },
-      "secondary": {
-        "value": "mig"
-      }
+      "accuracy": true,
+      "damage": false
     },
     "accuracy": {
       "value": 0
     },
     "damage": {
-      "hasDamage": {
-        "value": false
-      },
+      "hasDamage": false,
       "value": 0,
-      "type": {
-        "value": "physical"
-      },
+      "type": "physical",
       "onRoll": "",
       "onApply": ""
     },
-    "impdamage": {
-      "hasImpDamage": {
-        "value": false
-      },
-      "value": 0,
-      "impType": {
-        "value": "minor"
-      },
-      "type": {
-        "value": "physical"
-      }
-    },
     "source": "FUCR219",
-    "rollInfo": {
-      "useWeapon": {
-        "hrZero": {
-          "value": false
-        },
-        "accuracy": {
-          "value": true
-        },
-        "damage": {
-          "value": false
-        }
-      },
-      "attributes": {
-        "primary": {
-          "value": "dex"
-        },
-        "secondary": {
-          "value": "dex"
-        }
-      },
-      "accuracy": {
-        "value": 0
-      },
-      "damage": {
-        "hasDamage": {
-          "value": false
-        },
-        "type": {
-          "value": "physical"
-        },
-        "value": 0
-      }
-    },
     "hasRoll": {
       "value": true
     },
@@ -132,6 +59,9 @@
       "duration": {
         "interval": null
       }
+    },
+    "showTitleCard": {
+      "value": false
     }
   },
   "effects": [],
@@ -152,7 +82,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706514105557,
-    "modifiedTime": 1775597132829,
+    "modifiedTime": 1779262452093,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Cooking_SkhjmD8IDm1yff3e.json
+++ b/src/packs/skills/skill_Cooking_SkhjmD8IDm1yff3e.json
@@ -4,14 +4,10 @@
   "type": "skill",
   "img": "systems/projectfu/styles/static/compendium/classes/gourmet/cooking.png",
   "system": {
-    "subtype": {},
     "summary": {
       "value": ""
     },
-    "description": "<p><span>When you </span><strong>rest</strong><span> inside a settlement, you gain <strong>【SL】 ingredients</strong></span>.</p><p>You may use an action and combine <strong>2 or 3 ingredients</strong> to prepare a <strong>delicacy</strong> and choose one option: you apply its effects to yourself or an ally you can see; <strong>or</strong> you perform a <strong>free attack</strong> with a weapon you have equipped. This attack deals no damage, but you apply the delicacy's effects to each enemy hit by the attack.</p><p>You may carry <strong>up to 10 +【SL × 5】ingredients</strong>, and they <strong>will never spoil until you use them</strong>; if you take this Skill during character creation, you begin play with <strong>ten </strong>ingredients with random tastes.</p><hr /><p>For <strong>cooking</strong> breakdown and a list of <strong>Ingredients &amp; Delicacies</strong>, refer to: @UUID[Compendium.projectfu.handouts.JournalEntry.vsXmQQBeh7FSTCc4]{Gourmet Rules} or see <strong>Natural Fantasy Atlas</strong>, page <strong>150</strong>.<br />To <strong>automate</strong>, VTT Instructions can be found here: @UUID[Compendium.projectfu.handouts.JournalEntry.vsXmQQBeh7FSTCc4.JournalEntryPage.fDzgptyBKkS5y2YY]{Cookbook VTT Instructions}</p>",
-    "isFavored": {
-      "value": false
-    },
+    "description": "<p><span>When you </span><strong>rest</strong><span> inside a settlement, you gain <strong>【SL】 ingredients</strong></span>.</p><p>You may use an action and combine <strong>2 or 3 ingredients</strong> to prepare a <strong>delicacy</strong> and choose one option: you apply its effects to yourself or an ally you can see; <strong>or</strong> you perform a <strong>free attack</strong> with a weapon you have equipped. This attack deals no damage, but you apply the delicacy's effects to each enemy hit by the attack.</p><p>You may carry <strong>up to 10 +【SL × 5】ingredients</strong>, and they <strong>will never spoil until you use them</strong>; if you take this Skill during character creation, you begin play with <strong>ten</strong> ingredients with random tastes.</p><hr /><p>For <strong>cooking</strong> breakdown and a list of <strong>Ingredients &amp; Delicacies</strong>, refer to: @UUID[Compendium.projectfu.handouts.JournalEntry.vsXmQQBeh7FSTCc4]{Gourmet Rules} or see <strong>Natural Fantasy Atlas</strong>, page <strong>150</strong>.<br />To <strong>automate</strong>, VTT Instructions can be found here: @UUID[Compendium.projectfu.handouts.JournalEntry.vsXmQQBeh7FSTCc4.JournalEntryPage.fDzgptyBKkS5y2YY]{Cookbook VTT Instructions}</p>",
     "showTitleCard": {
       "value": false
     },
@@ -27,10 +23,6 @@
       "accuracy": true,
       "damage": false
     },
-    "attributes": {
-      "primary": "ins",
-      "secondary": "mig"
-    },
     "accuracy": 0,
     "defense": "",
     "damage": {
@@ -39,7 +31,7 @@
       "type": "untyped",
       "onRoll": "",
       "onApply": "",
-      "hrZero": true
+      "hrZero": false
     },
     "hasResource": {
       "value": false
@@ -83,7 +75,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676964457,
-    "modifiedTime": 1775546574504,
+    "modifiedTime": 1779263078128,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/skills/skill_Counterattack_XhcTVGtGEk7L2Ddq.json
+++ b/src/packs/skills/skill_Counterattack_XhcTVGtGEk7L2Ddq.json
@@ -27,15 +27,12 @@
       "value": "weaponmaster"
     },
     "useWeapon": {
-      "accuracy": {
-        "value": false
-      },
-      "damage": {
-        "value": false
-      },
+      "accuracy": true,
+      "damage": true,
       "hrZero": {
         "value": false
-      }
+      },
+      "traits": true
     },
     "attributes": {
       "primary": {
@@ -49,13 +46,12 @@
       "value": 0
     },
     "damage": {
-      "hasDamage": {
-        "value": false
-      },
+      "hasDamage": true,
       "value": 0,
       "type": "",
       "onRoll": "",
-      "onApply": ""
+      "onApply": "",
+      "hrZero": true
     },
     "impdamage": {
       "hasImpDamage": {
@@ -244,7 +240,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706514121336,
-    "modifiedTime": 1778089801732,
+    "modifiedTime": 1779263144068,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Hawkeye_hmDCgX5OEk5l4uXW.json
+++ b/src/packs/skills/skill_Hawkeye_hmDCgX5OEk5l4uXW.json
@@ -5,16 +5,10 @@
   "_id": "hmDCgX5OEk5l4uXW",
   "img": "systems/projectfu/styles/static/compendium/classes/sharpshooter/sharpshooter_hawkeye.png",
   "system": {
-    "subtype": {
-      "value": ""
-    },
     "summary": {
       "value": ""
     },
     "description": "<p>When you perform the <strong>Guard</strong> action, if you choose <strong>not</strong> to provide cover to another creature, you may choose one option:</p><ul><li><p>The next <strong>ranged</strong> attack you perform before the end of the current scene will deal <strong>【SL × 3】</strong> extra damage.</p></li><li><p>You may immediately perform a <strong>free attack</strong> with a <strong>bow</strong> or <strong>firearm</strong> you have equipped, treating your <strong>High Roll</strong> as <strong>0</strong> when calculating damage dealt by this attack.</p></li></ul><hr /><p><strong>You Receive:</strong> @EFFECT[Compendium.projectfu.skills.Item.enboiNabyACt4OUB]</p>",
-    "isFavored": {
-      "value": false
-    },
     "showTitleCard": {
       "value": false
     },
@@ -27,13 +21,9 @@
       "value": "sharpshooter"
     },
     "useWeapon": {
-      "accuracy": {
-        "value": false
-      },
+      "accuracy": true,
       "damage": true,
-      "hrZero": {
-        "value": false
-      }
+      "traits": true
     },
     "attributes": {
       "primary": {
@@ -51,54 +41,10 @@
       "value": 0,
       "type": "",
       "onRoll": "",
-      "onApply": ""
-    },
-    "impdamage": {
-      "hasImpDamage": {
-        "value": false
-      },
-      "value": 0,
-      "impType": {
-        "value": "minor"
-      },
-      "type": {
-        "value": "physical"
-      }
+      "onApply": "",
+      "hrZero": true
     },
     "source": "FUCR205",
-    "rollInfo": {
-      "useWeapon": {
-        "hrZero": {
-          "value": true
-        },
-        "accuracy": {
-          "value": true
-        },
-        "damage": {
-          "value": true
-        }
-      },
-      "attributes": {
-        "primary": {
-          "value": "dex"
-        },
-        "secondary": {
-          "value": "dex"
-        }
-      },
-      "accuracy": {
-        "value": 0
-      },
-      "damage": {
-        "hasDamage": {
-          "value": false
-        },
-        "type": {
-          "value": "physical"
-        },
-        "value": 0
-      }
-    },
     "hasRoll": {
       "value": true
     },
@@ -112,7 +58,12 @@
       "max": 6
     },
     "defense": "",
-    "fuid": "hawkeye"
+    "fuid": "hawkeye",
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    }
   },
   "effects": [],
   "ownership": {
@@ -132,7 +83,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706506760285,
-    "modifiedTime": 1770634023017,
+    "modifiedTime": 1779263107862,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Knife_and_Fork_GJHaSepRfZZ5TRWN.json
+++ b/src/packs/skills/skill_Knife_and_Fork_GJHaSepRfZZ5TRWN.json
@@ -4,14 +4,10 @@
   "type": "skill",
   "img": "systems/projectfu/styles/static/compendium/classes/gourmet/knife_and_fork.png",
   "system": {
-    "subtype": {},
     "summary": {
       "value": ""
     },
     "description": "<p>When you perform the <strong>free attack</strong> granted by the <strong>Cooking</strong> Skill, if you combined <strong>no more than 2 ingredients</strong>, you may have the attack deal damage as normal. If you do, you treat your <strong>High Roll (HR)</strong> as 0 when calculating damage dealt by this attack</p>",
-    "isFavored": {
-      "value": false
-    },
     "showTitleCard": {
       "value": false
     },
@@ -25,11 +21,8 @@
     },
     "useWeapon": {
       "accuracy": true,
-      "damage": true
-    },
-    "attributes": {
-      "primary": "ins",
-      "secondary": "mig"
+      "damage": true,
+      "traits": true
     },
     "accuracy": 0,
     "defense": "",
@@ -62,6 +55,11 @@
     "targeting": {
       "rule": "special",
       "max": 0
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
     }
   },
   "effects": [],
@@ -78,7 +76,7 @@
     "systemId": "projectfu",
     "systemVersion": "#{VERSION}#",
     "createdTime": 1742676964457,
-    "modifiedTime": 1770409639011,
+    "modifiedTime": 1779263095026,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "exportSource": null
   },

--- a/src/packs/skills/skill_Queen_s_Gambit_HC27DMHBE4M54y6Y.json
+++ b/src/packs/skills/skill_Queen_s_Gambit_HC27DMHBE4M54y6Y.json
@@ -5,16 +5,10 @@
   "_id": "HC27DMHBE4M54y6Y",
   "img": "systems/projectfu/styles/static/compendium/classes/commander/commander_queens_gambit.png",
   "system": {
-    "subtype": {
-      "value": ""
-    },
     "summary": {
       "value": ""
     },
-    "description": "<p>During a conflict, you may use an action to perform a <strong>free attack</strong> with a weapon you have equipped, treating your <strong>High Roll (HR)</strong> as 0 when calculating damage. After the attack is resolved, choose one option:</p><ul><li><p>One ally who is able to hear you recovers <strong>【5 + (SL × 5)】</strong> Hit Points.</p></li><li><p>You may immediately use a Skill you acquired among <strong>Bishop’s Edict</strong>, <strong>Charging Cavalry</strong> or <strong>King’s Castle</strong> for free (spending the appropriate MP).</p></li></ul>",
-    "isFavored": {
-      "value": false
-    },
+    "description": "<p>During a conflict, you may use an action to perform a <strong>free attack</strong> with a weapon you have equipped, treating your <strong>High Roll (HR)</strong> as 0 when calculating damage. After the attack is resolved, choose one option:</p><ul><li><p>One ally who is able to hear you recovers <strong>【5 + (SL × 5)】</strong> Hit Points.</p></li><li><p>You may immediately use a Skill you acquired among <strong>Bishop's Edict</strong>, <strong>Charging Cavalry</strong> or <strong>King's Castle</strong> for free (spending the appropriate MP).</p></li></ul>",
     "showTitleCard": {
       "value": false
     },
@@ -27,15 +21,8 @@
       "value": "commander"
     },
     "useWeapon": {
-      "accuracy": {
-        "value": false
-      },
-      "damage": {
-        "value": false
-      },
-      "hrZero": {
-        "value": false
-      }
+      "accuracy": true,
+      "damage": true
     },
     "attributes": {
       "primary": {
@@ -49,60 +36,14 @@
       "value": 0
     },
     "damage": {
-      "hasDamage": {
-        "value": false
-      },
+      "hasDamage": true,
       "value": 0,
       "type": "",
       "onRoll": "",
-      "onApply": ""
-    },
-    "impdamage": {
-      "hasImpDamage": {
-        "value": false
-      },
-      "value": 0,
-      "impType": {
-        "value": "minor"
-      },
-      "type": {
-        "value": "physical"
-      }
+      "onApply": "",
+      "hrZero": true
     },
     "source": "FUHF141",
-    "rollInfo": {
-      "useWeapon": {
-        "hrZero": {
-          "value": true
-        },
-        "accuracy": {
-          "value": true
-        },
-        "damage": {
-          "value": true
-        }
-      },
-      "attributes": {
-        "primary": {
-          "value": "dex"
-        },
-        "secondary": {
-          "value": "dex"
-        }
-      },
-      "accuracy": {
-        "value": 0
-      },
-      "damage": {
-        "hasDamage": {
-          "value": true
-        },
-        "type": {
-          "value": "physical"
-        },
-        "value": 0
-      }
-    },
     "hasRoll": {
       "value": true
     },
@@ -148,7 +89,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706555569192,
-    "modifiedTime": 1771831292694,
+    "modifiedTime": 1779263020954,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Shadow_Strike_W5hE9L8x7AsJI7a1.json
+++ b/src/packs/skills/skill_Shadow_Strike_W5hE9L8x7AsJI7a1.json
@@ -5,16 +5,10 @@
   "_id": "W5hE9L8x7AsJI7a1",
   "img": "systems/projectfu/styles/static/compendium/classes/darkblade/darkblade_shadow_strike.png",
   "system": {
-    "subtype": {
-      "value": ""
-    },
     "summary": {
       "value": ""
     },
-    "description": "<p>You have learned to channel your vital force into your attacks. You may use an action to perform a <strong>Shadow Strike</strong>: roll your current <strong>Might</strong> die and lose an amount of Hit Points equal to <strong>【the number rolled on your Might die】</strong>. If this didn’t reduce your Hit Points to 0, you may perform a <strong>free attack</strong> with a weapon you have equipped: if this attack hits one or more targets, it deals extra damage equal to <strong>【SL + the number rolled on your Might die】</strong>. However, all damage dealt by this attack becomes <strong>dark</strong> and its damage type cannot be changed.</p>",
-    "isFavored": {
-      "value": false
-    },
+    "description": "<p>You have learned to channel your vital force into your attacks. You may use an action to perform a <strong>Shadow Strike</strong>: roll your current <strong>Might</strong> die and lose an amount of Hit Points equal to <strong>【the number rolled on your Might die】</strong>. If this didn't reduce your Hit Points to 0, you may perform a <strong>free attack</strong> with a weapon you have equipped: if this attack hits one or more targets, it deals extra damage equal to <strong>【SL + the number rolled on your Might die】</strong>. However, all damage dealt by this attack becomes <strong>dark</strong> and its damage type cannot be changed.</p>",
     "showTitleCard": {
       "value": false
     },
@@ -27,83 +21,18 @@
       "value": "darkblade"
     },
     "useWeapon": {
-      "accuracy": {
-        "value": false
-      },
-      "damage": true,
-      "hrZero": {
-        "value": false
-      }
-    },
-    "attributes": {
-      "primary": {
-        "value": "mig"
-      },
-      "secondary": {
-        "value": "mig"
-      }
-    },
-    "accuracy": {
-      "value": 0
+      "accuracy": true,
+      "damage": true
     },
     "damage": {
-      "hasDamage": {
-        "value": false
-      },
+      "hasDamage": true,
       "value": 0,
-      "type": {
-        "value": "physical"
-      },
-      "extra": "^backlash(mig, hp)+$sl",
+      "type": "dark",
       "onRoll": "^backlash(mig,hp)+$sl",
-      "onApply": ""
-    },
-    "impdamage": {
-      "hasImpDamage": {
-        "value": false
-      },
-      "value": 0,
-      "impType": {
-        "value": "minor"
-      },
-      "type": {
-        "value": "physical"
-      }
+      "onApply": "",
+      "hrZero": false
     },
     "source": "FUCR185",
-    "rollInfo": {
-      "useWeapon": {
-        "hrZero": {
-          "value": false
-        },
-        "accuracy": {
-          "value": true
-        },
-        "damage": {
-          "value": false
-        }
-      },
-      "attributes": {
-        "primary": {
-          "value": "dex"
-        },
-        "secondary": {
-          "value": "dex"
-        }
-      },
-      "accuracy": {
-        "value": 0
-      },
-      "damage": {
-        "hasDamage": {
-          "value": true
-        },
-        "type": {
-          "value": "dark"
-        },
-        "value": 0
-      }
-    },
     "hasRoll": {
       "value": true
     },
@@ -120,7 +49,13 @@
     "fuid": "shadow-strike",
     "targeting": {
       "rule": "special"
-    }
+    },
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    },
+    "accuracy": ""
   },
   "effects": [],
   "ownership": {
@@ -140,7 +75,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706496911469,
-    "modifiedTime": 1770342956042,
+    "modifiedTime": 1779264750410,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Symbolism_Twj3wpoMzSpUE3Go.json
+++ b/src/packs/skills/skill_Symbolism_Twj3wpoMzSpUE3Go.json
@@ -5,16 +5,10 @@
   "_id": "Twj3wpoMzSpUE3Go",
   "img": "systems/projectfu/styles/static/compendium/classes/symbolist/symbolist_symbolism.png",
   "system": {
-    "subtype": {
-      "value": ""
-    },
     "summary": {
       "value": ""
     },
     "description": "<p>Each time you acquire this Skill, you learn <strong>two symbols</strong>.</p><p>You may have up to <strong>up to 【SL + 1】 symbols active at the same time</strong>; if you create more while at your limit, you must first choose and destroy some of your previous <strong>symbols</strong>.</p><p>You may perform the <strong>Inventory</strong> action and spend <strong>2 Inventory Points</strong> to create a <strong>symbol</strong> you have learned and choose one option: apply that <strong>symbol</strong> to yourself; <strong>or</strong> apply that <strong>symbol</strong> to an ally you can see; <strong>or</strong> perform a <strong>free attack</strong> with a weapon you have equipped. This attack deals no damage, but you apply a copy of the chosen <strong>symbol</strong> to each enemy hit by the attack (each copy counts as a separate <strong>symbol</strong> towards your limit or <strong>【SL + 1】</strong> active <strong>symbols</strong>).</p><hr /><p>For <strong>symbol</strong> breakdown and a list of <strong>Symbols</strong>, refer to: @UUID[Compendium.projectfu.handouts.JournalEntry.t38IeNrS9T7NQspT]{Symbolist Rules} or see <strong>High Fantasy Atlas</strong>, page <strong>148</strong>.</p>",
-    "isFavored": {
-      "value": false
-    },
     "showTitleCard": {
       "value": false
     },
@@ -28,75 +22,9 @@
     },
     "useWeapon": {
       "accuracy": true,
-      "damage": true,
-      "hrZero": {
-        "value": false
-      }
-    },
-    "attributes": {
-      "primary": {
-        "value": "mig"
-      },
-      "secondary": {
-        "value": "mig"
-      }
-    },
-    "accuracy": {
-      "value": 0
-    },
-    "damage": {
-      "hasDamage": false,
-      "value": 0,
-      "type": "",
-      "onRoll": "",
-      "onApply": ""
-    },
-    "impdamage": {
-      "hasImpDamage": {
-        "value": false
-      },
-      "value": 0,
-      "impType": {
-        "value": "minor"
-      },
-      "type": {
-        "value": "physical"
-      }
+      "damage": false
     },
     "source": "FUHF147",
-    "rollInfo": {
-      "useWeapon": {
-        "hrZero": {
-          "value": false
-        },
-        "accuracy": {
-          "value": true
-        },
-        "damage": {
-          "value": false
-        }
-      },
-      "attributes": {
-        "primary": {
-          "value": "dex"
-        },
-        "secondary": {
-          "value": "dex"
-        }
-      },
-      "accuracy": {
-        "value": 0
-      },
-      "damage": {
-        "hasDamage": {
-          "value": false
-        },
-        "type": {
-          "value": "physical"
-        },
-        "value": 0
-      }
-    },
     "hasRoll": {
       "value": true
     },
@@ -119,6 +47,12 @@
       "duration": {
         "interval": null
       }
+    },
+    "accuracy": "",
+    "damage": {
+      "hasDamage": false,
+      "onRoll": "",
+      "onApply": ""
     }
   },
   "effects": [],
@@ -139,7 +73,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706563320133,
-    "modifiedTime": 1775599401014,
+    "modifiedTime": 1779263133406,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/skills/skill_Vibrato_pQVuklFnMKXxHTFr.json
+++ b/src/packs/skills/skill_Vibrato_pQVuklFnMKXxHTFr.json
@@ -5,16 +5,10 @@
   "_id": "pQVuklFnMKXxHTFr",
   "img": "systems/projectfu/styles/static/compendium/classes/chanter/chanter_vibrato.png",
   "system": {
-    "subtype": {
-      "value": ""
-    },
     "summary": {
       "value": ""
     },
     "description": "<p>After you sing a <strong>verse</strong> with <strong>low</strong> or <strong>medium volume</strong>, you may perform a <strong>free attack</strong> with a weapon you have equipped; treat your <strong>High Roll (HR)</strong> as 0 when calculating damage dealt by this attack.</p>",
-    "isFavored": {
-      "value": false
-    },
     "showTitleCard": {
       "value": false
     },
@@ -27,82 +21,18 @@
       "value": "chanter"
     },
     "useWeapon": {
-      "accuracy": {
-        "value": false
-      },
-      "damage": {
-        "value": false
-      },
-      "hrZero": {
-        "value": false
-      }
-    },
-    "attributes": {
-      "primary": {
-        "value": "mig"
-      },
-      "secondary": {
-        "value": "mig"
-      }
-    },
-    "accuracy": {
-      "value": 0
+      "accuracy": true,
+      "damage": true
     },
     "damage": {
-      "hasDamage": {
-        "value": false
-      },
+      "hasDamage": true,
       "value": 0,
       "type": "",
       "onRoll": "",
-      "onApply": ""
-    },
-    "impdamage": {
-      "hasImpDamage": {
-        "value": false
-      },
-      "value": 0,
-      "impType": {
-        "value": "minor"
-      },
-      "type": {
-        "value": "physical"
-      }
+      "onApply": "",
+      "hrZero": true
     },
     "source": "FUHF137",
-    "rollInfo": {
-      "useWeapon": {
-        "hrZero": {
-          "value": true
-        },
-        "accuracy": {
-          "value": true
-        },
-        "damage": {
-          "value": true
-        }
-      },
-      "attributes": {
-        "primary": {
-          "value": "dex"
-        },
-        "secondary": {
-          "value": "dex"
-        }
-      },
-      "accuracy": {
-        "value": 0
-      },
-      "damage": {
-        "hasDamage": {
-          "value": true
-        },
-        "type": {
-          "value": "physical"
-        },
-        "value": 0
-      }
-    },
     "hasRoll": {
       "value": true
     },
@@ -116,7 +46,13 @@
       "step": 1,
       "max": 6
     },
-    "fuid": "vibrato"
+    "fuid": "vibrato",
+    "effects": {
+      "duration": {
+        "interval": null
+      }
+    },
+    "accuracy": ""
   },
   "effects": [],
   "sort": 500000,
@@ -136,7 +72,7 @@
     "systemVersion": "#{VERSION}#",
     "coreVersion": "13.351",
     "createdTime": 1706551925144,
-    "modifiedTime": 1770268965880,
+    "modifiedTime": 1779264764872,
     "lastModifiedBy": "mA8SNY2rY4X5tOHa",
     "compendiumSource": null,
     "duplicateSource": null,

--- a/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
+++ b/src/packs/technospheres/mnemosphere_Mnemosphere__Loremaster_oYgcCTfSe0WY87Vp.json
@@ -11,188 +11,188 @@
     "level": 1,
     "maxLevel": 5,
     "items": [
-		{
-			"name": "Flash of Insight",
-			"type": "skill",
-			"_id": "D4Al2CatwtTnU5tL",
-			"img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
-			"system": {
-				"summary": {
-					"value": ""
-				},
-				"description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location — this includes using the <strong>Study</strong> action during a conflict — you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation. You may ask these questions immediately or save them for later; whenever you ask one of these questions, the Game Master will answer truthfully and you will describe your character's deductive process.</p><p>This Skill may only be used once on the same creature, item or location.</p>",
-				"showTitleCard": {
-					"value": false
-				},
-				"level": {
-					"value": 0,
-					"max": 3,
-					"min": 0
-				},
-				"class": {
-					"value": "loremaster"
-				},
-				"useWeapon": {
-					"accuracy": false,
-					"damage": false,
-					"traits": true
-				},
-				"attributes": {
-					"primary": "dex",
-					"secondary": "dex"
-				},
-				"accuracy": "0",
-				"damage": {
-					"hasDamage": false,
-					"value": 0,
-					"type": "physical",
-					"onRoll": "",
-					"onApply": "",
-					"hrZero": false
-				},
-				"source": "FUCR199",
-				"hasRoll": {
-					"value": false
-				},
-				"hasResource": {
-					"value": false
-				},
-				"rp": {
-					"name": "Name",
-					"current": 0,
-					"step": 1,
-					"max": 6,
-					"enabled": false
-				},
-				"defense": "def",
-				"fuid": "flash-of-insight",
-				"targeting": {
-					"rule": "self",
-					"max": 0
-				},
-				"traits": [],
-				"effects": {
-					"entries": [],
-					"prompt": false,
-					"duration": {
-						"event": "",
-						"tracking": ""
-					}
-				},
-				"cost": {
-					"resource": "mp",
-					"amount": "",
-					"perTarget": false
-				},
-				"resource": {
-					"enabled": false,
-					"amount": "",
-					"type": "hp"
-				}
-			},
-			"effects": [
-				{
-					"name": "Flash of Insight",
-					"img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
-					"system": {
-						"duration": {
-							"event": "none",
-							"interval": 1,
-							"tracking": "self",
-							"remaining": 1
-						},
-						"type": "default",
-						"predicate": {
-							"crisisInteraction": "none"
-						},
-						"rules": {
-							"elements": {
-								"5qIf7IG9ZAkwVt9R": {
-									"type": "ruleElement",
-									"_id": "5qIf7IG9ZAkwVt9R",
-									"trigger": {
-										"_id": "N7OFfFMpeQInn2lL",
-										"type": "renderCheckRuleTrigger",
-										"eventRelation": "source",
-										"checkTypes": [
-											"open"
-										],
-										"itemGroups": [],
-										"local": false,
-										"identifier": ""
-									},
-									"predicates": {
-										"udvpE739WHduDidd": {
-											"type": "checkRulePredicate",
-											"_id": "udvpE739WHduDidd",
-											"result": 13,
-											"attributes": {
-												"primary": {
-													"value": "ins"
-												},
-												"secondary": {
-													"value": "ins"
-												}
-											},
-											"parity": "",
-											"outcome": "",
-											"quantifier": "any"
-										}
-									},
-									"actions": {
-										"OqeboGimrr953F0i": {
-											"type": "messageRuleAction",
-											"_id": "OqeboGimrr953F0i",
-											"message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
-										}
-									},
-									"selector": "initial",
-									"enabled": true
-								}
-							},
-							"progress": {
-								"enabled": false,
-								"id": "",
-								"name": "",
-								"current": 0,
-								"max": 6,
-								"style": "basic",
-								"step": 1
-							},
-							"stacking": {
-								"progress": false,
-								"duration": false,
-								"increment": 1
-							}
-						}
-					},
-					"duration": {
-						"startTime": null,
-						"combat": null
-					},
-					"disabled": false,
-					"_id": "45F7umTTsKZUmmgj",
-					"type": "base",
-					"changes": [],
-					"description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location, you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation.</p>",
-					"origin": null,
-					"tint": "#ffffff",
-					"transfer": true,
-					"statuses": [],
-					"sort": 0,
-					"flags": {}
-				}
-			],
-			"flags": {
-				"core": {},
-				"projectfu": {
-					"favorite": false,
-          "classConverted": true
-				}
-			},
-			"sort": 0
-		},
-		{
+      {
+        "name": "Flash of Insight",
+        "type": "skill",
+        "_id": "D4Al2CatwtTnU5tL",
+        "img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
+        "system": {
+          "summary": {
+            "value": ""
+          },
+          "description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location — this includes using the <strong>Study</strong> action during a conflict — you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation. You may ask these questions immediately or save them for later; whenever you ask one of these questions, the Game Master will answer truthfully and you will describe your character's deductive process.</p><p>This Skill may only be used once on the same creature, item or location.</p>",
+          "showTitleCard": {
+            "value": false
+          },
+          "level": {
+            "value": 0,
+            "max": 3,
+            "min": 0
+          },
+          "class": {
+            "value": "loremaster"
+          },
+          "useWeapon": {
+            "accuracy": false,
+            "damage": false,
+            "traits": true
+          },
+          "attributes": {
+            "primary": "dex",
+            "secondary": "dex"
+          },
+          "accuracy": "0",
+          "damage": {
+            "hasDamage": false,
+            "value": 0,
+            "type": "physical",
+            "onRoll": "",
+            "onApply": "",
+            "hrZero": false
+          },
+          "source": "FUCR199",
+          "hasRoll": {
+            "value": false
+          },
+          "hasResource": {
+            "value": false
+          },
+          "rp": {
+            "name": "Name",
+            "current": 0,
+            "step": 1,
+            "max": 6,
+            "enabled": false
+          },
+          "defense": "def",
+          "fuid": "flash-of-insight",
+          "targeting": {
+            "rule": "self",
+            "max": 0
+          },
+          "traits": [],
+          "effects": {
+            "entries": [],
+            "prompt": false,
+            "duration": {
+              "event": "",
+              "tracking": ""
+            }
+          },
+          "cost": {
+            "resource": "mp",
+            "amount": "",
+            "perTarget": false
+          },
+          "resource": {
+            "enabled": false,
+            "amount": "",
+            "type": "hp"
+          }
+        },
+        "effects": [
+          {
+            "name": "Flash of Insight",
+            "img": "systems/projectfu/styles/static/compendium/classes/loremaster/loremaster_flash_of_insight.png",
+            "system": {
+              "duration": {
+                "event": "none",
+                "interval": 1,
+                "tracking": "self",
+                "remaining": 1
+              },
+              "type": "default",
+              "predicate": {
+                "crisisInteraction": "none"
+              },
+              "rules": {
+                "elements": {
+                  "5qIf7IG9ZAkwVt9R": {
+                    "type": "ruleElement",
+                    "_id": "5qIf7IG9ZAkwVt9R",
+                    "trigger": {
+                      "_id": "N7OFfFMpeQInn2lL",
+                      "type": "renderCheckRuleTrigger",
+                      "eventRelation": "source",
+                      "checkTypes": [
+                        "open"
+                      ],
+                      "itemGroups": [],
+                      "local": false,
+                      "identifier": ""
+                    },
+                    "predicates": {
+                      "udvpE739WHduDidd": {
+                        "type": "checkRulePredicate",
+                        "_id": "udvpE739WHduDidd",
+                        "result": 13,
+                        "attributes": {
+                          "primary": {
+                            "value": "ins"
+                          },
+                          "secondary": {
+                            "value": "ins"
+                          }
+                        },
+                        "parity": "",
+                        "outcome": "",
+                        "quantifier": "any"
+                      }
+                    },
+                    "actions": {
+                      "OqeboGimrr953F0i": {
+                        "type": "messageRuleAction",
+                        "_id": "OqeboGimrr953F0i",
+                        "message": "<p>If this was to investigate a creature, item or location, you may ask the GM up to<strong>【SL】</strong>questions concerning the subject.</p>"
+                      }
+                    },
+                    "selector": "initial",
+                    "enabled": true
+                  }
+                },
+                "progress": {
+                  "enabled": false,
+                  "id": "",
+                  "name": "",
+                  "current": 0,
+                  "max": 6,
+                  "style": "basic",
+                  "step": 1
+                },
+                "stacking": {
+                  "progress": false,
+                  "duration": false,
+                  "increment": 1
+                }
+              }
+            },
+            "duration": {
+              "startTime": null,
+              "combat": null
+            },
+            "disabled": false,
+            "_id": "45F7umTTsKZUmmgj",
+            "type": "base",
+            "changes": [],
+            "description": "<p>When you roll a <strong>13 or higher</strong> on a Check performed to investigate a creature, item or location, you may ask the Game Master up to <strong>【SL】</strong> questions concerning the subject of your investigation.</p>",
+            "origin": null,
+            "tint": "#ffffff",
+            "transfer": true,
+            "statuses": [],
+            "sort": 0,
+            "flags": {}
+          }
+        ],
+        "flags": {
+          "core": {},
+          "projectfu": {
+            "favorite": false,
+            "classConverted": true
+          }
+        },
+        "sort": 0
+      },
+      {
         "name": "Focused",
         "type": "skill",
         "_id": "2qECrNCT1GTwpQIs",


### PR DESCRIPTION
Various Skills that have "Use Weapon Accuracy" enabled had conflicting data between rollInfo and useWeapon in our compendium entries. The new data migration fixes have uncovered this and has caused these skills to disable the "Use Weapon Accuracy" due to the inaccurate weapon model data.

Also, the Loremaster Mnemosphere has some weird tabbing that got fixed by the unpack.