### PR TITLE
fix: run class fuid converter on item creation

### DIFF
--- a/module/documents/items/class-fuid-converter.mjs
+++ b/module/documents/items/class-fuid-converter.mjs
@@ -3,13 +3,8 @@ import { Flags } from '../../helpers/flags.mjs';
 import { CompendiumIndex } from '../../ui/compendium/compendium-index.mjs';
 
 async function convertClassAttributeFromClassLists(item, classes) {
-	let updates = {
-		flags: {
-			[SYSTEM]: {
-				[Flags.ClassConverted]: true,
-			},
-		},
-	};
+	let updates = {};
+	let conversionResolved = true;
 
 	const classAttribute = item.system?.class?.value;
 	if (classAttribute) {
@@ -34,6 +29,10 @@ async function convertClassAttributeFromClassLists(item, classes) {
 					continue;
 				}
 			}
+
+			// Class reference could not be resolved against any known class list. Skip the conversion flag
+			// so the converter can retry on a later session when the matching class becomes available.
+			conversionResolved = false;
 		}
 
 		if (fuids.length > 0) {
@@ -46,7 +45,20 @@ async function convertClassAttributeFromClassLists(item, classes) {
 		}
 	}
 
-	item.update(updates);
+	// Only mark the item as converted if every class reference resolved. Items that failed to
+	// resolve (e.g., class compendium not yet loaded, or class not present in the world) keep the
+	// flag unset so the converter can retry next time.
+	if (conversionResolved) {
+		updates.flags = {
+			[SYSTEM]: {
+				[Flags.ClassConverted]: true,
+			},
+		};
+	}
+
+	if (Object.keys(updates).length > 0) {
+		await item.update(updates);
+	}
 }
 
 async function convertActorItemsClassAttributes(actorSource) {
@@ -93,11 +105,41 @@ async function convertGameItemsClassAttributes() {
 	}
 }
 
+/**
+ * Convert a single item's class attribute. Used by the createItem hook so that newly added
+ * items get their class reference normalized immediately, rather than waiting for the next
+ * world reload.
+ * @param {Item} item The newly created item. Skipped if it's not a class-bearing type or
+ *                    already has the conversion flag.
+ */
+async function convertSingleItem(item) {
+	if (!item) return;
+	if (item.type !== 'skill' && item.type !== 'spell' && item.type !== 'heroic') return;
+	if (item.flags?.projectfu?.classConverted) return;
+
+	// Collect class lookup sources: actor classes (if item belongs to an actor), world classes,
+	// and compendium classes.
+	const actorClasses = item.parent?.items?.filter((i) => i.type === 'class') ?? [];
+	const worldClasses = game.items.filter((i) => i.type === 'class');
+	const compendiumClasses = await CompendiumIndex.instance.getClasses();
+	const allClasses = [...actorClasses, ...worldClasses, ...compendiumClasses.class];
+
+	await convertClassAttributeFromClassLists(item, allClasses);
+}
+
 export class ClassFuidConverter {
 	static run() {
 		for (const actor of game.actors) {
 			convertActorItemsClassAttributes(actor);
 		}
 		convertGameItemsClassAttributes();
+	}
+
+	/**
+	 * Convert a single item. Safe to call from the createItem hook.
+	 * @param {Item} item
+	 */
+	static convertItem(item) {
+		return convertSingleItem(item);
 	}
 }

--- a/module/projectfu.mjs
+++ b/module/projectfu.mjs
@@ -529,6 +529,14 @@ Hooks.once('ready', async function () {
 		item.toggleFavorite(true);
 	});
 
+	// Normalize class references on freshly created skill/spell/heroic items so that mismatched
+	// case (e.g. system.class.value = "Predator" vs class fuid "predator") gets fixed immediately
+	// instead of only on the next world reload.
+	Hooks.on('createItem', (item, options, userId) => {
+		if (game.userId !== userId) return; // Only the creating user should run the conversion
+		ClassFuidConverter.convertItem(item);
+	});
+
 	ClassFuidConverter.run();
 });
 


### PR DESCRIPTION
## Summary

`ClassFuidConverter` currently runs only once during the system `ready` hook. Skills, spells, or heroic items added to actors mid-session keep their original `system.class.value` (which can be the class display name with capitalization, e.g. `"Predator"`) and never get normalized to the matching class `fuid` (`"predator"`). The character sheet's class level tally compares the slugified class name against this stored value, so the affected class silently reports `0/10` on the Classes tab even though the player has invested skill ranks in it.

This PR makes two narrow adjustments:

1. **Run the converter on `createItem`.** A `createItem` hook in `projectfu.mjs` calls a new `ClassFuidConverter.convertItem(item)` helper so that newly added skills/spells/heroic items are normalized immediately instead of having to wait for the next world reload.
2. **Don't set `flags.projectfu.classConverted` on unresolved items.** Previously the flag was set unconditionally in `convertClassAttributeFromClassLists`, even when the converter could not find a matching class (e.g. compendium not yet loaded, class not yet added to the world). That marked the item as migrated and prevented retries on subsequent sessions. The flag is now only set when every class reference resolved.

## Repro

1. Create a character with class A (whose `fuid` matches its display name slugified).
2. Add class B to the same character (where class B is a class whose skills ship with `system.class.value` using a different casing than the class `fuid`, e.g. `Predator` skills from compendium content).
3. Add one of class B's skills to the character.
4. Open the Classes tab: class B shows `0/10` although the skill has ranks.

After the fix, the new skill's `system.class.value` is normalized at creation time and the tally is correct without reloading the world.

## Notes

- The conversion logic itself is unchanged; only its invocation pattern.
- The pre-existing `ClassFuidConverter.run()` migration sweep on `ready` still runs as before, so worlds opened before this change still get caught up on the next launch (and now correctly retry items that previously failed silently).
- No new dependencies, no schema changes, no breaking changes to the public API of `ClassFuidConverter` (`run()` kept; `convertItem()` added).