### PR TITLE
feat:Adds check for Heroic Skills with no Class specified; Fixes #1221

### DIFF
--- a/module/ui/compendium/compendium-filter.mjs
+++ b/module/ui/compendium/compendium-filter.mjs
@@ -49,6 +49,9 @@ export class CompendiumFilter {
 			if (this.categories) {
 				for (const category of Object.values(this.categories)) {
 					if (category.selected?.size > 0) {
+						// Make sure we show Heroic Skills that are universal.
+						if (entry.type === 'heroic' && entry.metadata.class === undefined) return true;
+
 						const paths = Array.isArray(category.propertyPath) ? category.propertyPath : [category.propertyPath];
 						const matchesAnyPath = paths.some((path) => {
 							const value = foundry.utils.getProperty(entry, path);


### PR DESCRIPTION
Adds check for heroic skills with no class specified (Extra Spells, Ambidexterity, etc) to ensure they show up when filtering by class, as they are still valid options.