### PR TITLE
Check Rule Predicate Succeeds When Result is Equal

### DIFF
--- a/module/documents/effects/predicates/check-rule-predicate.mjs
+++ b/module/documents/effects/predicates/check-rule-predicate.mjs
@@ -184,7 +184,7 @@ export class CheckRulePredicate extends RulePredicateDataModel {
 		}
 
 		// Check result
-		if (this.result != null && check.result <= this.result) {
+		if (this.result != null && check.result < this.result) {
 			return false;
 		}
 


### PR DESCRIPTION
The Check Rule Predicate should succeed when the outcome number given equals the result.