### PR TITLE
Bugfix: Incorrect Drag&Drop data with inline UUID link

### DIFF
--- a/module/sheets/actor-standard-sheet.mjs
+++ b/module/sheets/actor-standard-sheet.mjs
@@ -765,6 +765,7 @@ export class FUStandardActorSheet extends FUActorSheet {
 
 	async _onDragStart(ev) {
 		const { fromUuid } = foundry.utils;
+		if ('link' in ev.target.dataset) return;
 		const target = ev.currentTarget;
 
 		// Owned Items


### PR DESCRIPTION
- don't start item drag&drop in actor sheet, if the target being dragged is a foundry UUID link

fixes #1237 