### PR TITLE
Bugfix: Custom weapons not flagged as 'attack'

### DIFF
--- a/module/documents/items/customWeapon/custom-weapon-data-model.mjs
+++ b/module/documents/items/customWeapon/custom-weapon-data-model.mjs
@@ -51,6 +51,7 @@ const prepareCheck = (check, actor, item, registerCallback) => {
 				weaponCategory: item.system.category,
 				handedness: 'two-handed',
 			})
+			.addTraits(Traits.Attack)
 			.addTraits(Traits.Damage)
 			.addTraits(item.system.getDamageType())
 			.addTraits(...item.system.traits)


### PR DESCRIPTION
- add 'attack' trait to checks with custom weapons