### PR TITLE
Fixed Effect Button Remove And Hover Text

### DIFF
--- a/lang/cn.json
+++ b/lang/cn.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "应用于目标",
 		"ChatApplySelected": "应用于选择",
 		"ChatDisableSelected": "[Ctrl + Click] to disable effect",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "点击以将效果应用于所选令牌。",
 		"ChatApplyNoTargetSelected": "No actor selected.",
 		"ChatApplyNoCharacterSelected": "No character selected. Unable to apply.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Auf anvisierte Ziele anwenden",
 		"ChatApplySelected": "Auf ausgewählte Tokens anwenden",
 		"ChatDisableSelected": "[STRG + Linksklick] um den Effekt zu deaktivieren.",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Klicken um Schaden für ausgewählte Tokens zu verrechnen.",
 		"ChatApplyNoTargetSelected": "Kein Akteur ausgewählt.",
 		"ChatApplyNoCharacterSelected": "Kein Charakter ausgewählt.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Apply to targeted token",
 		"ChatApplySelected": "Apply to selected token",
 		"ChatDisableSelected": "[Ctrl + Click] to disable effect",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Click to apply effect to selected tokens.",
 		"ChatApplyNoTargetSelected": "No actor selected.",
 		"ChatApplyNoCharacterSelected": "No character selected. Unable to apply.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Aplicar al token objetivo",
 		"ChatApplySelected": "Aplicar al token seleccionado",
 		"ChatDisableSelected": "[Ctrl + Clic] para deshabilitar efecto",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Haz click para aplicar daño a los tokens seleccionados.",
 		"ChatApplyNoTargetSelected": "Ningún actor seleccionado.",
 		"ChatApplyNoCharacterSelected": "Ningún personaje seleccionado. No se puede aplicar.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Appliquer aux cibles",
 		"ChatApplySelected": "Appliquer à la sélection",
 		"ChatDisableSelected": "[Ctrl + Clique] pour désactiver l'effet",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Cliquez pour appliquer des dégâts aux tokens sélectionnés.",
 		"ChatApplyNoTargetSelected": "Aucun acteur sélectionné",
 		"ChatApplyNoCharacterSelected": "Aucun personnage sélectionner. Impossible d'appliquer.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Applica al Bersaglio",
 		"ChatApplySelected": "Applica a Selezionato",
 		"ChatDisableSelected": "[Ctrl + Click] per disabilitare l'effetto",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Clicca per applicare danno ai token selezionati.",
 		"ChatApplyNoTargetSelected": "Nessun attore selezionato.",
 		"ChatApplyNoCharacterSelected": "Nessun personaggio selezionato. Impossibile applicare.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Zastosuj na cel",
 		"ChatApplySelected": "Zasosuj wybrane",
 		"ChatDisableSelected": "[Ctrl + Kliknij) by wyłączyć efekt",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Kliknij, aby zastosować efekt do wybranych tokenów",
 		"ChatApplyNoTargetSelected": "Nie wybrano aktora.",
 		"ChatApplyNoCharacterSelected": "No character selected. Unable to apply.",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Aplicar aos Alvos",
 		"ChatApplySelected": "Aplicar a seleção",
 		"ChatDisableSelected": "[Ctrl + Clique] para desligar o efeito",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Clique para aplicar dano aos personagens selecionados.",
 		"ChatApplyNoTargetSelected": "Nenhum personagem selecionado.",
 		"ChatApplyNoCharacterSelected": "Nenhum personagem selecionado. Não é possível aplicar.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -929,6 +929,7 @@
 		"ChatApplyTargeted": "Применить к нацеленным токенам",
 		"ChatApplySelected": "Применить к выбранным токенам",
 		"ChatDisableSelected": "[Ctrl + ЛКМ] для отключения эффекта",
+		"ChatExamineSelectedEffect": "[Right Click] to examine effect",
 		"ChatApplySelectedTooltip": "Нажмите, чтобы наложить эффект выбранным токенам.",
 		"ChatApplyNoTargetSelected": "Персонаж не выбран.",
 		"ChatApplyNoCharacterSelected": "Не выбран персонаж. Невозможно применить.",

--- a/module/enrichers/inline-effects.mjs
+++ b/module/enrichers/inline-effects.mjs
@@ -40,7 +40,7 @@ function createEffectAnchor(effect, label) {
 	anchor.draggable = true;
 	anchor.dataset.effect = StringUtils.toBase64(effect);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
-	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}`);
+	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}<br>${game.i18n.localize('FU.ChatExamineSelectedEffect')}`);
 	const icon = document.createElement('i');
 	icon.classList.add('fue', 'fu-effect-placeholder');
 	anchor.append(icon);
