### PR TITLE
Bugfix: Default to primary actor when no tokens are selected

### DIFF
--- a/module/helpers/target-handler.mjs
+++ b/module/helpers/target-handler.mjs
@@ -60,8 +60,12 @@ export async function getPrioritizedUserTargeted() {
 export async function getSelected(warn = true) {
 	const targets = canvas.tokens.controlled.map((token) => token.document.actor).filter((actor) => actor);
 
-	if (targets.length === 0 && warn) {
-		ui.notifications.warn('FU.ChatApplyEffectNoActorsSelected', { localize: true });
+	if (targets.length === 0) {
+		if (!game.user.isGM && game.user.character) {
+			return [game.user.character];
+		} else if (warn) {
+			ui.notifications.warn('FU.ChatApplyEffectNoActorsSelected', { localize: true });
+		}
 	}
 	return targets || [];
 }


### PR DESCRIPTION
- for players only default to the primary actor when determining the target of an action and no token is selected