### PR TITLE
Automatically open support check prompt

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -2014,6 +2014,8 @@
 			"ChangeWarning1": "Proceed with caution!"
 		},
 		"NpcEquipmentSettings": "NPC Equipment",
-		"NpcEquipmentSettingsHint": "Controls whether NPCs can acquire the 'Use Equipment' skill, and the initial skill points available for 'Humanoid' NPCs."
+		"NpcEquipmentSettingsHint": "Controls whether NPCs can acquire the 'Use Equipment' skill, and the initial skill points available for 'Humanoid' NPCs.",
+		"SettingGroupCheckAutomaticPrompt": "Enable automatic Support Check prompts",
+		"SettingGroupCheckAutomaticPromptHint": "Enable to automatically open the Support Check prompt, whenever another player starts a Group Check."
 	}
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2015,7 +2015,9 @@
 		},
 		"NpcEquipmentSettings": "NPC Equipment",
 		"NpcEquipmentSettingsHint": "Controls whether NPCs can acquire the 'Use Equipment' skill, and the initial skill points available for 'Humanoid' NPCs.",
-		"SettingGroupCheckAutomaticPrompt": "Enable automatic Support Check prompts",
-		"SettingGroupCheckAutomaticPromptHint": "Enable to automatically open the Support Check prompt, whenever another player starts a Group Check."
+		"SettingGroupCheckAutomaticPrompt": "Automatic Group Check prompt",
+		"SettingGroupCheckAutomaticPromptHint": "Enable to automatically open the Support Check prompt, whenever another player starts a Group Check.",
+		"SettingInitiativeCheckAutomaticPrompt": "Automatic Initiative Check prompt",
+		"SettingInitiativeCheckAutomaticPromptHint": "Enable to automatically open the Support Check prompt, whenever another player starts an Initiative Check and your primary Character is part of the active Combat."
 	}
 }

--- a/module/checks/support-check.mjs
+++ b/module/checks/support-check.mjs
@@ -4,6 +4,7 @@ import { Checks } from './checks.mjs';
 import { CheckHooks } from './check-hooks.mjs';
 import { CheckConfiguration } from './check-configuration.mjs';
 import { CHECK_ROLL } from './default-section-order.mjs';
+import { getSystemSetting, SETTINGS } from '../settings.js';
 
 const supportCheckKey = 'supportCheck';
 
@@ -177,10 +178,20 @@ const getBond = (check) => {
 	return check.additionalData[supportCheckKey].bond ?? [];
 };
 