@@ -62,7 +62,7 @@ function createCompendiumEffectAnchor(effect, config, label) {
 	}
 	anchor.dataset.config = StringUtils.toBase64(config);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
-	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}`);
+	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}<br>${game.i18n.localize('FU.ChatExamineSelectedEffect')}`);
 	InlineHelper.appendImage(anchor, effect.img);
 	anchor.append(label ? label : effect.name);
 	return anchor;
@@ -217,7 +217,7 @@ async function onRender(element) {
 			const status = renderContext.dataset.status;
 			const statusEffect = CONFIG.statusEffects.find((value) => value.id === status);
 			if (statusEffect) {
-				effectData = { ...statusEffect, statuses: [status] };
+				effectData = { ...statusEffect, statuses: Set([status]) };
 			}
 		} else {
 			effectData = StringUtils.fromBase64(renderContext.dataset.effect);

--- a/module/enrichers/inline-effects.mjs
+++ b/module/enrichers/inline-effects.mjs
@@ -1,5 +1,5 @@
 import { statusEffects } from '../documents/effects/statuses.mjs';
-import { Effects, disableStatusEffect } from '../pipelines/effects.mjs';
+import { Effects } from '../pipelines/effects.mjs';
 import { targetHandler } from '../helpers/target-handler.mjs';
 import { InlineEffectConfiguration } from './inline-effect-configuration.mjs';
 import { InlineHelper } from '../helpers/inline-helper.mjs';
@@ -40,7 +40,7 @@ function createEffectAnchor(effect, label) {
 	anchor.draggable = true;
 	anchor.dataset.effect = StringUtils.toBase64(effect);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
-	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}<br>${game.i18n.localize('FU.ChatExamineSelectedEffect')}`);
+	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatExamineSelectedEffect')}`);
 	const icon = document.createElement('i');
 	icon.classList.add('fue', 'fu-effect-placeholder');
 	anchor.append(icon);
@@ -62,7 +62,7 @@ function createCompendiumEffectAnchor(effect, config, label) {
 	}
 	anchor.dataset.config = StringUtils.toBase64(config);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
-	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatDisableSelected')}<br>${game.i18n.localize('FU.ChatExamineSelectedEffect')}`);
+	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${effect.name})<br>${game.i18n.localize('FU.ChatExamineSelectedEffect')}`);
 	InlineHelper.appendImage(anchor, effect.img);
 	anchor.append(label ? label : effect.name);
 	return anchor;
@@ -85,7 +85,7 @@ function createStatusAnchor(effectValue, status, config) {
 	anchor.dataset.config = StringUtils.toBase64(config);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
 	const localizedName = game.i18n.localize(status.name);
-	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${localizedName})<br>${game.i18n.localize('FU.ChatDisableSelected')}`);
+	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${localizedName})`);
 
 	InlineHelper.appendImage(anchor, status.img);
 	anchor.append(localizedName);
@@ -172,23 +172,14 @@ async function onRender(element) {
 
 	// Click handler
 	element.addEventListener('click', async function (event) {
-		const isCtrlClick = event.ctrlKey;
 		const targets = await targetHandler();
 		if (!targets.length) return;
 
 		targets.forEach((actor) => {
 			if (effectData) {
-				if (isCtrlClick) {
-					Effects.removeEffect(actor, renderContext.sourceInfo, effectData);
-				} else {
-					Effects.applyEffect(actor, effectData, renderContext.sourceInfo, config);
-				}
-			} else if (status) {
-				if (isCtrlClick) {
-					disableStatusEffect(actor, status);
-				} else if (!actor.statuses.has(status)) {
-					Effects.toggleStatusEffect(actor, status, renderContext.sourceInfo, config);
-				}
+				Effects.applyEffect(actor, effectData, renderContext.sourceInfo, config);
+			} else if (status && !actor.statuses.has(status)) {
+				Effects.toggleStatusEffect(actor, status, renderContext.sourceInfo, config);
 			}
 		});
 	});

--- a/module/enrichers/inline-effects.mjs
+++ b/module/enrichers/inline-effects.mjs
@@ -1,5 +1,5 @@
 import { statusEffects } from '../documents/effects/statuses.mjs';
-import { Effects } from '../pipelines/effects.mjs';
+import { Effects, disableStatusEffect } from '../pipelines/effects.mjs';
 import { targetHandler } from '../helpers/target-handler.mjs';
 import { InlineEffectConfiguration } from './inline-effect-configuration.mjs';
 import { InlineHelper } from '../helpers/inline-helper.mjs';
@@ -85,7 +85,7 @@ function createStatusAnchor(effectValue, status, config) {
 	anchor.dataset.config = StringUtils.toBase64(config);
 	anchor.classList.add('inline', INLINE_EFFECT_CLASS, 'disable-how-to');
 	const localizedName = game.i18n.localize(status.name);
-	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${localizedName})`);
+	anchor.setAttribute('data-tooltip', `${game.i18n.localize('FU.ChatApplySelected')} (${localizedName})<br>${game.i18n.localize('FU.ChatDisableSelected')}`);
 
 	InlineHelper.appendImage(anchor, status.img);
 	anchor.append(localizedName);
