### PR TITLE
Proper Null Checks in Execute Macro Action

### DIFF
--- a/module/documents/effects/actions/execute-macro-rule-action.mjs
+++ b/module/documents/effects/actions/execute-macro-rule-action.mjs
@@ -29,8 +29,8 @@ export class ExecuteMacroRuleAction extends RuleActionDataModel {
 	async execute(context, selected) {
 		if (this.macro) {
 			this.macro.execute({
-				actor: context.source.actor,
-				token: context.source.token,
+				actor: context?.source?.actor ?? null,
+				token: context?.source?.token ?? null,
 				context: context,
 				selected: selected,
 			});


### PR DESCRIPTION
Recreating commit from @yoshisman8 to fix error that occurs when Execute Macro Rule Action is used on a End of Combat Rule Trigger.
