### PR TITLE
feat: Allow keeping images and/or names intact during item migration

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1997,6 +1997,8 @@
 		},
 		"ClassFeatureVehicleModules": "Vehicle Modules",
 		"DialogCreateItemSelectTypeContent": "Select the type of item you want to create:",
-		"DialogCreateItemSelectTypeTitle": "Select Item Type"
+		"DialogCreateItemSelectTypeTitle": "Select Item Type",
+		"CompendiumMigrateItemKeepImages": "Keep item images unchanged",
+		"CompendiumMigrateItemKeepNames": "Keep item names unchanged"
 	}
 }

--- a/module/documents/actors/character/advancement-tracker.mjs
+++ b/module/documents/actors/character/advancement-tracker.mjs
@@ -665,7 +665,7 @@ export class AdvancementTracker {
 		});
 
 		/** @type AdvancementSkillUpdate[] **/
-		const result = await dialog.open();
+		const { selected: result } = await dialog.open();
 		if (result) {
 			await Promise.all(result.map((update) => update.item.update({ 'system.level.value': update.targetLevel })));
 			ui.notifications.info(`Synchronized ${result.length} skills.`);
@@ -689,7 +689,7 @@ export class AdvancementTracker {
 			getDescription: (item) => item.system.description,
 			title: 'FU.AdvancementsPruneItems',
 		});
