### PR TITLE
Removed Heroic Skill Class Caption

### DIFF
--- a/module/helpers/tables/heroics-table-renderer.mjs
+++ b/module/helpers/tables/heroics-table-renderer.mjs
@@ -38,13 +38,7 @@ export class HeroicsTableRenderer extends FUTableRenderer {
 		const context = new ExpressionContext(item.actor, item, []);
 		const data = {
 			FU,
-			class: item.system.class.value,
 		};
-
-		const clazz = await SkillLikeTableHelper.findMatchingClass(item);
-		if (clazz) {
-			data.class = clazz.name;
-		}
 
 		let mainWeapon = SkillLikeTableHelper.resolveMainWeapon(item);
 		if (mainWeapon) {


### PR DESCRIPTION
The Classes are not useful to display in the Heroic Class caption. So, removed the added data for it.