### PR TITLE
Optional rules setting application TPL notice

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2008,6 +2008,7 @@
 		"AdversaryFilterMisc": "Miscellaneous",
 		"AbilityNoWeaponSelected": "No weapon selected!",
 		"ThemeFoundrySetting": "Apply Theme to Core Foundry",
-		"ThemeFoundrySettingHint": "If enabled, the theme configured for the ProjectFU system will also be applied to many parts of the core Foundry interface."
+		"ThemeFoundrySettingHint": "If enabled, the theme configured for the ProjectFU system will also be applied to many parts of the core Foundry interface.",
+		"OptionalRulesTPLNotice": "<i class='fa-solid fa-triangle-exclamation warning'></i> <strong>Note:</strong> Several of the items below are not included in the compendia distributed with the system, as they are not covered by the Fabula Ultima Third Party License, and will require manual entry to create them.<br>These items include:  Quirks, Zero Powers, variant Arcana, and Camping Activities"
 	}
 }

--- a/module/settings.js
+++ b/module/settings.js
@@ -354,18 +354,22 @@ export const registerSystemSettings = async function () {
 		label: game.i18n.localize('FU.OptionalRulesManage'),
 		hint: game.i18n.localize('FU.OptionalRulesSettingsInstuction'),
 		icon: 'fas fa-book',
-		type: createConfigurationApp('FU.OptionalRules', [
-			SETTINGS.optionQuirks,
-			SETTINGS.optionZeroPower,
-			SETTINGS.optionArcanumPulse,
-			SETTINGS.optionCampingRules,
-			SETTINGS.useRevisedStudyRule,
-			SETTINGS.technospheres,
-			SETTINGS.pressureSystem,
-			SETTINGS.optionPressureGaugeShow,
-			SETTINGS.optionPressureGaugePosition,
-			SETTINGS.optionPressureGaugeTheme,
-		]),
+		type: createConfigurationApp(
+			'FU.OptionalRules',
+			[
+				SETTINGS.optionQuirks,
+				SETTINGS.optionZeroPower,
+				SETTINGS.optionArcanumPulse,
+				SETTINGS.optionCampingRules,
+				SETTINGS.useRevisedStudyRule,
+				SETTINGS.technospheres,
+				SETTINGS.pressureSystem,
+				SETTINGS.optionPressureGaugeShow,
+				SETTINGS.optionPressureGaugePosition,
+				SETTINGS.optionPressureGaugeTheme,
+			],
+			'FU.OptionalRulesTPLNotice',
+		),
 		restricted: true,
 	});
 
@@ -1148,11 +1152,17 @@ export const registerSystemSettings = async function () {
  * @return {typeof SettingsConfigurationApp}
  * @remarks Expects the settings to be various settings to be already registered, but hidden.
  */
-function createConfigurationApp(name, settings) {
+function createConfigurationApp(name, settings, headerText = '') {
 	return class ConfigApp extends SettingsConfigurationApp {
 		static DEFAULT_OPTIONS = {
 			window: { title: name },
 		};
+
+		async _prepareContext(options) {
+			const context = await super._prepareContext(options);
+			context.headerText = headerText;
+			return context;
+		}
 
 		constructor() {
 			super(settings);

--- a/module/settings/settings-configuration-app.js
+++ b/module/settings/settings-configuration-app.js
@@ -1,5 +1,6 @@
 import FUApplication from '../ui/application.mjs';
 import { SYSTEM } from '../helpers/config.mjs';
+import { systemTemplatePath } from '../helpers/system-utils.mjs';
 
 export class SettingsConfigurationApp extends FUApplication {
 	/** @type ApplicationConfiguration */
@@ -15,7 +16,10 @@ export class SettingsConfigurationApp extends FUApplication {
 	/** @type {Record<string, HandlebarsTemplatePart>} */
 	static PARTS = {
 		main: {
-			template: 'systems/projectfu/templates/app/settings/settings-config-app.hbs',
+			template: systemTemplatePath('app/settings/settings-config-app'),
+		},
+		footer: {
+			template: 'templates/generic/form-footer.hbs',
 		},
 	};
 
@@ -77,6 +81,9 @@ export class SettingsConfigurationApp extends FUApplication {
 		Object.assign(context, {
 			settings: this.#settingData,
 		});
+
+		context.buttons = [{ type: 'submit', icon: 'fa-solid fa-floppy-disk', label: 'FU.SettingsSave' }];
+
 		return context;
 	}
 

--- a/styles/css/app/settings-config-app.css
+++ b/styles/css/app/settings-config-app.css
@@ -14,6 +14,14 @@
 		}
 	}
 
+	.warning {
+		color: #eed202;
+	}
+
+	.scrollable {
+		margin-right: 0;
+	}
+
 	.setting {
 		padding-bottom: 0.5em;
 	}

--- a/templates/app/settings/settings-config-app.hbs
+++ b/templates/app/settings/settings-config-app.hbs
@@ -1,12 +1,11 @@
-<div class="desc">
+<div class="desc scrollable">
+	{{#if headerText}}
+		{{{localize headerText}}}
+		<hr>
+	{{/if}}
 	{{#each settings as |setting|}}
 		<div class="setting">
 			{{formGroup setting.field value=setting.value localize=true}}
 		</div>
 	{{/each}}
-	<div class="form-group buttons">
-		<button type="submit">
-			<i class="fas fa-floppy-disk"></i>{{localize "FU.SettingsSave"}}
-		</button>
-	</div>
 </div>


### PR DESCRIPTION
Adds the ability to have header text for the generic setting applications, and adds a disclaimer to the optional rules setting application notifying users that optional item types will need to be manually created.

To hopefully reduce how many people ask where they are
<img width="478" height="217" alt="image" src="https://github.com/user-attachments/assets/886494e9-24c4-4449-b698-f463cd8dda14" />
