### PR TITLE
Fixed Header Color in Global Theme

### DIFF
--- a/styles/css/global/theme.css
+++ b/styles/css/global/theme.css
@@ -607,7 +607,7 @@ app.projectfu .prosemirror menu {
 		& h6 {
 			font-family: var(--font-secondary);
 			font-weight: var(--font-weight-bold);
-			color: var(--color-border-primary);
+			color: var(--color-text-primary);
 		}
 
 		& h1 {


### PR DESCRIPTION
The global theme was using the Border Primary color for the header's text color incorrectly.

This makes the text in the popped out Encounter Tracker actually readable.
<img width="299" height="484" alt="image" src="https://github.com/user-attachments/assets/2eaf1780-7c19-4110-acb6-0413936bd632" />
