### PR TITLE
Add Damage Overrides to Skill Damage

### DIFF
--- a/module/documents/items/skill-like-item-helper.mjs
+++ b/module/documents/items/skill-like-item-helper.mjs
@@ -257,6 +257,12 @@ const addSkillDamage = async (config, item, context, weaponData = undefined) => 
 			}
 		}
 
+		if (weaponData && item.system.useWeapon.traits) {
+			config.setDamageOverride(context.actor, 'attack');
+		} else {
+			config.setDamageOverride(context.actor, 'skill');
+		}
+
 		const onRoll = item.system.damage.onRoll;
 		if (onRoll) {
 			const extraDamage = await Expressions.evaluateAsync(onRoll, context);


### PR DESCRIPTION
The Skill Like Item Helper was not setting any damage overrides from effects. Added it to either set it as a Skill or as an Attack if using the weapon's traits.