### PR TITLE
Feature/filter selected character npc

### DIFF
--- a/module/helpers/target-handler.mjs
+++ b/module/helpers/target-handler.mjs
@@ -58,7 +58,10 @@ export async function getPrioritizedUserTargeted() {
  * @returns {Promise<FUActor[]>}
  */
 export async function getSelected(warn = true) {
-	const targets = canvas.tokens.controlled.map((token) => token.document.actor).filter((actor) => actor);
+	const targets = canvas.tokens.controlled
+		.map((token) => token.document.actor)
+		.filter((actor) => actor)
+		.filter((actor) => actor.isCharacterType);
 
 	if (targets.length === 0) {
 		if (!game.user.isGM && game.user.character) {

--- a/module/helpers/target-handler.mjs
+++ b/module/helpers/target-handler.mjs
@@ -58,10 +58,7 @@ export async function getPrioritizedUserTargeted() {
  * @returns {Promise<FUActor[]>}
  */
 export async function getSelected(warn = true) {
-	const targets = canvas.tokens.controlled
-		.map((token) => token.document.actor)
-		.filter((actor) => actor)
-		.filter((actor) => actor.isCharacterType);
+	const targets = canvas.tokens.controlled.map((token) => token.document.actor).filter((actor) => actor?.isCharacterType);
 
 	if (targets.length === 0) {
 		if (!game.user.isGM && game.user.character) {


### PR DESCRIPTION
- filter selected for actions to only return 'character' or 'npc' actors

This helps with the situation where a player has selected the party token for overworld travel but uses an elixir for example.
Trying to restore MP to the party throws an error in the console but has no visible effect to the player, causing confusion.
With this change the player will be treated as if they had not selected the party, thus defaulting to their primary character.
This behaviour is likely what most players expect to happen.