### PR TITLE
Bugfix: Spellblade not properly accounting for skill level

### DIFF
--- a/module/documents/effects/predicates/check-rule-predicate.mjs
+++ b/module/documents/effects/predicates/check-rule-predicate.mjs
@@ -1,7 +1,6 @@
 import { RulePredicateDataModel } from './rule-predicate-data-model.mjs';
 import { systemTemplatePath } from '../../../helpers/system-utils.mjs';
 import { FU } from '../../../helpers/config.mjs';
-import { ItemAttributesDataModel } from '../../items/common/item-attributes-data-model.mjs';
 import { FUHooks } from '../../../hooks.mjs';
 import { CheckConfiguration } from '../../../checks/check-configuration.mjs';
 
@@ -31,7 +30,10 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 		return Object.assign(super.defineSchema(), {
 			parity: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.parity) }),
 			outcome: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.checkOutcome) }),
-			attributes: new fields.EmbeddedDataField(ItemAttributesDataModel, { initial: { primary: { value: '' }, secondary: { value: '' } } }),
+			attributes: new fields.SchemaField({
+				primary: new fields.SchemaField({ value: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.attributes) }) }),
+				secondary: new fields.SchemaField({ value: new fields.StringField({ initial: '', blank: true, choices: Object.keys(FU.attributes) }) }),
+			}),
 			result: new fields.NumberField({ integer: true }),
 			quantifier: new fields.StringField({
 				initial: 'any',

--- a/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
+++ b/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
@@ -167,8 +167,7 @@
                 "eventRelation": "source",
                 "checkTypes": [
                   "magic"
-                ],
-                "identifier": ""
+                ]
               },
               "predicates": {
                 "YAHJUD5SD1ClxolQ": {
@@ -178,9 +177,6 @@
                   "attributes": {
                     "primary": {
                       "value": "dex"
-                    },
-                    "secondary": {
-                      "value": ""
                     }
                   }
                 },
@@ -217,11 +213,6 @@
             "current": 0,
             "max": 6,
             "style": "basic"
-          },
-          "stacking": {
-            "progress": false,
-            "duration": false,
-            "increment": 1
           }
         }
       },
@@ -247,8 +238,8 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1743535722306,
-        "modifiedTime": 1780819122735,
-        "lastModifiedBy": "VpDy3go69LzoCFsX",
+        "modifiedTime": 1771832393259,
+        "lastModifiedBy": "mA8SNY2rY4X5tOHa",
         "exportSource": null
       },
       "_key": "!items.effects!v6rTedHMjbLuLdN3.DhBhEANF8jRMaBo4"

--- a/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
+++ b/src/packs/skills/skill_Spellblade_v6rTedHMjbLuLdN3.json
@@ -167,7 +167,8 @@
                 "eventRelation": "source",
                 "checkTypes": [
                   "magic"
-                ]
+                ],
+                "identifier": ""
               },
               "predicates": {
                 "YAHJUD5SD1ClxolQ": {
@@ -177,6 +178,9 @@
                   "attributes": {
                     "primary": {
                       "value": "dex"
+                    },
+                    "secondary": {
+                      "value": ""
                     }
                   }
                 },
@@ -213,6 +217,11 @@
             "current": 0,
             "max": 6,
             "style": "basic"
+          },
+          "stacking": {
+            "progress": false,
+            "duration": false,
+            "increment": 1
           }
         }
       },
@@ -238,8 +247,8 @@
         "systemId": "projectfu",
         "systemVersion": "#{VERSION}#",
         "createdTime": 1743535722306,
-        "modifiedTime": 1771832393259,
-        "lastModifiedBy": "mA8SNY2rY4X5tOHa",
+        "modifiedTime": 1780819122735,
+        "lastModifiedBy": "VpDy3go69LzoCFsX",
         "exportSource": null
       },
       "_key": "!items.effects!v6rTedHMjbLuLdN3.DhBhEANF8jRMaBo4"


### PR DESCRIPTION
- fix Spellblade check bonus required attributes incorrectly initializing to [DEX + DEX]

I was unable to reproduce the issue in #1199 but found that Spellblade does not correctly add the skill level as bonus to check formulas that include dexterity only once and fixed that.

fixes #1199 