### PR TITLE
Bugfix: Targets get removed when over max allowed

### DIFF
--- a/module/checks/common-sections.mjs
+++ b/module/checks/common-sections.mjs
@@ -451,7 +451,7 @@ const actions = (data, actor, item, targetData, flags, inspector = undefined) =>
 			let rule;
 			if (item && item.system.targeting) {
 				rule = item.system.targeting.rule ?? Targeting.rule.multiple;
-				targetData = await Targeting.filterTargetsByRule(actor, item, targetData);
+				targetData = await Targeting.processTargetData(actor, item, targetData);
 			} else {
 				rule = targetData?.length > 1 ? Targeting.rule.multiple : Targeting.rule.single;
 			}

--- a/module/helpers/targeting.mjs
+++ b/module/helpers/targeting.mjs
@@ -42,9 +42,10 @@ const STRICT_TARGETING = false;
  * @param {FUActor[] | Token[] | TargetData[]} targets
  * @returns {FUActor[]|FUItem}
  */
-async function filterTargetsByRule(actor, item, targets) {
+async function processTargetData(actor, item, targets) {
 	if (!item.system.targeting) {
-		throw Error(`"No targeting data model in the given item ${item.name}`);
+		ui.notifications.warn(`"No targeting data model in the given item ${item.name}`);
+		return targets;
 	}
 
 	/**
@@ -56,19 +57,13 @@ async function filterTargetsByRule(actor, item, targets) {
 		case 'self':
 			return [];
 		case 'single':
-			if (targets.length === 0) {
-				return [];
-			} else if (targets.length > 1) {
+			if (targets.length > 1) {
 				ui.notifications.warn('FU.ChatApplyMaxTargetWarning', { localize: true });
-				return [];
 			}
-			return [targets[0]];
+			return targets;
 		case 'multiple':
-			if (targets.length === 0) {
-				return [];
-			} else if (targets.length > targeting.max.value) {
+			if (targets.length > targeting.max) {
 				ui.notifications.warn('FU.ChatApplyMaxTargetWarning', { localize: true });
-				return [];
 			}
 			return targets;
 		case 'weapon': {
@@ -202,7 +197,7 @@ export const Targeting = Object.freeze({
 		weapon: 'weapon',
 		special: 'special',
 	},
-	filterTargetsByRule,
+	processTargetData,
 	getSerializedTargetData,
 	serializeTargetData,
 	deserializeTargetData,


### PR DESCRIPTION
- fix 'single' and 'multiple' targeting rules forcibly removing targets when above allowed number of targets
- fix 'multiple' targeting rule never taking effect because 'targeting.max.value' did not exist

fixes #1219 