@@ -172,14 +172,19 @@ async function onRender(element) {
 
 	// Click handler
 	element.addEventListener('click', async function (event) {
+		const isCtrlClick = event.ctrlKey;
 		const targets = await targetHandler();
 		if (!targets.length) return;
 
 		targets.forEach((actor) => {
 			if (effectData) {
 				Effects.applyEffect(actor, effectData, renderContext.sourceInfo, config);
-			} else if (status && !actor.statuses.has(status)) {
-				Effects.toggleStatusEffect(actor, status, renderContext.sourceInfo, config);
+			} else if (status) {
+				if (isCtrlClick) {
+					disableStatusEffect(actor, status);
+				} else if (!actor.statuses.has(status)) {
+					Effects.toggleStatusEffect(actor, status, renderContext.sourceInfo, config);
+				}
 			}
 		});
 	});

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -381,7 +381,7 @@ export async function createStatusEffect(actor, statusEffectId, sourceInfo, conf
 		const instance = await ActiveEffect.create(
 			{
 				...statusEffect,
-				statuses: [statusEffectId],
+				statuses: new Set([statusEffectId]),
 				flags: createEffectFlags(statusEffect, sourceInfo, statusEffectId),
 			},
 			{ parent: actor },
@@ -458,13 +458,13 @@ function removeEffect(document, source, effect) {
 	const existingEffect = document.effects.find(
 		(e) =>
 			e.getFlag(SYSTEM, Flags.ActiveEffect.Temporary) &&
-			e.sourceItem === source &&
+			e.getFlag(SYSTEM, Flags.ActiveEffect.Source)?.name === source.name &&
 			e.changes.length === effect.changes.length &&
 			e.changes.every((change, index) => change.key === effect.changes[index].key && change.mode === effect.changes[index].mode && change.value === effect.changes[index].value),
 	);
 
 	if (existingEffect) {
-		sendToChatEffectRemoved(effect, document);
+		sendToChatEffectRemoved(existingEffect, document);
 		existingEffect.delete();
 	} else {
 		console.log('No matching effect found to remove.');

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -458,7 +458,7 @@ function removeEffect(document, source, effect) {
 	const existingEffect = document.effects.find(
 		(e) =>
 			e.getFlag(SYSTEM, Flags.ActiveEffect.Temporary) &&
-			e.getFlag(SYSTEM, Flags.ActiveEffect.Source)?.fuid === source.fuid &&
+			e.sourceItem === source &&
 			e.changes.length === effect.changes.length &&
 			e.changes.every((change, index) => change.key === effect.changes[index].key && change.mode === effect.changes[index].mode && change.value === effect.changes[index].value),
 	);

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -458,7 +458,7 @@ function removeEffect(document, source, effect) {
 	const existingEffect = document.effects.find(
 		(e) =>
 			e.getFlag(SYSTEM, Flags.ActiveEffect.Temporary) &&
-			e.getFlag(SYSTEM, Flags.ActiveEffect.Source)?.name === source.name &&
+			e.getFlag(SYSTEM, Flags.ActiveEffect.Source)?.fuid === source.fuid &&
 			e.changes.length === effect.changes.length &&
 			e.changes.every((change, index) => change.key === effect.changes[index].key && change.mode === effect.changes[index].mode && change.value === effect.changes[index].value),
 	);


### PR DESCRIPTION
- Added instruction for examining effect with Right Click to hover text.
- Fixed effect button CTRL+Click function of removing its effect from the actor.
- Plugged some holes in the status to effects that were incorrectly making an Array of statuses instead of a Set.