### PR TITLE
Alphabetize options in selectOptionDialog

### DIFF
--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -205,6 +205,7 @@ export default class FoundryUtils {
 			name: 'option',
 			type: 'checkboxes',
 			value: selected,
+			sort: true,
 		});
 
 		const selectGroup = fields.createFormGroup({


### PR DESCRIPTION
Adds sort option to select field created for `selectOptionDialog`

This will sort the drop-down for adding rule actions/predicates as well as the drop-down for changing a feature's subtype

<img width="422" height="628" alt="image" src="https://github.com/user-attachments/assets/6754bffd-bb9a-47d8-bfed-130ff35863f9" />
