### PR TITLE
Bugfix: Rule elements not invoked for meta currency changes

### DIFF
--- a/module/documents/effects/triggers/resource-update-rule-trigger.mjs
+++ b/module/documents/effects/triggers/resource-update-rule-trigger.mjs
@@ -85,7 +85,7 @@ export class ResourceUpdateRuleTrigger extends RuleTriggerDataModel {
 		}
 
 		if (this.changeThreshold.operator) {
-			const comparisonOperation = ComparisonOperations[this.threshold.operator];
+			const comparisonOperation = ComparisonOperations[this.changeThreshold.operator];
 			if (!comparisonOperation(Math.abs(amount), Math.abs(this.changeThreshold.amount))) {
 				return false;
 			}

--- a/module/enrichers/inline-resources.mjs
+++ b/module/enrichers/inline-resources.mjs
@@ -179,7 +179,7 @@ async function applyRecovery(sourceInfo, targets, resourceType, amount, uncapped
 }
 
 async function applyLoss(sourceInfo, targets, resourceType, amount) {
-	const request = new ResourceRequest(sourceInfo, targets, resourceType, amount);
+	const request = new ResourceRequest(sourceInfo, targets, resourceType, amount < 0 ? amount : -amount);
 	return ResourcePipeline.processLoss(request);
 }
 

--- a/module/helpers/player-list-enhancements.mjs
+++ b/module/helpers/player-list-enhancements.mjs
@@ -1,6 +1,8 @@
 import { CharacterDataModel } from '../documents/actors/character/character-data-model.mjs';
 import { SYSTEM } from './config.mjs';
 import { Flags } from './flags.mjs';
+import { CommonEvents } from '../checks/common-events.mjs';
+import { InlineSourceInfo } from './inline-helper.mjs';
 
 /**
  * @param {UserData} user
@@ -134,6 +136,7 @@ async function spendMetaCurrency(actor, force = false) {
 				},
 			};
 			ChatMessage.create(data);
+			await CommonEvents.resource(actor, [actor], InlineSourceInfo.fromObject(actor), 'fp', -1, null, null);
 			await actor.update({
 				'system.resources.fp.value': actor.system.resources.fp.value - 1,
 			});
@@ -158,6 +161,7 @@ async function gainMetaCurrency(actor) {
 		metaCurrency = game.i18n.localize('FU.Ultima');
 	}
 	if (metaCurrency) {
+		await CommonEvents.resource(actor, [actor], InlineSourceInfo.fromObject(actor), 'fp', 1, null, null);
 		await actor.update({
 			'system.resources.fp.value': actor.system.resources.fp.value + 1,
 		});

--- a/module/pipelines/resource-pipeline.mjs
+++ b/module/pipelines/resource-pipeline.mjs
@@ -175,6 +175,9 @@ function calculateMissingResource(actor, resourcePath) {
  */
 async function createChatMessage(request, actor, amount, flavor, template, message, renderData) {
 	const chat = new FUChatBuilder(actor, request.item).withData(renderData).withFlags(Pipeline.initializedFlags(Flags.ChatMessage.ResourceGain, true)).withFlavor(flavor);
+	if (request.resourceType === 'fp' && !request.gain) {
+		chat.withFlags(Pipeline.initializedFlags(Flags.ChatMessage.UseMetaCurrency, amount));
+	}
 	CommonSections.template(
 		chat.sections,
 		template,

--- a/module/ui/metacurrency/MetaCurrencyTrackerApplication.mjs
+++ b/module/ui/metacurrency/MetaCurrencyTrackerApplication.mjs
@@ -64,13 +64,14 @@ function handleMetaCurrencyUsed(document, options, userId) {
 	}
 	let useMetaCurrency = document.getFlag(SYSTEM, Flags.ChatMessage.UseMetaCurrency);
 	if (useMetaCurrency && game.users.activeGM?.isSelf) {
+		const amount = typeof useMetaCurrency === 'number' ? useMetaCurrency : 1;
 		const speakerActor = ChatMessage.getSpeakerActor(document.speaker);
 		if (speakerActor) {
 			if (speakerActor.system instanceof CharacterDataModel) {
-				increment(SETTINGS.metaCurrencyFabula);
+				increment(SETTINGS.metaCurrencyFabula, amount);
 			}
 			if (speakerActor.system instanceof NpcDataModel) {
-				increment(SETTINGS.metaCurrencyUltima);
+				increment(SETTINGS.metaCurrencyUltima, amount);
 			}
 		}
 	}
@@ -79,9 +80,9 @@ function handleMetaCurrencyUsed(document, options, userId) {
 	}
 }
 
-function increment(setting) {
+function increment(setting, amount = 1) {
 	const oldValue = game.settings.get(SYSTEM, setting);
-	game.settings.set(SYSTEM, setting, oldValue + 1);
+	game.settings.set(SYSTEM, setting, oldValue + amount);
 }
 
 export class MetaCurrencyTrackerApplication extends FUApplication {


### PR DESCRIPTION
- have the meta currency handling call the resource event
- fix typo in ResourceUpdateRuleTrigger, causing resource operations with a threshold to throw an error

fixes #1213 