### PR TITLE
Localize NPC source for spells in Compendium Browser

### DIFF
--- a/module/ui/compendium/compendium-browser.mjs
+++ b/module/ui/compendium/compendium-browser.mjs
@@ -66,6 +66,7 @@ class SpellsCompendiumTableRenderer extends CompendiumTableRenderer {
 			cost: CommonColumns.propertyColumn('FU.Cost', 'system.cost.amount'),
 			class: CommonColumns.propertyColumn('FU.Class', 'system.class.value', {
 				mapFunction: (value) => {
+					if (value.toLowerCase() === 'npc') return 'ACTOR.TypeNpc';
 					return CompendiumIndex.instance.getItemByFuidSync(value)?.name ?? StringUtils.titleToKebab(value);
 				},
 			}),


### PR DESCRIPTION
This PR adds a quick check when retrieving the name of a class for the spell table, to ensure we are using the NPC localization key where appropriate.