### PR TITLE
bugfix: Unable to remove multiple effects using chat message

### DIFF
--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -757,17 +757,25 @@ function onRenderChatMessage(message, element) {
 		return;
 	}
 
-	Pipeline.handleClickRevert(message, element, 'removeEffect', (dataset) => {
-		const actorId = dataset.actorId;
-		const effectId = dataset.id;
-		console.debug(`Removing effect ${effectId} from ${actorId}`);
-		/** @type FUActor **/
-		const actor = fromUuidSync(actorId);
-		const effect = actor.effects.get(effectId);
-		if (effect) {
-			effect.delete();
-		}
-	});
+	Pipeline.handleClickRevert(
+		message,
+		element,
+		'removeEffect',
+		(dataset) => {
+			const actorId = dataset.actorId;
+			const effectId = dataset.id;
+			console.debug(`Removing effect ${effectId} from ${actorId}`);
+			/** @type FUActor **/
+			const actor = fromUuidSync(actorId);
+			const effect = actor.effects.get(effectId);
+			if (effect) {
+				effect.delete();
+			}
+		},
+		(actionName, el) => {
+			return `${actionName}+${el.dataset.actorId}+${el.dataset.id}`;
+		},
+	);
 
 	Pipeline.handleClick(message, element, 'applyEffect', async (dataset) => {
 		const effectId = dataset.effectId;

--- a/module/pipelines/pipeline.mjs
+++ b/module/pipelines/pipeline.mjs
@@ -163,14 +163,15 @@ function handleClick(message, html, actionName, onClick) {
  * @param {HTMLElement} html
  * @param {String} actionName
  * @param {(data: Object) => Promise<void>} action
+ * @param {(actionName: string, element: HTMLElement) => string?} getCustomActionId
  */
-async function handleClickRevert(message, html, actionName, action) {
-	html.querySelectorAll(`a[data-action="${actionName}"]`).forEach((element) => {
-		const messageContent = html.querySelector('.message-content');
-		const reverted = message.getFlag(SYSTEM, Flags.ChatMessage.RevertedAction)?.includes(actionName);
+async function handleClickRevert(message, html, actionName, action, getCustomActionId) {
+	const elements = [...html.querySelectorAll(`a[data-action="${actionName}"]`).values()];
+	elements.forEach((element) => {
+		const actionId = getCustomActionId ? getCustomActionId(actionName, element) : actionName;
+		const reverted = message.getFlag(SYSTEM, Flags.ChatMessage.RevertedAction)?.includes(actionId);
 
 		if (reverted) {
-			messageContent?.classList.add('strikethrough');
 			element.classList.add('action-disabled');
 		} else {
 			element.addEventListener('click', async (event) => {
@@ -178,7 +179,7 @@ async function handleClickRevert(message, html, actionName, action) {
 				try {
 					await action({ ...element.dataset });
 					const revertedActions = message.getFlag(SYSTEM, Flags.ChatMessage.RevertedAction) ?? [];
-					revertedActions.push(actionName);
+					revertedActions.push(actionId);
 					await message.setFlag(SYSTEM, Flags.ChatMessage.RevertedAction, revertedActions);
 				} catch (ex) {
 					console.debug(ex);
@@ -186,6 +187,10 @@ async function handleClickRevert(message, html, actionName, action) {
 			});
 		}
 	});
+	if (elements.length && elements.every((elem) => elem.classList.contains('action-disabled'))) {
+		const messageContent = html.querySelector('.message-content');
+		messageContent?.classList.add('strikethrough');
+	}
 }
 
 /**


### PR DESCRIPTION
- enhance Pipeline::handleClickRevert with the ability to compute a custom action id for cases where multiple of the same action may be present in any given chat message

fixes #1164 although there may be other occurences of the same problem
