### PR TITLE
Bugfix: Message Rule Action may break reroll functionality

### DIFF
--- a/module/checks/checks.mjs
+++ b/module/checks/checks.mjs
@@ -193,7 +193,14 @@ const checkFromCheckResult = (check) => {
  * @return {Promise<void>}
  */
 const modifyCheck = async (checkId, callback) => {
-	const message = game.messages.search({ filters: [{ field: `flags.projectfu.${Flags.ChatMessage.Check}.id`, value: checkId }] }).at(0);
+	const message = game.messages
+		.search({
+			filters: [
+				{ field: `flags.projectfu.${Flags.ChatMessage.Check}.id`, value: checkId },
+				{ field: 'isRoll', value: true },
+			],
+		})
+		.at(-1);
 	if (message) {
 		/** @type CheckResultV2 */
 		const oldCheck = foundry.utils.duplicate(message.getFlag(SYSTEM, Flags.ChatMessage.Check));


### PR DESCRIPTION
- in `modifyCheck` filter for messages that contain rolls and take the newest message

Depending on the used rule trigger a message action may post before or after the actual check and contains a potentially incomplete copy of the check result under the same flag key as the actual check.
I opted to make the filtering stricter rather than changing the output of the message action to avoid breaking any functionality I have no knowledge of.