### PR TITLE
Bugfix: Party Sheet adversaries filtering errors after combat

### DIFF
--- a/module/sheets/actor-party-sheet.mjs
+++ b/module/sheets/actor-party-sheet.mjs
@@ -396,7 +396,7 @@ export class FUPartySheet extends FUActorSheet {
 				for (const misc of this.#adversaryFilters.misc) {
 					switch (misc) {
 						case 'inCombat':
-							if (!game.combat.hasInstancedActor(adversary.uuid)) display = false;
+							if (game.combat && !game.combat.hasInstancedActor(adversary.uuid)) display = false;
 					}
 				}
 			}


### PR DESCRIPTION
- fix Actor Sheet adversaries filter throwing errors when still filtering for `inCombat` after combat