-		const result = await dialog.open();
+		const { selected: result } = await dialog.open();
 		if (result) {
 			await actor.deleteEmbeddedDocuments(
 				'Item',

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -574,8 +574,8 @@ export default class FoundryUtils {
 				if (!compendiumItem) {
 					continue;
 				}
-				const procedure = async () => {
-					await FoundryUtils.migrateItem(compendiumItem, item);
+				const procedure = async (options) => {
+					await FoundryUtils.migrateItem(compendiumItem, item, options);
 				};
 				updates.push({
 					item: item,
@@ -752,7 +752,8 @@ export default class FoundryUtils {
 			},
 		};
 		const dialog = new ItemSelectionDialog(data);
-		return await dialog.open();
+		const { selected } = await dialog.open();
+		return selected;
 	}
 
 	/**
@@ -776,18 +777,25 @@ export default class FoundryUtils {
 			},
 		};
 		const dialog = new ItemSelectionDialog(data);
-		const result = await dialog.open();
+		const { selected: result } = await dialog.open();
 		return result;
 	}
+
+	/**
+	 * @typedef ItemMigrationOptions
+	 * @property {boolean?} keepNames
+	 * @property {boolean?} keepImages
+	 */
 
 	/**
 	 * @desc Migrates the data of an item onto another.
 	 * @param {FUItem} sourceItem
 	 * @param {FUItem} targetItem
+	 * @param {ItemMigrationOptions} options
 	 * @returns {Promise}
 	 * @async
 	 */
-	static async migrateItem(sourceItem, targetItem) {
+	static async migrateItem(sourceItem, targetItem, options = {}) {
 		// Gather retained data model properties
 		const retainedFields = {};
 		for (const fieldPath of targetItem.system.retainedFieldPaths) {
@@ -801,8 +809,8 @@ export default class FoundryUtils {
 		// Properties
 		await targetItem.update(
 			{
-				name: sourceItem.name,
-				img: sourceItem.img,
+				name: options.keepNames ? targetItem.name : sourceItem.name,
+				img: options.keepImages ? targetItem.img : sourceItem.img,
 				system: foundry.utils.deepClone(sourceItem.system),
 				flags: foundry.utils.deepClone(sourceItem.flags),
 			},

--- a/module/pipelines/application-pipeline.mjs
+++ b/module/pipelines/application-pipeline.mjs
@@ -161,7 +161,7 @@ async function handleArcanum(actor, item) {
 		};
 
 		const dialog = new ItemSelectionDialog(data);
-		const result = await dialog.open();
+		const { selected: result } = await dialog.open();
 		if (result && result.length > 0) {
 			/** @type FUItem **/
 			const selectedArcana = result[0];
@@ -229,7 +229,7 @@ async function handleTheriomorphosis(actor, item) {
 	};
 
 	const dialog = new ItemSelectionDialog(data);
-	const selectedForms = await dialog.open();
+	const { selected: selectedForms } = await dialog.open();
 	if (selectedForms) {
 		await actor.update({
 			'system.equipped.therioforms': selectedForms.map(({ id }) => id),

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -741,7 +741,7 @@ async function promptEffectChoices(effectData, sourceInfo) {
 	};
 
 	const dialog = new ItemSelectionDialog(data);
-	const result = await dialog.open();
+	const { selected: result } = await dialog.open();
 	if (result && result.length > 0) {
 		return await Promise.all(result.map((choice) => getTargetedAction(choice.id, sourceInfo, effectData.duration)));
 	}

--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -1053,7 +1053,7 @@ export class FUPartySheet extends FUActorSheet {
 			if (items.length > 0) groups.push({ name: group.name, items });
 		}
 
-		const selected = await new ItemSelectionDialog({
+		const { selected } = await new ItemSelectionDialog({
 			title: `${StringUtils.localize('CONTROLS.CommonSelect')} ${game.i18n.localize('FU.Actor')}`,
 			style: 'grouped-list',
 			groups,
@@ -1162,7 +1162,7 @@ export class FUPartySheet extends FUActorSheet {
 
 		try {
 			const dialog = new ItemSelectionDialog(data);
-			const selectedPages = await dialog.open();
+			const { selected: selectedPages } = await dialog.open();
 
 			if (selectedPages && selectedPages.length > 0) {
 				const pages = selectedPages.map((item) => item._originalPage);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -225,13 +225,20 @@ export class FUActorSheet extends api.HandlebarsApplicationMixin(sheets.ActorShe
 					const text = item.system?.description ?? '';
 					return text;
 				},
+				additionalInputs: {
+					keepImages: new foundry.data.fields.BooleanField({ label: 'FU.CompendiumMigrateItemKeepImages', initial: true }),
+					keepNames: new foundry.data.fields.BooleanField({ label: 'FU.CompendiumMigrateItemKeepNames', initial: true }),
+				},
 			};
 			const dialog = new ItemSelectionDialog(data);
-			const result = await dialog.open();
+			const {
+				selected: result,
+				additionalInputs: { keepImages, keepNames },
+			} = await dialog.open();
 			if (result && result.length > 0) {
 				const uuids = new Set(result.map((item) => item.uuid));
 				const selectedUpdates = updates.filter((u) => uuids.has(u.item.uuid)).map((u) => u.procedure);
-				await Promise.all(selectedUpdates.map((fn) => fn()));
+				await Promise.all(selectedUpdates.map((fn) => fn({ keepImages, keepNames })));
 				ui.notifications.info(StringUtils.localize('FU.CompendiumMigrateSuccess', { count: selectedUpdates.length }));
 			}
 		}

--- a/module/ui/features/item-selection-dialog.mjs
+++ b/module/ui/features/item-selection-dialog.mjs
@@ -31,6 +31,7 @@ import { StringUtils } from '../../helpers/string-utils.mjs';
  * @property {Number} max
  * @property {(item: FUItem) => Promise<string>} getDescription
  * @property {String} okLabel
+ * @property {Record<string, DataField>} additionalInputs
  */
 
 /**
@@ -75,7 +76,7 @@ export class ItemSelectionDialog {
 	}
 
 	/**
-	 * @returns {Promise<Object[]>} selected
+	 * @returns {Promise<{selected: Object[], additionalInputs: {}}>} selected
 	 */
 	async open() {
 		// We cache the item descriptions here...
@@ -118,7 +119,7 @@ export class ItemSelectionDialog {
 			}
 		};
 
-		const result = await foundry.applications.api.DialogV2.input({
+		let result = await foundry.applications.api.DialogV2.input({
 			window: {
 				title: this.data.title,
 			},
@@ -302,12 +303,24 @@ export class ItemSelectionDialog {
 			},
 		});
 		if (result) {
+			const returnValue = { selected: [], additionalInputs: {} };
+
+			result = foundry.utils.expandObject(result);
+			for (let [name, field] of Object.entries(this.data.additionalInputs ?? {})) {
+				let inputValue = result.additionalInputs[name];
+				if (inputValue && Array.isArray(field.choices) && Number.isFinite(Number(inputValue))) {
+					returnValue.additionalInputs[name] = field.choices[Number(inputValue)];
+				} else {
+					returnValue.additionalInputs[name] = inputValue;
+				}
+			}
 			// If a custom payload is expected
 			if (this.data.payload) {
-				return this.#selectedIndexes.map((idx) => this.data.payload[idx]);
+				returnValue.selected = this.#selectedIndexes.map((idx) => this.data.payload[idx]);
 			} else {
-				return this.#selectedItems;
+				returnValue.selected = this.#selectedItems;
 			}
+			return returnValue;
 		} else {
 			throw Error('Canceled by user.');
 		}

--- a/templates/dialog/dialog-item-selection.hbs
+++ b/templates/dialog/dialog-item-selection.hbs
@@ -6,6 +6,14 @@
 			</span>
 		</div>
 	{{/if}}
+	{{#if additionalInputs}}
+		<fieldset class="title-fieldset">
+			{{#each additionalInputs}}
+				{{formGroup this name=(concat "additionalInputs." @key) localize=true}}
+			{{/each}}
+		</fieldset>
+		<hr>
+	{{/if}}
 	<div class="fu-selection-dialog__filter">
 		<input type="search"
 			   class="resource-inputs select-dropdown-full"


### PR DESCRIPTION
- improve ItemSelectionDialog API to support additional inputs
- add additional inputs to item migration dialog to keep images and/or names as they are

fixes #830 