+const onCreateChatMessage = (chatMessage, options, userId) => {
+	const groupCheckFlag = chatMessage.getFlag(SYSTEM, Flags.ChatMessage.GroupCheckV2);
+	if (userId !== game.user.id && groupCheckFlag && getSystemSetting(SETTINGS.groupCheckAutomaticPrompt)) {
+		if (groupCheckFlag.status === 'open') {
+			handleSupportCheck(groupCheckFlag);
+		}
+	}
+};
+
 const initialize = () => {
 	Hooks.on('renderChatLog', attachSupportCheckListener);
 	Hooks.on(CheckHooks.prepareCheck, onPrepareCheck);
 	Hooks.on(CheckHooks.renderCheck, onRenderSupportCheck);
+	Hooks.on('createChatMessage', onCreateChatMessage);
 };
 
 export const SupportCheck = Object.freeze({

--- a/module/checks/support-check.mjs
+++ b/module/checks/support-check.mjs
@@ -52,6 +52,7 @@ async function handleSupportCheck(groupCheck, character) {
 				checkType: game.i18n.localize(groupCheck.initiative ? 'FU.InitiativeCheck' : 'FU.GroupCheck'),
 				bonds,
 			}),
+			rejectClose: true,
 			ok: {
 				callback: (event, button, dialog) => {
 					const selected = dialog.element.querySelector('[name=bond]:checked').value;
@@ -189,12 +190,12 @@ const onCreateChatMessage = (chatMessage, options, userId) => {
 	/** @type GroupCheckV2Flag */
 	const groupCheckFlag = chatMessage.getFlag(SYSTEM, Flags.ChatMessage.GroupCheckV2);
 
-	if (groupCheckFlag?.status === 'open' && groupCheckFlag.leader !== character.id && getSystemSetting(SETTINGS.groupCheckAutomaticPrompt)) {
-		if (groupCheckFlag.initiative) {
+	if (groupCheckFlag?.status === 'open' && groupCheckFlag.leader !== character.id) {
+		if (groupCheckFlag.initiative && getSystemSetting(SETTINGS.initiativeCheckAutomaticPrompt)) {
 			if (character.inCombat) {
 				handleSupportCheck(groupCheckFlag, character);
 			}
-		} else {
+		} else if (getSystemSetting(SETTINGS.groupCheckAutomaticPrompt)) {
 			handleSupportCheck(groupCheckFlag, character);
 		}
 	}

--- a/module/checks/support-check.mjs
+++ b/module/checks/support-check.mjs
@@ -10,10 +10,10 @@ const supportCheckKey = 'supportCheck';
 
 /**
  * @param {GroupCheckV2Flag} groupCheck
+ * @param {FUActor} character
  * @return {Promise<void>}
  */
-async function handleSupportCheck(groupCheck) {
-	const character = canvas.tokens.controlled.at(0)?.document.actor || game.user.character;
+async function handleSupportCheck(groupCheck, character) {
 	if (!character) {
 		ui.notifications.error('FU.GroupCheckMissingCharacter', { localize: true });
 		return;
@@ -49,6 +49,7 @@ async function handleSupportCheck(groupCheck) {
 			options: { classes: ['projectfu', 'unique-dialog', 'backgroundstyle'] },
 			content: await foundry.applications.handlebars.renderTemplate('systems/projectfu/templates/dialog/dialog-group-check-support-bond.hbs', {
 				leader: game.actors.get(groupCheck.leader).name,
+				checkType: game.i18n.localize(groupCheck.initiative ? 'FU.InitiativeCheck' : 'FU.GroupCheck'),
 				bonds,
 			}),
 			ok: {
@@ -98,7 +99,8 @@ function attachSupportCheckListener(chatLog, html) {
 				if (groupCheck && groupCheck.status === 'open') {
 					event.target.disabled = true;
 					try {
-						await handleSupportCheck(groupCheck);
+						const character = canvas.tokens.controlled.at(0)?.document.actor || game.user.character;
+						await handleSupportCheck(groupCheck, character);
 					} finally {
 						event.target.disabled = false;
 					}
@@ -179,10 +181,21 @@ const getBond = (check) => {
 };
 
 const onCreateChatMessage = (chatMessage, options, userId) => {
+	const character = game.user.character;
+	if (game.user.isGM || !character) {
+		return;
+	}
+
+	/** @type GroupCheckV2Flag */
 	const groupCheckFlag = chatMessage.getFlag(SYSTEM, Flags.ChatMessage.GroupCheckV2);
-	if (userId !== game.user.id && groupCheckFlag && getSystemSetting(SETTINGS.groupCheckAutomaticPrompt)) {
-		if (groupCheckFlag.status === 'open') {
-			handleSupportCheck(groupCheckFlag);
+
+	if (groupCheckFlag?.status === 'open' && groupCheckFlag.leader !== character.id && getSystemSetting(SETTINGS.groupCheckAutomaticPrompt)) {
+		if (groupCheckFlag.initiative) {
+			if (character.inCombat) {
+				handleSupportCheck(groupCheckFlag, character);
+			}
+		} else {
+			handleSupportCheck(groupCheckFlag, character);
 		}
 	}
 };

--- a/module/settings.js
+++ b/module/settings.js
@@ -114,6 +114,8 @@ export const SETTINGS = Object.freeze({
 	optionEnableDragRulerGridded: 'optionEnableDragRulerGridded',
 	// Compendium Browser
 	optionCompendiumBrowserPacks: 'optionCompendiumBrowserPacks',
+	// Checks
+	groupCheckAutomaticPrompt: 'groupCheckAutomaticPrompt',
 });
 
 /**
@@ -1154,6 +1156,16 @@ export const registerSystemSettings = async function () {
 		requiresReload: true,
 		default: 'all',
 		choices: FU.compendiumBrowserPacks,
+	});
+
+	game.settings.register(SYSTEM, SETTINGS.groupCheckAutomaticPrompt, {
+		name: game.i18n.localize('FU.SettingGroupCheckAutomaticPrompt'),
+		hint: game.i18n.localize('FU.SettingGroupCheckAutomaticPromptHint'),
+		scope: 'user',
+		config: true,
+		type: Boolean,
+		requiresReload: false,
+		default: false,
 	});
 };
 

--- a/module/settings.js
+++ b/module/settings.js
@@ -116,6 +116,7 @@ export const SETTINGS = Object.freeze({
 	optionCompendiumBrowserPacks: 'optionCompendiumBrowserPacks',
 	// Checks
 	groupCheckAutomaticPrompt: 'groupCheckAutomaticPrompt',
+	initiativeCheckAutomaticPrompt: 'initiativeCheckAutomaticPrompt',
 });
 
 /**
@@ -1166,6 +1167,16 @@ export const registerSystemSettings = async function () {
 		type: Boolean,
 		requiresReload: false,
 		default: false,
+	});
+
+	game.settings.register(SYSTEM, SETTINGS.initiativeCheckAutomaticPrompt, {
+		name: game.i18n.localize('FU.SettingInitiativeCheckAutomaticPrompt'),
+		hint: game.i18n.localize('FU.SettingInitiativeCheckAutomaticPromptHint'),
+		scope: 'user',
+		config: true,
+		type: Boolean,
+		requiresReload: false,
+		default: true,
 	});
 };
 

--- a/templates/dialog/dialog-group-check-support-bond.hbs
+++ b/templates/dialog/dialog-group-check-support-bond.hbs
@@ -1,6 +1,6 @@
 <div class='dialog-group-check-support desc'>
     <div>
-        <p>{{localize 'FU.GroupCheckBondDialogContent'}} <span class='leader'>{{leader}}</span></p>
+        <p>{{localize 'FU.GroupCheckBondDialogContent' type=checkType}} <span class='leader'>{{leader}}</span></p>
     </div>
     <div class='flexcol'>
         <label class='bond'>


### PR DESCRIPTION
- add setting controlling whether the user gets automatically prompted for a Support Check whenever another user starts a Group Check
- for Initiative Checks only prompt players who take part in combat

fixes #1201 