### PR TITLE
Fixed Issue #1294

### DIFF
--- a/module/documents/effects/actions/execute-macro-rule-action.mjs
+++ b/module/documents/effects/actions/execute-macro-rule-action.mjs
@@ -29,8 +29,8 @@ export class ExecuteMacroRuleAction extends RuleActionDataModel {
 	async execute(context, selected) {
 		if (this.macro) {
 			this.macro.execute({
-				actor: context.source.actor,
-				token: context.source.token,
+				actor: context?.source?.actor ?? null,
+				token: context?.source?.token ?? null,
 				context: context,
 				selected: selected,
 			});


### PR DESCRIPTION
Added basic null checks to prevent macros from never executing when context.source is undefined/null