### PR TITLE
Apply affinities when staggered

### DIFF
--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -373,10 +373,10 @@ function collectMultipliers(context) {
 	let applyAffinity = true;
 
 	if (game.settings.get(SYSTEM, SETTINGS.pressureSystem)) {
-		const pressure = context.actor.resolveProgress('pressure');
-		const stagger = context.actor.resolveEffect('stagger');
+		const hasPressureClock = !!context.actor.resolveProgress('pressure');
+		const isStaggered = !!context.actor.resolveEffect('stagger')?.active;
 		// If they are not staggered, do not apply VU to the damage
-		if (pressure && !stagger && context.affinity === -1) applyAffinity = false;
+		if (hasPressureClock && !isStaggered && context.affinity === FU.affValue.vulnerability) applyAffinity = false;
 	}
 
 	if (applyAffinity) context.addModifier('affinity', affinityModifier);

--- a/module/pipelines/damage-pipeline.mjs
+++ b/module/pipelines/damage-pipeline.mjs
@@ -369,12 +369,17 @@ function collectMultipliers(context) {
 		context.addModifier('scaleIncomingDamage', scaleIncomingDamage);
 	}
 
-	// When the pressure system is active, Affinities other than VU are still applied
-	// as Pressure Points are evaluated on HP loss rather than damage
-	if (!game.settings.get(SYSTEM, SETTINGS.pressureSystem) || (context.affinity !== 0 && context.affinity !== -1)) {
-		const modifier = affinityDamageModifier[context.affinity]();
-		context.addModifier('affinity', modifier);
+	const affinityModifier = affinityDamageModifier[context.affinity]();
+	let applyAffinity = true;
+
+	if (game.settings.get(SYSTEM, SETTINGS.pressureSystem)) {
+		const pressure = context.actor.resolveProgress('pressure');
+		const stagger = context.actor.resolveEffect('stagger');
+		// If they are not staggered, do not apply VU to the damage
+		if (pressure && !stagger && context.affinity === -1) applyAffinity = false;
 	}
+
+	if (applyAffinity) context.addModifier('affinity', affinityModifier);
 }
 
 /**


### PR DESCRIPTION
Refactors the affinity portion of the damage pipeline to ensure they are applied normally when an actor is staggered
VU will still not multiply incoming damage if the actor is not staggered and has a pressure clock


Note: The current pressure/stagger system has a flaw in its design that leads to incorrect handling of a particularly niche situation if an actor were to *gain* Immunity or Absorption to a damage type while staggered.  Fixing this will require refactoring how staggering is handled entirely.