### PR TITLE
feat: Confirmation dialog for 'weaponMagicCheck' functionality

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1999,6 +1999,8 @@
 		"DialogCreateItemSelectTypeContent": "Select the type of item you want to create:",
 		"DialogCreateItemSelectTypeTitle": "Select Item Type",
 		"CompendiumMigrateItemKeepImages": "Keep item images unchanged",
-		"CompendiumMigrateItemKeepNames": "Keep item names unchanged"
+		"CompendiumMigrateItemKeepNames": "Keep item names unchanged",
+		"MagicCheckDialogUseWeaponCheckTitle": "Use Weapon?",
+		"MagicCheckDialogUseWeaponCheckContent": "Use weapon accuracy for Magic Check?"
 	}
 }

--- a/module/documents/items/spell/spell-data-model.mjs
+++ b/module/documents/items/spell/spell-data-model.mjs
@@ -174,14 +174,23 @@ export class SpellDataModel extends FUStandardItemDataModel {
 
 			let attributeOverride = false;
 			if (actor.getFlag(Flags.Scope, Flags.Toggle.WeaponMagicCheck)) {
-				const weapon = await WeaponResolver.prompt(actor, true);
-				if (weapon) {
-					check.primary = weapon.data.accuracy.primary;
-					check.secondary = weapon.data.accuracy.secondary;
-					attributeOverride = true;
-					// TODO: Clean up
-					config.addWeaponAccuracy(weapon.item);
-					config.setWeaponReference(weapon.item);
+				const useWeapon = await foundry.applications.api.Dialog.confirm({
+					window: {
+						title: 'FU.MagicCheckDialogUseWeaponCheckTitle',
+					},
+					content: game.i18n.localize('FU.MagicCheckDialogUseWeaponCheckContent'),
+					rejectClose: false,
+				});
+				if (useWeapon) {
+					const weapon = await WeaponResolver.prompt(actor, true);
+					if (weapon) {
+						check.primary = weapon.data.accuracy.primary;
+						check.secondary = weapon.data.accuracy.secondary;
+						attributeOverride = true;
+						// TODO: Clean up
+						config.addWeaponAccuracy(weapon.item);
+						config.setWeaponReference(weapon.item);
+					}
 				}
 			}
 


### PR DESCRIPTION
- added confirmation prompt for using weapon accuracy for a magic check when 'weaponMagicCheck' flag is set

fixes #1002 

It's not the most elegant solution and can't accurately model the rules yet, but it works for now.