### PR TITLE
Force Taste Alias To Be a String

### DIFF
--- a/module/documents/items/classFeature/gourmet/cookbook-data-model.mjs
+++ b/module/documents/items/classFeature/gourmet/cookbook-data-model.mjs
@@ -55,7 +55,7 @@ export class CookbookDataModel extends RollableClassFeatureDataModel {
 		let tastes = { ...TASTES };
 		if (model.actor) {
 			for (const taste of Object.keys(tastes)) {
-				tastes[taste] = model.actor.getFlag(SYSTEM, getTasteAliasFlag(taste)) || TASTES[taste];
+				tastes[taste] = String(model.actor.getFlag(SYSTEM, getTasteAliasFlag(taste)) || TASTES[taste]);
 			}
 		}
 		return {

--- a/module/documents/items/classFeature/gourmet/ingredient-data-model.mjs
+++ b/module/documents/items/classFeature/gourmet/ingredient-data-model.mjs
@@ -86,7 +86,7 @@ export class IngredientDataModel extends ClassFeatureDataModel {
 		let tastes = { ...TASTES };
 		if (model.actor) {
 			for (const taste of Object.keys(tastes)) {
-				tastes[taste] = model.actor.getFlag(SYSTEM, getTasteAliasFlag(taste)) || TASTES[taste];
+				tastes[taste] = String(model.actor.getFlag(SYSTEM, getTasteAliasFlag(taste)) || TASTES[taste]);
 			}
 		}
 		return {


### PR DESCRIPTION
When the taste alias is set as a number, the rendering errors and fails when it attempts to do a string operation on it.