### PR TITLE
fix:Some CSS updates to ActiveEffect sheet

### DIFF
--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -194,10 +194,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 
 		context.expandedRuleElements = this.#expandedRuleElements;
 
-		if (context.fields?.origin instanceof foundry.data.fields.DocumentUUIDField && context.source?.origin) {
-			const originDoc = await fromUuid(context.source.origin);
-			context.originName = originDoc?.name ?? '';
-		}
+		context.originName = this.document.sourceName;
 		return context;
 	}
 

--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -193,6 +193,11 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 		}
 
 		context.expandedRuleElements = this.#expandedRuleElements;
+
+		if (context.fields?.origin instanceof foundry.data.fields.DocumentUUIDField && context.source?.origin) {
+			const originDoc = await fromUuid(context.source.origin);
+			context.originName = originDoc?.name ?? '';
+		}
 		return context;
 	}
 

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -1138,6 +1138,7 @@
 
 .projectfu.active-effect-sheet .top-tabs {
 	margin-top: 0;
+	margin-inline: 0;
 }
 
 .projectfu prose-mirror {

--- a/styles/css/global/sheet.css
+++ b/styles/css/global/sheet.css
@@ -1130,6 +1130,16 @@
 	}
 }
 
+.projectfu document-tags button {
+	box-shadow: none !important;
+	border: none !important;
+	border-radius: 0 !important;
+}
+
+.projectfu.active-effect-sheet .top-tabs {
+	margin-top: 0;
+}
+
 .projectfu prose-mirror {
 	max-height: 350px;
 

--- a/templates/effects/active-effect-details.hbs
+++ b/templates/effects/active-effect-details.hbs
@@ -5,7 +5,16 @@
 		{{formGroup fields.tint value=source.tint rootId=rootId placeholder="#ffffff"}}
 		{{formGroup fields.statuses value=source.statuses options=statuses rootId=rootId classes="statuses"}}
 		{{#if isActorEffect}}
-			{{formGroup fields.origin value=source.origin rootId=rootId disabled=true}}
+			{{!--
+				Since the field is a DocumentUUIDField that is always disabled, we build the form group manually
+				so we can force it to display as a text input, rather than the document picker that would be created
+			--}}
+			<div class="form-group">
+				<label for="{{rootId}}-{{fields.origin.name}}">{{localize fields.origin.label}}</label>
+				<div class="form-fields">
+					<input type="text" disabled name="{{fields.origin.name}}" id="{{rootId}}-{{fields.origin.name}}" value="{{originName}}" data-tooltip="{{source.origin}}">
+				</div>
+			</div>
 		{{/if}}
 		{{#if isItemEffect}}
 			{{formGroup fields.transfer value=source.transfer rootId=rootId label=legacyTransfer.label


### PR DESCRIPTION
- Adds CSS to remove `margin-top` from ActiveEffect sheet top tabs
- Removes `box-shadow`, `border`, and `border-radius` from the document selection button that's added to formGroups generated from `DocumentUUIDField`s
- Replaces the automatically generated formGroup for effects' `origin` property with a text input, as it is always disabled and having the selection button is unnecessary and potentially confusing

So far as I can tell, we aren't generating formGroups for any other `DocumentUUIDField`, but the CSS is included here in case we do in the future or I missed one somewhere, to hopefully have them appear in a less-janky way.

Before:
<img width="607" height="316" alt="image" src="https://github.com/user-attachments/assets/295b5b60-73c6-4cee-a7f4-e0332a8ab8c8" />

After:
<img width="607" height="316" alt="image" src="https://github.com/user-attachments/assets/f480f5c7-2c5d-4858-af2e-7fdb77ba5845" />
