### PR TITLE
bugfix: Compendium link in Advancement view only covers a small part of the icon

### DIFF
--- a/styles/css/app/advancement-tracker.css
+++ b/styles/css/app/advancement-tracker.css
@@ -278,6 +278,11 @@
 	z-index: 0;
 }
 
+.pfu-advancement__entry__card-ring-img-link {
+	display: block;
+	clip-path: circle(50%);
+}
+
 .pfu-advancement__entry__card-ring__badges {
 	position: absolute;
 	inset: 0;

--- a/templates/app/partials/advancement-option-card.hbs
+++ b/templates/app/partials/advancement-option-card.hbs
@@ -8,7 +8,7 @@
 					<div class="pfu-advancement__entry__card-ring-border {{#if (pfuCollectionContains item.id @root.skillMap)}}invested{{else}}untracked{{/if}}">
 					</div>
 					<div class="pfu-advancement__entry__card-ring-img">
-						{{pfuItemAnchor item size='l'}}
+						{{pfuItemAnchor item size='l' classes="pfu-advancement__entry__card-ring-img-link"}}
 					</div>
 					{{#if (pfuCollectionContains item.id @root.skillMap)}}
 						{{#with (lookup @root.skillMap item.id) as |skill|}}
@@ -49,7 +49,7 @@
 				<div class="pfu-advancement__entry__card-ring">
 					<div class="pfu-advancement__entry__card-ring-border"></div>
 					<div class="pfu-advancement__entry__card-ring-img">
-						{{pfuItemAnchor entry size='l'}}
+						{{pfuItemAnchor entry size='l' classes="pfu-advancement__entry__card-ring-img-link"}}
 					</div>
 
 					{{!-- Badges --}}


### PR DESCRIPTION
- make compendium link cover the full icon