### PR TITLE
bugfix: Rule Elements apply comparison operations inconsistently

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1997,6 +1997,8 @@
 		},
 		"ClassFeatureVehicleModules": "Vehicle Modules",
 		"DialogCreateItemSelectTypeContent": "Select the type of item you want to create:",
-		"DialogCreateItemSelectTypeTitle": "Select Item Type"
+		"DialogCreateItemSelectTypeTitle": "Select Item Type",
+		"GreaterThanOrEqual": "Greater Than Or Equal",
+		"LessThanOrEqual": "Less Than Or Equal"
 	}
 }

--- a/module/documents/effects/predicates/progress-track-predicate.mjs
+++ b/module/documents/effects/predicates/progress-track-predicate.mjs
@@ -1,6 +1,7 @@
 import { RulePredicateDataModel } from './rule-predicate-data-model.mjs';
 import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
 import { FU } from '../../../helpers/config.mjs';
+import { ComparisonOperations } from '../../../helpers/comparison-operations.mjs';
 
 const fields = foundry.data.fields;
 
@@ -18,7 +19,7 @@ export class ProgressTrackRulePredicate extends RulePredicateDataModel {
 
 	static defineSchema() {
 		return Object.assign(super.defineSchema(), {
-			value: new fields.NumberField({ blank: true }),
+			value: new fields.NumberField(),
 			identifier: new fields.StringField({ initial: '' }),
 			comparisonOperator: new fields.StringField({
 				initial: '',
@@ -45,17 +46,19 @@ export class ProgressTrackRulePredicate extends RulePredicateDataModel {
 		const progress = context.character.actor.resolveProgress(this.identifier);
 		if (!progress) return false;
 
-		switch (this.comparisonOperator) {
-			case 'max':
-				return progress.current >= progress.max;
-			case 'greaterThan':
-				return progress.current > this.value;
-			case 'lessThan':
-				return progress.current < this.value;
-			case 'equals':
-				return progress.current === this.value;
+		if (!this.comparisonOperator) {
+			return false;
 		}
 
-		return false;
+		if (this.comparisonOperator === 'max') {
+			return progress.current >= progress.max;
+		}
+
+		if (!Number.isFinite(this.value)) {
+			return false;
+		}
+
+		const comparisonOperation = ComparisonOperations[this.comparisonOperator];
+		return comparisonOperation(progress.current, this.value);
 	}
 }

--- a/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
+++ b/module/documents/effects/triggers/calculate-expense-rule-trigger.mjs
@@ -5,6 +5,7 @@ import { FUHooks } from '../../../hooks.mjs';
 import { FU } from '../../../helpers/config.mjs';
 import { TraitsPredicateDataModel } from '../../items/common/traits-predicate-data-model.mjs';
 import { FeatureTraits, TraitUtils } from '../../../pipelines/traits.mjs';
+import { ComparisonOperations } from '../../../helpers/comparison-operations.mjs';
 
 const fields = foundry.data.fields;
 
@@ -31,7 +32,7 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 	}
 
 	static defineSchema() {
-		const schema = Object.assign(super.defineSchema(), {
+		return Object.assign(super.defineSchema(), {
 			resource: new fields.StringField({
 				initial: 'mp',
 				choices: Object.keys(FU.resources),
@@ -43,7 +44,11 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 				blank: true,
 			}),
 			threshold: new fields.SchemaField({
-				operator: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.comparisonOperator) }),
+				operator: new fields.StringField({
+					initial: '',
+					blank: true,
+					choices: Object.keys(FU.comparisonOperator),
+				}),
 				amount: new fields.NumberField({ initial: 0 }),
 			}),
 			identifier: new fields.StringField(),
@@ -51,7 +56,6 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 				options: TraitUtils.getOptions(FeatureTraits),
 			}),
 		});
-		return schema;
 	}
 
 	static get localization() {
@@ -84,20 +88,8 @@ export class CalculateExpenseRuleTrigger extends RuleTriggerDataModel {
 		if (this.threshold.operator) {
 			const amount = context.event.expense.amount;
 			if (Number.isInteger(amount)) {
-				switch (this.threshold.operator) {
-					case 'greaterThan':
-						if (amount >= this.threshold.amount) {
-							return true;
-						}
-						break;
-
-					case 'lessThan':
-						if (amount <= this.threshold.amount) {
-							return true;
-						}
-						break;
-				}
-				return false;
+				const comparisonOperation = ComparisonOperations[this.threshold.operator];
+				return comparisonOperation(amount, this.threshold.amount);
 			} else {
 				console.warn(`The given amount in the event was not an integer.`);
 			}

--- a/module/documents/effects/triggers/damage-rule-trigger.mjs
+++ b/module/documents/effects/triggers/damage-rule-trigger.mjs
@@ -2,6 +2,7 @@ import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
 import { RuleTriggerDataModel } from './rule-trigger-data-model.mjs';
 import { FU } from '../../../helpers/config.mjs';
 import { FUHooks } from '../../../hooks.mjs';
+import { ComparisonOperations } from '../../../helpers/comparison-operations.mjs';
 
 const fields = foundry.data.fields;
 
@@ -28,7 +29,7 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 	}
 
 	static defineSchema() {
-		const schema = Object.assign(super.defineSchema(), {
+		return Object.assign(super.defineSchema(), {
 			damageType: new fields.StringField({
 				initial: '',
 				choices: Object.keys(FU.damageTypes),
@@ -41,11 +42,14 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 			}),
 			itemGroups: new fields.SetField(new fields.StringField()),
 			damageThreshold: new fields.SchemaField({
-				operator: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.comparisonOperator) }),
+				operator: new fields.StringField({
+					initial: '',
+					blank: true,
+					choices: Object.keys(FU.comparisonOperator),
+				}),
 				amount: new fields.NumberField({ initial: 0 }),
 			}),
 		});
-		return schema;
 	}
 
 	static migrateData(source) {
@@ -85,20 +89,10 @@ export class DamageRuleTrigger extends RuleTriggerDataModel {
 		}
 
 		if (this.damageThreshold.operator) {
-			switch (this.damageThreshold.operator) {
-				case 'greaterThan':
-					if (context.event.amount >= this.damageThreshold.amount) {
-						return true;
-					}
-					break;
-
-				case 'lessThan':
-					if (context.event.amount <= this.damageThreshold.amount) {
-						return true;
-					}
-					break;
+			const comparisonOperation = ComparisonOperations[this.threshold.operator];
+			if (!comparisonOperation(context.event.amount, this.threshold.amount)) {
+				return false;
 			}
-			return false;
 		}
 
 		if (this.affinity) {

--- a/module/documents/effects/triggers/progress-track-rule-trigger.mjs
+++ b/module/documents/effects/triggers/progress-track-rule-trigger.mjs
@@ -2,6 +2,7 @@ import { FU } from '../../../helpers/config.mjs';
 import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
 import { FUHooks } from '../../../hooks.mjs';
 import { RuleTriggerDataModel } from './rule-trigger-data-model.mjs';
+import { ComparisonOperations } from '../../../helpers/comparison-operations.mjs';
 
 const fields = foundry.data.fields;
 
@@ -22,8 +23,8 @@ export class ProgressTrackRuleTrigger extends RuleTriggerDataModel {
 	}
 
 	static defineSchema() {
-		const schema = Object.assign(super.defineSchema(), {
-			value: new fields.NumberField({ blank: true }),
+		return Object.assign(super.defineSchema(), {
+			value: new fields.NumberField(),
 			identifier: new fields.StringField({ initial: '' }),
 			local: new fields.BooleanField({ initial: false }),
 			comparisonOperator: new fields.StringField({
@@ -35,8 +36,6 @@ export class ProgressTrackRuleTrigger extends RuleTriggerDataModel {
 				},
 			}),
 		});
-
-		return schema;
 	}
 
 	static get localization() {
@@ -66,16 +65,15 @@ export class ProgressTrackRuleTrigger extends RuleTriggerDataModel {
 		const actorProgress = context.character?.actor?.resolveProgress(this.identifier);
 		if (actorProgress !== progress) return false;
 
-		switch (this.comparisonOperator) {
-			case 'max':
-				return progress.current >= progress.max;
-			case 'greaterThan':
-				return progress.current > this.value;
-			case 'lessThan':
-				return progress.current < this.value;
-			case 'equals':
-				return progress.current === this.value;
+		if (this.comparisonOperator === 'max') {
+			return progress.current >= progress.max;
 		}
-		return false;
+
+		if (!Number.isInteger(this.value)) {
+			return false;
+		}
+
+		const comparisonOperation = ComparisonOperations[this.comparisonOperator];
+		return comparisonOperation(progress.current, this.value);
 	}
 }

--- a/module/documents/effects/triggers/resource-update-rule-trigger.mjs
+++ b/module/documents/effects/triggers/resource-update-rule-trigger.mjs
@@ -2,6 +2,7 @@ import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
 import { RuleTriggerDataModel } from './rule-trigger-data-model.mjs';
 import { FUHooks } from '../../../hooks.mjs';
 import { FU } from '../../../helpers/config.mjs';
+import { ComparisonOperations } from '../../../helpers/comparison-operations.mjs';
 
 const fields = foundry.data.fields;
 
@@ -25,18 +26,21 @@ export class ResourceUpdateRuleTrigger extends RuleTriggerDataModel {
 	}
 
 	static defineSchema() {
-		const schema = Object.assign(super.defineSchema(), {
+		return Object.assign(super.defineSchema(), {
 			resource: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.resources) }),
 			change: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.scalarChange) }),
 			changeThreshold: new fields.SchemaField({
-				operator: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.comparisonOperator) }),
+				operator: new fields.StringField({
+					initial: '',
+					blank: true,
+					choices: Object.keys(FU.comparisonOperator),
+				}),
 				amount: new fields.NumberField({ initial: 0 }),
 			}),
 			itemGroups: new fields.SetField(new fields.StringField()),
 			identifier: new fields.StringField(),
 			local: new fields.BooleanField({ initial: false }),
 		});
-		return schema;
 	}
 
 	static get localization() {
@@ -81,18 +85,9 @@ export class ResourceUpdateRuleTrigger extends RuleTriggerDataModel {
 		}
 
 		if (this.changeThreshold.operator) {
-			switch (this.changeThreshold.operator) {
-				case 'greaterThan':
-					if (!(Math.abs(amount) >= Math.abs(this.changeThreshold.amount))) {
-						return false;
-					}
-					break;
-
-				case 'lessThan':
-					if (!(Math.abs(amount) <= Math.abs(this.changeThreshold.amount))) {
-						return false;
-					}
-					break;
+			const comparisonOperation = ComparisonOperations[this.threshold.operator];
+			if (!comparisonOperation(Math.abs(amount), Math.abs(this.changeThreshold.amount))) {
+				return false;
 			}
 		}
 

--- a/module/helpers/comparison-operations.mjs
+++ b/module/helpers/comparison-operations.mjs
@@ -1,0 +1,52 @@
+/**
+ * @callback ComparisonOperation
+ * @param {number} lhs left-hand side operand
+ * @param {number} rhs right-hand side operand
+ * @return boolean
+ */
+
+/**
+ * @type ComparisonOperation
+ */
+const greaterThan = (lhs, rhs) => {
+	return lhs > rhs;
+};
+
+/**
+ * @type ComparisonOperation
+ */
+const greaterThanOrEqual = (lhs, rhs) => {
+	return lhs >= rhs;
+};
+
+/**
+ * @type ComparisonOperation
+ */
+const equals = (lhs, rhs) => {
+	return lhs === rhs;
+};
+
+/**
+ * @type ComparisonOperation
+ */
+const lessThanOrEqual = (lhs, rhs) => {
+	return lhs <= rhs;
+};
+
+/**
+ * @type ComparisonOperation
+ */
+const lessThan = (lhs, rhs) => {
+	return lhs < rhs;
+};
+
+/**
+ * @type {Record<FUComparisonOperator, ComparisonOperation>}
+ */
+export const ComparisonOperations = {
+	greaterThan,
+	greaterThanOrEqual,
+	equals,
+	lessThanOrEqual,
+	lessThan,
+};

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -1038,7 +1038,7 @@ FU.scalarOperation = {
 };
 
 /**
- * @typedef {"greaterThan" | "lessThan"} FUComparisonOperator
+ * @typedef {"greaterThan" | "greaterThanOrEqual" | "equals" | "lessThanOrEqual" | "lessThan"} FUComparisonOperator
  */
 
 /**
@@ -1047,9 +1047,14 @@ FU.scalarOperation = {
  * @property {Number} amount
  */
 
+/**
+ * @type {Record<FUComparisonOperator, string>}
+ */
 FU.comparisonOperator = {
 	greaterThan: 'FU.GreaterThan',
+	greaterThanOrEqual: 'FU.GreaterThanOrEqual',
 	equals: 'FU.Equals',
+	lessThanOrEqual: 'FU.LessThanOrEqual',
 	lessThan: 'FU.LessThan',
 };
 


### PR DESCRIPTION
- expand supported comparison operators by adding "greaterThanOrEqual" and "lessThanOrEqual"
- unify comparison operation logic

fixes #1138 

I'm admittedly not very well versed in using Rule Elements yet, but I think I did not change the semantics in most cases.
The notable exception is `DamageRuleTrigger` lines 91-96, where it previously short circuited the evaluation on a met threshold instead of proceeding to evaluate affinity.
I assumed this to be a bug.