### PR TITLE
feat: Add support for referencing mnemosphere skills for companions

### DIFF
--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -375,7 +375,7 @@ export class FUActor extends Actor {
 	 */
 	getItemsByFuid(fuid, type) {
 		const fuidFilter = (i) => i.system.fuid === fuid;
-		if (!type) return this.items.filter(fuidFilter);
+		if (!type) return this.allItems().filter(fuidFilter).toArray();
 		const itemTypes = this.itemTypes;
 		if (!Object.prototype.hasOwnProperty.call(itemTypes, type)) {
 			throw new Error(`Type ${type} is invalid!`);

--- a/module/documents/actors/npc/npc-data-model.mjs
+++ b/module/documents/actors/npc/npc-data-model.mjs
@@ -28,6 +28,12 @@ Hooks.on('preUpdateActor', async (document, changed) => {
 		if (roleChanged || levelChanged) {
 			setRoleAttributes(document, newRole, newLevel);
 		}
+
+		if (foundry.utils.hasProperty(changed, 'system.references.actor')) {
+			if (!changed.system.references.actor) {
+				foundry.utils.setProperty(changed, 'system.references.skill', null);
+			}
+		}
 	}
 });
 
@@ -75,6 +81,9 @@ Hooks.on('preUpdateActor', async (document, changed) => {
  * @property {string} associatedTherioforms
  * @property {NpcSkillTracker} spTracker
  * @property {TraitsDataModel} pressurePoints
+ * @property {Object} references
+ * @property {FUActor|null} actor
+ * @property {string|null} skill
  */
 export class NpcDataModel extends BaseCharacterDataModel {
 	static defineSchema() {

--- a/module/sheets/actor-sheet-utils.mjs
+++ b/module/sheets/actor-sheet-utils.mjs
@@ -354,19 +354,27 @@ function prepareCharacterData(context) {
 function prepareNpcCompanionData(context) {
 	if (context.actor.system.rank.value === 'companion' || context.actor.system.rank.value === 'custom') {
 		// Populate the dropdown with owned actors
-		context.ownedActors = game.actors.filter((a) => a.type === 'character' && a.testUserPermission(game.user, 'OWNER'));
+		context.ownedActors = Object.fromEntries(game.actors.filter((a) => a.type === 'character' && a.testUserPermission(game.user, 'OWNER')).map((actor) => [actor.id, actor.name]));
 
 		// Check if a refActor is selected
 		const refActor = context.system.references.actor;
-		context.refActorLevel = refActor ? refActor.system.level.value : 0;
+		context.refActorId = refActor?.id;
+		context.refActorLevel = refActor?.system.level.value ?? 0;
 
 		if (refActor) {
 			// Filter skills associated with the refActor
-			context.availableSkills = refActor.items.filter((item) => item.type === 'skill');
+			context.availableSkills = Object.fromEntries(
+				refActor
+					.allItems()
+					.filter((item) => item.type === 'skill')
+					.map((skill) => [skill.uuid, skill.name])
+					.toArray(),
+			);
 
 			// Retrieve the selected referenceSkill by UUID
-			context.refSkill = context.system.references.skill ? context.availableSkills.find((skill) => skill.uuid === context.system.references.skill) : null;
-			context.refSkillLevel = context.refSkill ? context.refSkill.system.level.value || 0 : 0;
+			context.refSkill = context.system.references.skill;
+			const referencedSkill = foundry.utils.fromUuidSync(context.system.references.skill);
+			context.refSkillLevel = referencedSkill?.system.level.value ?? 0;
 		} else {
 			// No referencePlayer selected, clear skills and selected skill
 			context.availableSkills = [];

--- a/templates/actor/character/parts/actor-section-settings.hbs
+++ b/templates/actor/character/parts/actor-section-settings.hbs
@@ -365,36 +365,22 @@
 					<!-- Companion -->
 					{{#if (or (eq actor.system.rank.value "companion") (eq actor.system.rank.value "custom"))}}
 						<label class="resource-label-sm flexcol flex-group-center"
-							   data-tooltip="{{localize 'FU.Reference'}}) {{localize 'FU.PlayerLevel'}}"
-							   for="refActor">
+							   data-tooltip="{{localize 'FU.Reference'}}) {{localize 'FU.PlayerLevel'}}">
 							<i class="fa-solid fa-user-group"></i>
 							{{localize 'FU.Player'}}
 							<span class="resource-label-m">LV: {{refActorLevel}}</span>
-							<select name="system.references.actor" id="refActor" class="resource-inputs">
-								<option value="">—</option>
-								{{#each ownedActors as |owned|}}
-									<option value="{{owned.id}}"
-											{{#if (eq ../system.references.actor.id owned.id)}}selected{{/if}}>
-										{{owned.name}}
-									</option>
-								{{/each}}
+							<select name="system.references.actor" class="resource-inputs">
+								{{selectOptions ownedActors blank="—" selected=refActorId sort=true}}
 							</select>
 						</label>
 
 						<label class="resource-label-sm flexcol flex-group-center"
-							   data-tooltip="{{localize 'FU.Reference'}}) {{localize 'FU.SkillLevel'}}"
-							   for="refSkill">
+							   data-tooltip="{{localize 'FU.Reference'}}) {{localize 'FU.SkillLevel'}}">
 							<i class="fa-solid fa-cogs"></i>
 							{{localize 'FU.Skill'}}
 							<span class="resource-label-m">SL: {{refSkillLevel}}</span>
-							<select name="system.references.skill" id="refSkill" class="resource-inputs">
-								<option value="">—</option>
-								{{#each availableSkills as |skill|}}
-									<option value="{{skill.uuid}}"
-											{{#if (eq ../system.references.skill skill.uuid)}}selected{{/if}}>
-										{{skill.name}}
-									</option>
-								{{/each}}
+							<select name="system.references.skill" class="resource-inputs">
+								{{selectOptions availableSkills blank="—" selected=refSkill sort=true}}
 							</select>
 						</label>
 					{{/if}}


### PR DESCRIPTION
- pull available skills from all actor skills, including skills nested in mnemospheres
- refactor sheet data preparation and dropdowns to use `selectOptions` helper
- add "sanity check" to preUpdate hook for npcs, removing skill reference whenever actor reference is removed

fixes #595 