### PR TITLE
Compendium browser spell filters

### DIFF
--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -800,14 +800,22 @@ export class CompendiumBrowser extends FUApplication {
 
 			case 'spells':
 				{
-					const spells = await this.index.getItemsOfType('spell');
-					const classes = ['Elementalist', 'Entropist', 'Spiritist', 'NPC']; // hardcoded for now
-					const classOptions = classes.map((c) => {
-						return {
-							value: c,
-							label: c,
-						};
-					});
+					const [spells, classes] = await Promise.all([this.index.getItemsOfType('spell'), this.index.getItemsOfType('class')]);
+					// TODO: Find a way to NOT hardcode these, this is very brittle
+					const classesWithSpells = ['elementalist', 'entropist', 'spiritist'];
+					const classOptions = [
+						...classesWithSpells.map((c) => {
+							return {
+								value: c,
+								label: classes.find((item) => item.system.fuid === c)?.name ?? c,
+							};
+						}),
+						{
+							value: 'NPC',
+							label: 'ACTOR.TypeNpc',
+						},
+					];
+
 					await this.onRenderTables(
 						[
 							{

--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -801,20 +801,23 @@ export class CompendiumBrowser extends FUApplication {
 			case 'spells':
 				{
 					const [spells, classes] = await Promise.all([this.index.getItemsOfType('spell'), this.index.getItemsOfType('class')]);
-					// TODO: Find a way to NOT hardcode these, this is very brittle
-					const classesWithSpells = ['elementalist', 'entropist', 'spiritist'];
-					const classOptions = [
-						...classesWithSpells.map((c) => {
-							return {
-								value: c,
-								label: classes.find((item) => item.system.fuid === c)?.name ?? c,
-							};
-						}),
-						{
-							value: 'NPC',
-							label: 'ACTOR.TypeNpc',
-						},
-					];
+					const classesWithSpells = spells
+						.map((spell) => spell.system.class.value)
+						.reduce((set, fuid) => {
+							set.add(fuid);
+							return set;
+						}, new Set());
+
+					const classOptions = classesWithSpells.map((fuid) => {
+						let label;
+						if (fuid.toLowerCase() === 'npc') label = 'ACTOR.TypeNpc';
+						else label = classes.find((item) => item.system.fuid === fuid)?.name ?? fuid;
+
+						return {
+							value: fuid,
+							label,
+						};
+					});
 
 					await this.onRenderTables(
 						[


### PR DESCRIPTION
This PR updates the filter list on the Spells tab of the Compendium Browser to use class fuids for checkbox values, rather than names.
It also does a lookup for the classes to ensure it retrieves their proper localized name
And it localizes the NPC list item

We may need to consider doing something like adding a boolean field to the class data model to indicate if that class grants spells or not, so that this filter list can be generated automatically instead of using a hard-coded set of values