### PR TITLE
Bugfix: Clocks from non-applicable effects shown in overview tab

### DIFF
--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -280,14 +280,6 @@ export class FUActor extends Actor {
 		}
 	}
 
-	// TODO: Use the above name
-	/**
-	 * @returns {ActiveEffect[]}
-	 */
-	get combinedEffects() {
-		return Array.from(this.allEffects());
-	}
-
 	/**
 	 * @override
 	 * @returns {FUActiveEffect[]}

--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -405,6 +405,10 @@ export class FUStandardActorSheet extends FUActorSheet {
 
 					context.favoritesTable = await this.#favoritesTable.renderTable(this.document);
 					context.temporaryEffects = this.actor.temporaryEffects.filter((e) => e.hasDuration);
+					context.effectsWithClocks = this.actor
+						.allApplicableEffects()
+						.filter((e) => e.system.rules.progress.enabled)
+						.toArray();
 				}
 				break;
 

--- a/templates/actor/partials/actor-clocks.hbs
+++ b/templates/actor/partials/actor-clocks.hbs
@@ -12,10 +12,8 @@
 		{{/if}}
 	{{/each}}
 
-	{{#each actor.combinedEffects as |effect|}}
-		{{#if effect.system.rules.progress.enabled}}
-			{{pfuProgress effect 'system.rules.progress' displayName=true style=effect.system.rules.progress.style }}
-		{{/if}}
+	{{#each effectsWithClocks as |effect|}}
+		{{pfuProgress effect 'system.rules.progress' displayName=true style=effect.system.rules.progress.style }}
 	{{/each}}
 
 	{{!-- Optional Feature Sections --}}


### PR DESCRIPTION
- only show clocks from applicable effects on the overview tab

This change addresses the issue of non-applicable clocks/progress tracks cluttering the overview tab.
An example is the 'Airmid' arcanum and its 'Medicine Points'.
The points are only relevant when the arcanist is merged with 'Airmid' and lose relevance as soon as the arcanum is dismissed.
As such they should only be displayed as long as the arcanist is merged.