### PR TITLE
Bugfix: Party sheet adversaries list shows rank for unstudied NPCs

### DIFF
--- a/templates/actor/party/actor-party-section-adversaries.hbs
+++ b/templates/actor/party/actor-party-section-adversaries.hbs
@@ -25,7 +25,7 @@
 								<div class="blurb pfu-tags">
 									<div class="fu-tag {{_rank}}">
 										{{#if (eq this.studyResult 'none')}}
-											{{localize 'FU.Unknown'}} {{localize this.rank}}
+											{{localize 'FU.Unknown'}}
 										{{else}}
 											{{localize this.species }} {{localize this.rank}}
 										{{/if}}


### PR DESCRIPTION
- remove rank from unstudied NPCs