### PR TITLE
Bugfix: PseudoDocuments broken again

### DIFF
--- a/module/documents/actors/actor.mjs
+++ b/module/documents/actors/actor.mjs
@@ -91,7 +91,11 @@ export class FUActor extends foundry.documents.Actor {
 	prepareDerivedData() {
 		super.prepareDerivedData();
 		this.applyActiveEffects('default');
-		this.items.forEach((item) => item.applyActiveEffects());
+	}
+
+	applyActiveEffects(phase) {
+		super.applyActiveEffects(phase);
+		this.items.forEach((item) => item.applyActiveEffects(phase));
 	}
 
 	get tlTracker() {

--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -2,7 +2,6 @@ import { FU } from '../../helpers/config.mjs';
 import { systemTemplatePath } from '../../helpers/system-utils.mjs';
 import { PseudoDocument } from '../pseudo/pseudo-document.mjs';
 import { RuleElements } from '../../pipelines/rule-elements.mjs';
-import { RuleElementDataModel } from './rule-element-data-model.mjs';
 import { RuleActionRegistry } from './actions/rule-action-data-model.mjs';
 import { RuleTriggerRegistry } from './triggers/rule-trigger-data-model.mjs';
 import { RulePredicateRegistry } from './predicates/rule-predicate-data-model.mjs';
@@ -73,8 +72,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 					Object.values(RulePredicateRegistry.instance.qualifiedTypes).map((pt) => {
 						return pt.template;
 					}),
-				)
-				.concat([RuleElementDataModel.template]),
+				),
 		},
 
 		footer: {

--- a/module/documents/effects/pseudo-active-effect.mjs
+++ b/module/documents/effects/pseudo-active-effect.mjs
@@ -1,7 +1,5 @@
 import { PseudoDocument } from '../pseudo/pseudo-document.mjs';
-import { SYSTEM } from '../../helpers/config.mjs';
 import { ActiveEffectBehaviourMixin } from './active-effect-behaviour-mixin.mjs';
-import { Flags } from '../../helpers/flags.mjs';
 
 class BasePseudoActiveEffect extends PseudoDocument {
 	static documentName = 'ActiveEffect';
@@ -56,6 +54,54 @@ class BasePseudoActiveEffect extends PseudoDocument {
 	static LOCALIZATION_PREFIXES = foundry.documents.ActiveEffect.LOCALIZATION_PREFIXES;
 
 	/**
+	 * A cached compilation of core and registered application phases, along with their labels
+	 * @type {Record<string, {label: string; hint: string}>}
+	 */
+	static get CHANGE_PHASES() {
+		return foundry.documents.ActiveEffect.CHANGE_PHASES;
+	}
+
+	/**
+	 * A cached compilation of core and registered change types, along with their labels and default priorities
+	 * @type {Record<string, ActiveEffectChangeTypeConfig>}
+	 */
+	static get CHANGE_TYPES() {
+		return foundry.documents.ActiveEffect.CHANGE_TYPES;
+	}
+
+	/**
+	 * A cached compilation of core and registered expiry events
+	 * @type {Record<string, string>}
+	 */
+	static get EXPIRY_EVENTS() {
+		return foundry.documents.ActiveEffect.EXPIRY_EVENTS;
+	}
+
+	/**
+	 * A helper class that accepts registration of ActiveEffects and manages their prepared duration and expiry data.
+	 * @type {ActiveEffectRegistry}
+	 */
+	static get registry() {
+		return foundry.documents.ActiveEffect.registry;
+	}
+
+	/**
+	 * Provide a thumbnail image path used to represent this document.
+	 * @type {string}
+	 */
+	get thumbnail() {
+		return this.img;
+	}
+
+	/**
+	 * Is there some system logic that makes this active effect ineligible for application?
+	 * @type {boolean}
+	 */
+	get isSuppressed() {
+		return !!(this.system.isSuppressed ?? this.duration.expired);
+	}
+
+	/**
 	 * Retrieve the Document that this ActiveEffect targets for modification.
 	 * @type {Document|null}
 	 */
@@ -80,299 +126,260 @@ class BasePseudoActiveEffect extends PseudoDocument {
 	 * @type {boolean}
 	 */
 	get modifiesActor() {
-		if (!this.active) return false;
-		if (CONFIG.ActiveEffect.legacyTransferral) return this.parent instanceof Actor;
-		return this.target instanceof Actor;
-	}
-
-	get isTemporary() {
-		const duration = this.duration.seconds ?? (this.duration.rounds || this.duration.turns) ?? 0;
-		return duration > 0 || this.statuses.size > 0 || !!this.getFlag(SYSTEM, Flags.ActiveEffect.Temporary);
+		return this.active && this.target?.documentName === 'Actor';
 	}
 
 	/**
-	 * Is there some system logic that makes this active effect ineligible for application?
+	 * Whether this Active Effect has a temporary duration
 	 * @type {boolean}
 	 */
-	get isSuppressed() {
-		if (this.system instanceof foundry.abstract.TypeDataModel) return this.system.isSuppressed ?? false;
-		return false;
+	get isTemporary() {
+		return !!this.duration.expiry || Number.isFinite(this.duration.value);
 	}
 
 	/**
-	 * Apply EffectChangeData to a field within a DataModel.
-	 * @param {DataModel} model          The model instance.
-	 * @param {EffectChangeData} change  The change to apply.
-	 * @param {DataField} [field]        The field. If not supplied, it will be retrieved from the supplied model.
-	 * @returns {*}                      The updated value.
+	 * Whether this Active Effect is eligible to be registered with the {@link ActiveEffectRegistry}
 	 */
-	static applyField(model, change, field) {
-		field ??= model.schema.getField(change.key);
-		const current = foundry.utils.getProperty(model, change.key);
-		const update = field.applyChange(current, model, change);
-		if (update !== undefined) foundry.utils.setProperty(model, change.key, update);
-		return update;
+	get isExpiryTrackable() {
+		return this.persisted && !this.inCompendium && this.isEmbedded && this.active && !!this.start && this.isTemporary;
+	}
+
+	/** @inheritDoc */
+	_initialize(options = {}) {
+		super._initialize(options);
+		if (!Object.hasOwn(this, 'changes')) Object.defineProperty(this, 'changes', { get: () => this.system.changes });
+		foundry.documents.ActiveEffect._shimChanges(this.system.changes);
+	}
+
+	/** @override */
+	prepareBaseData() {
+		this.img ??= foundry.documents.ActiveEffect.DEFAULT_ICON;
+		this.duration.value ??= Infinity;
+		for (const change of this.system.changes) {
+			change.effect = this;
+			change.priority ??= ActiveEffect.CHANGE_TYPES[change.type]?.defaultPriority ?? 0;
+		}
+	}
+
+	/** @override */
+	prepareDerivedData() {
+		this.updateDuration();
 	}
 
 	/**
-	 * Apply this ActiveEffect to a provided Actor.
-	 * @param {Actor} actor                   The Actor to whom this effect should be applied
-	 * @param {EffectChangeData} change       The change data being applied
-	 * @returns {Record<string, *>}           An object of property paths and their updated values.
+	 * Update derived Active Effect duration data.
+	 * @param {object} [context] Contextual information indicating what lead to this call
+	 * @returns {ActiveEffectDuration}
 	 */
+	updateDuration(context) {
+		const unprepared = this.duration.units === this._source.duration.units ? this.duration : foundry.utils.deepClone(this._source.duration);
+		unprepared.value ??= Infinity;
+		const duration = (this.duration = this._prepareDuration(unprepared, context));
+		if (!Object.hasOwn(duration, 'type') || !Object.hasOwn(duration, 'duration')) {
+			Object.defineProperties(duration, {
+				type: {
+					get: () => {
+						const message = 'You are accessing ActiveEffectDuration#type, which is now at ActiveEffectDuration#units.';
+						foundry.utils.logCompatibilityWarning(message, { since: 14, until: 16, once: true });
+						return typeof duration.value === 'number' ? duration.units : 'none';
+					},
+					configurable: true,
+				},
+				duration: {
+					get() {
+						foundry.utils.logCompatibilityWarning('You are accessing ActiveEffectDuration#duration, ' + 'which is now at ActiveEffectDuration#seconds.', { since: 14, until: 16, once: true });
+						return this.start ? duration.seconds - (game.time.worldtime - this.start.time) : null;
+					},
+					configurable: true,
+				},
+			});
+		}
+		return duration;
+	}
 
-	apply(actor, change) {
-		let field;
-		const changes = {};
-		if (change.key.startsWith('system.')) {
-			if (actor.system instanceof foundry.abstract.DataModel) {
-				field = actor.system.schema.getField(change.key.slice(7));
+	/**
+	 * Compute derived data related to active effect duration.
+	 * @param {EffectDurationData} [duration] Unprepared duration data
+	 * @param {object} [context]              Contextual information indicating what lead to this call
+	 * @returns {ActiveEffectDuration}
+	 * @protected
+	 */
+	_prepareDuration(duration, context) {
+		duration ??= this.duration;
+		const now = game.time.worldTime;
+		duration._worldTime = now;
+
+		// Indefinite duration
+		if (!this.isTemporary) duration.expired = false;
+		if (!Number.isFinite(duration.value)) {
+			return Object.assign(duration, { seconds: Infinity, remaining: Infinity, secondsRemaining: Infinity, label: _loc('COMMON.None') });
+		}
+
+		return CONST.ACTIVE_EFFECT_TIME_DURATION_UNITS.includes(duration.units) ? this._prepareTimeBasedDuration(duration, context) : this._prepareCombatBasedDuration(duration, context);
+	}
+
+	/**
+	 * Prepare duration data from time-based (minutes, seconds, etc.) source data.
+	 * @param {EffectDurationData} duration Unprepared duration data
+	 * @param {object} [context]            Contextual information indicating what lead to this call
+	 * @returns {ActiveEffectDuration}
+	 * @protected
+	 */
+	_prepareTimeBasedDuration(duration, context) {
+		const calendar = game.time.calendar;
+		const durationInMonths = duration.units === 'months';
+		const unitsSingular = durationInMonths ? 'day' : duration.units.slice(0, -1);
+		const avgDaysPerMonth = durationInMonths && calendar.months.values.length ? calendar.days.daysPerYear / calendar.months.values.length : 0;
+		const durationValue = durationInMonths ? Math.ceil(duration.value * avgDaysPerMonth) : duration.value;
+		const seconds = calendar.componentsToTime({ [unitsSingular]: durationValue });
+		const worldTime = game.time.worldTime;
+
+		// Use the current world time as the start time effects lacking one
+		const start = this.start ?? { time: worldTime };
+
+		// Handle remaining value and label given the duration is exceeded
+		const secondsRemaining = start.time + seconds - worldTime;
+		let remainingComponents;
+		let formatter;
+		let roundFn;
+		if (secondsRemaining < 0) {
+			// Work around limitations of calendar API when there is a negative difference
+			remainingComponents = calendar.difference(worldTime, worldTime + secondsRemaining);
+			formatter = 'formatAgo';
+			roundFn = 'floor';
+		} else {
+			if (secondsRemaining > 0) duration.expired = false;
+			remainingComponents = calendar.difference(start.time + seconds);
+			formatter = 'formatDuration';
+			roundFn = 'ceil';
+		}
+		let remaining;
+		if (durationInMonths) {
+			// Months may not have a constant number of days and require approximation favoring later rather than earlier
+			// expiration
+			if (avgDaysPerMonth === 0) remaining = 0;
+			else {
+				const { secondsPerMinute, minutesPerHour, hoursPerDay } = calendar.days;
+				const secondsPerMonth = avgDaysPerMonth * hoursPerDay * minutesPerHour * secondsPerMinute;
+				remaining = Math.sign(secondsRemaining) * Math[roundFn](Math.abs(secondsRemaining / secondsPerMonth));
 			}
-		} else field = actor.schema.getField(change.key);
-		if (field) changes[change.key] = this.constructor.applyField(actor, change, field);
-		else this._applyLegacy(actor, change, changes);
-		return changes;
+		} else {
+			const absRemaining = calendar.componentsToUnit(remainingComponents, unitsSingular, { roundFn });
+			remaining = Math.sign(secondsRemaining) * absRemaining;
+		}
+		const formattableComponents = foundry.utils.iterateEntries(remainingComponents).reduce((components, [unit, value]) => {
+			if (durationInMonths && unit === 'day' && value > avgDaysPerMonth) return components;
+			if (value && foundry.data.CalendarData._DURATION_FORMAT_UNITS.has(unit)) components[unit] = value;
+			return components;
+		}, {});
+		const label = calendar.format(formattableComponents, formatter, { style: 'short', maxTerms: 2 }) || _loc('TIME.Now');
+		return Object.assign(duration, { seconds, remaining, secondsRemaining, label });
 	}
 
-	/* -------------------------------------------- */
-
 	/**
-	 * Apply this ActiveEffect to a provided Actor using a heuristic to infer the value types based on the current value
-	 * and/or the default value in the template.json.
-	 * @param {Actor} actor                The Actor to whom this effect should be applied.
-	 * @param {EffectChangeData} change    The change data being applied.
-	 * @param {Record<string, *>} changes  The aggregate update paths and their updated values.
+	 * Prepare duration data from combat-based (rounds or turns) source data.
+	 * @param {EffectDurationData} duration Unprepared duration data
+	 * @param {object} [context]            Contextual information indicating what lead to this call
+	 * @returns {ActiveEffectDuration}
 	 * @protected
 	 */
-	_applyLegacy(actor, change, changes) {
-		// Determine the data type of the target field
-		const current = foundry.utils.getProperty(actor, change.key) ?? null;
-		let target = current;
-		if (current === null) {
-			const model = game.model.Actor[actor.type] || {};
-			target = foundry.utils.getProperty(model, change.key) ?? null;
-		}
-		const targetType = foundry.utils.getType(target);
+	_prepareCombatBasedDuration(duration, context) {
+		const unitsSingular = duration.units.replace(/s$/, '');
+		/** @type {number} */
+		const timeConversion = CONFIG.time[`${unitsSingular}Time`] || 0;
+		const seconds = (duration.seconds = timeConversion ? Math.trunc(duration.value * timeConversion) : null);
+		const worldTime = game.time.worldTime;
+		const start = this.start ?? { time: worldTime };
+		const combat = game.combats.get(start.combat?.id) ?? game.combat;
+		const combatant = combat?.combatants.get(start.combatant) ?? combat?.getCombatantsByActor(this.actor)[0];
 
-		// Cast the effect change value to the correct type
-		let delta;
-		try {
-			if (targetType === 'Array') {
-				const innerType = target.length ? foundry.utils.getType(target[0]) : 'string';
-				delta = this.#castArray(change.value, innerType);
-			} else delta = this.#castDelta(change.value, targetType);
-		} catch (err) {
-			console.warn(`Actor [${actor.id}] | Unable to parse active effect change for ${change.key}: "${change.value}"`);
-			return;
+		// If no combat information is available, reframe the presented duration as time-based
+		if (!combatant || !combat.started || !combat.turns.length) {
+			return game._documentsReady && Number.isFinite(seconds)
+				? this._prepareTimeBasedDuration({ ...duration, units: 'seconds', value: seconds })
+				: Object.assign(duration, { remaining: Infinity, secondsRemaining: Infinity, label: _loc('COMMON.None') });
 		}
 
-		// Apply the change depending on the application mode
-		const modes = CONST.ACTIVE_EFFECT_MODES;
-		switch (change.mode) {
-			case modes.ADD:
-				this._applyAdd(actor, change, current, delta, changes);
-				break;
-			case modes.MULTIPLY:
-				this._applyMultiply(actor, change, current, delta, changes);
-				break;
-			case modes.OVERRIDE:
-				this._applyOverride(actor, change, current, delta, changes);
-				break;
-			case modes.UPGRADE:
-			case modes.DOWNGRADE:
-				this._applyUpgrade(actor, change, current, delta, changes);
-				break;
-			default:
-				this._applyCustom(actor, change, current, delta, changes);
-				break;
-		}
+		// Acquire the start round and turn number from the combatant if the current combat is not the same as the starting
+		// one.
+		const [startRound, startTurn] = combat === start.combat ? [start.round ?? combatant.roundJoined, (start.turn ?? 0) + 1] : [combatant.roundJoined, combatant.turnNumber + 1];
 
-		// Apply all changes to the Actor data
-		foundry.utils.mergeObject(actor, changes);
+		const currentRound = context?.round ?? combat.round;
+		const timeElapsed = timeConversion ? worldTime - start.time : 0;
+		switch (duration.units) {
+			case 'rounds': {
+				const elapsedInCombat = currentRound - startRound;
+				const totalElapsedInCombat = currentRound - 1;
+				const elapsedBeforeCombat = timeConversion ? Math.max(0, Math.floor(timeElapsed / timeConversion) - totalElapsedInCombat) : 0;
+				const remaining = duration.value - (elapsedInCombat + elapsedBeforeCombat);
+				const pluralRule = game.i18n.pluralRules.select(Math.abs(remaining));
+				const locKey = remaining >= 0 ? 'EFFECT.DURATION.ROUNDS' : 'EFFECT.DURATION.ROUNDS_AGO';
+				Object.assign(duration, { remaining, label: _loc(`${locKey}.${pluralRule}`, { rounds: Math.abs(remaining) }) });
+				break;
+			}
+			case 'turns': {
+				const currentTurn = 1 + (context?.turn ?? combat.turn);
+				const turnsPerRound = combat.turns.length;
+				const elapsedPriorRounds = Math.max(0, turnsPerRound - startTurn + turnsPerRound * (currentRound - startRound - 1));
+				const elapsedThisRound = startRound === currentRound ? Math.max(0, currentTurn - startTurn) : currentTurn;
+				const elapsedInCombat = elapsedPriorRounds + elapsedThisRound;
+				const elapsedBeforeCombat = timeConversion ? Math.floor(timeElapsed / timeConversion) - elapsedInCombat : 0;
+				const remaining = duration.value - (elapsedInCombat + elapsedBeforeCombat);
+				const pluralRule = game.i18n.pluralRules.select(Math.abs(remaining));
+				const locKey = remaining >= 0 ? 'EFFECT.DURATION.TURNS' : 'EFFECT.DURATION.TURNS_AGO';
+				Object.assign(duration, { remaining, label: _loc(`${locKey}.${pluralRule}`, { turns: Math.abs(remaining) }) });
+				break;
+			}
+		}
+		if (timeConversion) duration.secondsRemaining = duration.remaining * timeConversion;
+		else delete duration.secondsRemaining;
+		return duration;
 	}
 
-	/* -------------------------------------------- */
-
-	/**
-	 * Cast a raw EffectChangeData change string to the desired data type.
-	 * @param {string} raw      The raw string value
-	 * @param {string} type     The target data type that the raw value should be cast to match
-	 * @returns {*}             The parsed delta cast to the target data type
-	 */
-	#castDelta(raw, type) {
-		let delta;
-		switch (type) {
-			case 'boolean':
-				delta = Boolean(this.#parseOrString(raw));
-				break;
-			case 'number':
-				delta = Number.fromString(raw);
-				if (Number.isNaN(delta)) delta = 0;
-				break;
-			case 'string':
-				delta = String(raw);
-				break;
-			default:
-				delta = this.#parseOrString(raw);
+	/** @inheritDoc */
+	toCompendium(pack, options) {
+		const data = super.toCompendium(pack, options);
+		if (options?.clearState !== false) {
+			data.origin = null;
+			data.start = null;
 		}
-		return delta;
+		return data;
 	}
 
-	/* -------------------------------------------- */
-
 	/**
-	 * Cast a raw EffectChangeData change string to an Array of an inner type.
-	 * @param {string} raw      The raw string value
-	 * @param {string} type     The target data type of inner array elements
-	 * @returns {Array<*>}      The parsed delta cast as a typed array
+	 * Determine whether a change from this ActiveEffect should be applied during the current phase. Systems and modules
+	 * may override this method to introduce additional conditions under which a change is applied.
+	 * @param {ActiveEffectChangeData} change    The change being considered.
+	 * @param {object} [options]                 Options which affect whether the change is applied.
+	 * @param {string} [options.phase]           The application phase currently being evaluated.
+	 * @param {string} [options.replacementData] Replacement data to be used as part of the change's application
+	 * @returns {boolean}                        Should the change be applied during this phase (or at all)?
 	 */
-	#castArray(raw, type) {
-		let delta;
-		try {
-			delta = this.#parseOrString(raw);
-			delta = delta instanceof Array ? delta : [delta];
-		} catch (e) {
-			delta = [raw];
-		}
-		return delta.map((d) => this.#castDelta(d, type));
+	shouldApplyChange(change, options) {
+		return change.phase === options?.phase;
 	}
 
-	/* -------------------------------------------- */
-
 	/**
-	 * Parse serialized JSON, or retain the raw string.
-	 * @param {string} raw      A raw serialized string
-	 * @returns {*}             The parsed value, or the original value if parsing failed
+	 * Acquire replacement data for use in the application of this effect's changes.
+	 * @param {object} baseData Base data sourced from elsewhere (by default from `Actor#getRollData`)
+	 * @returns {object}        Data used to resolve "@" expressions in string {@link ActiveEffectChangeData} values
 	 */
-	#parseOrString(raw) {
-		try {
-			return JSON.parse(raw);
-		} catch (err) {
-			return raw;
-		}
+	getReplacementData(baseData) {
+		return baseData;
 	}
 
-	/* -------------------------------------------- */
-
 	/**
-	 * Apply an ActiveEffect that uses an ADD application mode.
-	 * The way that effects are added depends on the data type of the current value.
-	 *
-	 * If the current value is null, the change value is assigned directly.
-	 * If the current type is a string, the change value is concatenated.
-	 * If the current type is a number, the change value is cast to numeric and added.
-	 * If the current type is an array, the change value is appended to the existing array if it matches in type.
-	 *
-	 * @param {Actor} actor                   The Actor to whom this effect should be applied
-	 * @param {EffectChangeData} change       The change data being applied
-	 * @param {*} current                     The current value being modified
-	 * @param {*} delta                       The parsed value of the change object
-	 * @param {object} changes                An object which accumulates changes to be applied
-	 * @protected
+	 * Apply this ActiveEffect to a target Document.
+	 * @param {Actor|Item|TokenDocument} targetDoc The Document to which this effect should be applied
+	 * @param {ActiveEffectChangeData} change      The change data being applied
+	 * @param {object} [options]                   Options affecting the change application
+	 * @param {object} [options.replacementData]   Data used to resolve "@" expressions in a string value
+	 * @param {boolean} [options.modifyTarget]     Modify the target Document with the updated value.
+	 * @returns {Record<string, unknown>} An object of property keys and their updated values
 	 */
-	_applyAdd(actor, change, current, delta, changes) {
-		let update;
-		const ct = foundry.utils.getType(current);
-		switch (ct) {
-			case 'boolean':
-				update = current || delta;
-				break;
-			case 'null':
-				update = delta;
-				break;
-			case 'Array':
-				update = current.concat(delta);
-				break;
-			default:
-				update = current + delta;
-				break;
-		}
-		if (update !== current) changes[change.key] = update;
-	}
-
-	/* -------------------------------------------- */
-
-	/**
-	 * Apply an ActiveEffect that uses a MULTIPLY application mode.
-	 * Changes which MULTIPLY must be numeric to allow for multiplication.
-	 * @param {Actor} actor                   The Actor to whom this effect should be applied
-	 * @param {EffectChangeData} change       The change data being applied
-	 * @param {*} current                     The current value being modified
-	 * @param {*} delta                       The parsed value of the change object
-	 * @param {object} changes                An object which accumulates changes to be applied
-	 * @protected
-	 */
-	_applyMultiply(actor, change, current, delta, changes) {
-		let update;
-		const ct = foundry.utils.getType(current);
-		switch (ct) {
-			case 'boolean':
-				update = current && delta;
-				break;
-			case 'number':
-				update = current * delta;
-				break;
-		}
-		if (update !== current) changes[change.key] = update;
-	}
-
-	/* -------------------------------------------- */
-
-	/**
-	 * Apply an ActiveEffect that uses an OVERRIDE application mode.
-	 * Numeric data is overridden by numbers, while other data types are overridden by any value
-	 * @param {Actor} actor                   The Actor to whom this effect should be applied
-	 * @param {EffectChangeData} change       The change data being applied
-	 * @param {*} current                     The current value being modified
-	 * @param {*} delta                       The parsed value of the change object
-	 * @param {object} changes                An object which accumulates changes to be applied
-	 * @protected
-	 */
-	_applyOverride(actor, change, current, delta, changes) {
-		if (delta !== current) changes[change.key] = delta;
-	}
-
-	/* -------------------------------------------- */
-
-	/**
-	 * Apply an ActiveEffect that uses an UPGRADE, or DOWNGRADE application mode.
-	 * Changes which UPGRADE or DOWNGRADE must be numeric to allow for comparison.
-	 * @param {Actor} actor                   The Actor to whom this effect should be applied
-	 * @param {EffectChangeData} change       The change data being applied
-	 * @param {*} current                     The current value being modified
-	 * @param {*} delta                       The parsed value of the change object
-	 * @param {object} changes                An object which accumulates changes to be applied
-	 * @protected
-	 */
-	_applyUpgrade(actor, change, current, delta, changes) {
-		let update;
-		const ct = foundry.utils.getType(current);
-		switch (ct) {
-			case 'boolean':
-			case 'number':
-				if (change.mode === CONST.ACTIVE_EFFECT_MODES.UPGRADE && delta > current) update = delta;
-				else if (change.mode === CONST.ACTIVE_EFFECT_MODES.DOWNGRADE && delta < current) update = delta;
-				break;
-		}
-		if (update !== current && update !== undefined) changes[change.key] = update;
-	}
-
-	/* -------------------------------------------- */
-
-	/**
-	 * Apply an ActiveEffect that uses a CUSTOM application mode.
-	 * @param {Actor} actor                   The Actor to whom this effect should be applied
-	 * @param {EffectChangeData} change       The change data being applied
-	 * @param {*} current                     The current value being modified
-	 * @param {*} delta                       The parsed value of the change object
-	 * @param {object} changes                An object which accumulates changes to be applied
-	 * @protected
-	 */
-	_applyCustom(actor, change, current, delta, changes) {
-		const preHook = foundry.utils.getProperty(actor, change.key);
-		Hooks.call('applyActiveEffect', actor, change, current, delta, changes);
-		const postHook = foundry.utils.getProperty(actor, change.key);
-		if (postHook !== preHook && postHook !== undefined) changes[change.key] = postHook;
+	static applyChange(targetDoc, change, options = {}) {
+		console.warn("this shouldn't even be called. if it is being called the core implementation changed.");
+		return foundry.documents.ActiveEffect.implementation.applyChange(targetDoc, change, options);
 	}
 }
 

--- a/module/documents/effects/rule-element-data-model.mjs
+++ b/module/documents/effects/rule-element-data-model.mjs
@@ -1,4 +1,3 @@
-import { systemTemplatePath } from '../../helpers/system-utils.mjs';
 import { RuleActionRegistry } from './actions/rule-action-data-model.mjs';
 import { RuleTriggerRegistry } from './triggers/rule-trigger-data-model.mjs';
 import { RulePredicateRegistry } from './predicates/rule-predicate-data-model.mjs';
@@ -26,10 +25,6 @@ export class RuleElementDataModel extends foundry.abstract.DataModel {
 			selector: new StringField({ initial: 'initial', choices: Object.keys(FU.targetSelector) }),
 			enabled: new BooleanField({ initial: true }),
 		};
-	}
-
-	static get template() {
-		return systemTemplatePath('effects/rule-element');
 	}
 
 	/**

--- a/module/documents/items/hoplosphere/hoplosphere-data-model.mjs
+++ b/module/documents/items/hoplosphere/hoplosphere-data-model.mjs
@@ -526,7 +526,6 @@ export class HoplosphereDataModel extends foundry.abstract.TypeDataModel {
 					}
 				})
 				.sort((a, b) => a.coagulationLevel - b.coagulationLevel);
-			console.log(this.coagLevel, this.activeEffects);
 		}
 	}
 

--- a/module/documents/items/item-behaviour-mixin.mjs
+++ b/module/documents/items/item-behaviour-mixin.mjs
@@ -25,6 +25,18 @@ export function ItemBehaviourMixin(BaseClass) {
 
 		overrides = this.overrides ?? {};
 
+		_configure(options) {
+			super._configure(options);
+
+			/**
+			 * Track completed core ActiveEffect application phases as a backward compatibility measure for packages calling
+			 * Actor#applyActiveEffects without a phase argument.
+			 * @type {Set<string>}
+			 * @private
+			 */
+			Object.defineProperty(this, '_completedActiveEffectPhases', { value: new Set() });
+		}
+
 		/**
 		 * Augment the basic Item data model with additional dynamic data.
 		 * This method is automatically called when an item is created or updated.
@@ -32,6 +44,22 @@ export function ItemBehaviourMixin(BaseClass) {
 		prepareData() {
 			super.prepareData();
 			Hooks.callAll(FUHooks.DATA_PREPARED_ITEM, this);
+		}
+
+		/** @inheritDoc */
+		prepareBaseData() {
+			this._clearData();
+		}
+
+		/* -------------------------------------------- */
+
+		/**
+		 * Clear or replace properties not automatically reset by upstream initialization.
+		 * @protected
+		 */
+		_clearData() {
+			this.overrides = {};
+			this._completedActiveEffectPhases.clear();
 		}
 
 		/**
@@ -83,49 +111,58 @@ export function ItemBehaviourMixin(BaseClass) {
 			}
 		}
 
-		applyActiveEffects() {
-			const overrides = {};
+		applyActiveEffects(phase) {
+			/** @type {typeof foundry.documents.ActiveEffect} */
+			const ActiveEffect = foundry.documents.ActiveEffect.implementation;
+			if (typeof phase !== 'string') {
+				phase = this._completedActiveEffectPhases.has('initial') ? 'final' : 'initial';
+				const message = 'Actor#applyActiveEffects must be called with a string phase identifier, with "initial"' + ' as the first phase.';
+				foundry.utils.logCompatibilityWarning(message, { since: 14, until: 16, once: true });
+			} else if (!(phase in ActiveEffect.CHANGE_PHASES)) {
+				const error = new Error(`"${phase}" is not a registered ActiveEffect application phase.`);
+				Hooks.onError('Actor#applyActiveEffects', error, { log: 'error' });
+			}
+			if (this._completedActiveEffectPhases.has(phase)) {
+				const error = new Error(`ActiveEffect application phase "${phase}" has already completed and cannot be run again` + " in this Actor's data-preparation cycle.");
+				Hooks.onError('Actor#applyActiveEffects', error, { log: 'error' });
+				return;
+			}
+			this._completedActiveEffectPhases.add(phase);
 
 			// Organize non-disabled effects by their application priority
+			/** @type {ActiveEffectChangeData[]} */
 			const changes = [];
+			/** @type {ActiveEffectChangeData[]} */
+			const rollData = this.getRollData();
+			const dataByEffect = new Map();
 			for (const effect of this.allApplicableEffects()) {
-				if (!effect.active) {
-					continue;
+				if (!effect.active) continue;
+				const replacementData = effect.getReplacementData(rollData);
+				dataByEffect.set(effect, replacementData);
+				for (const change of effect.system.changes) {
+					if (change.key === '' || !effect.shouldApplyChange(change, { phase, replacementData })) continue;
+					const copy = foundry.utils.deepClone(change);
+					copy.effect = effect;
+					changes.push(copy);
 				}
-				changes.push(
-					...effect.changes.map((change) => {
-						const c = foundry.utils.deepClone(change);
-						c.effect = effect;
-						c.order = c.priority ?? c.mode * 10;
-						return c;
-					}),
-				);
 			}
-			changes.sort((a, b) => a.order - b.order);
+			changes.sort((a, b) => a.priority - b.priority);
+			ActiveEffect._shimChanges(changes);
 
 			// Apply all changes
-			for (let change of changes) {
-				if (!change.key) {
-					continue;
-				}
-				const changes = change.effect.apply(this, change);
-				Object.assign(overrides, changes);
+			const overrides = {};
+			for (const change of changes) {
+				const replacementData = dataByEffect.get(change.effect) ?? rollData;
+				const result = ActiveEffect.applyChange(this, change, { replacementData });
+				if (foundry.utils.isPlainObject(result)) Object.assign(overrides, result);
 			}
 
 			// Expand the set of final overrides
-			this.overrides = foundry.utils.expandObject(overrides);
+			foundry.utils.mergeObject(this.overrides, foundry.utils.expandObject(overrides));
 
-			if (this.system.afterApplyActiveEffects) {
-				this.system.afterApplyActiveEffects();
+			if (phase === 'final') {
+				this.render();
 			}
-
-			for (const item of this.allItems()) {
-				if (item.applyActiveEffects) {
-					item.applyActiveEffects();
-				}
-			}
-
-			this.render();
 		}
 
 		*allItems() {

--- a/module/documents/items/pseudo-item.mjs
+++ b/module/documents/items/pseudo-item.mjs
@@ -30,6 +30,7 @@ class BasePseudoItem extends PseudoDocument {
 			super.metadata,
 			{
 				hasTypeData: true,
+				baseTypeAllowed: false,
 				label: 'DOCUMENT.Item',
 			},
 			{ inplace: false },

--- a/module/documents/pseudo/base-pseudo-document.mjs
+++ b/module/documents/pseudo/base-pseudo-document.mjs
@@ -61,7 +61,7 @@ export class BasePseudoDocument extends foundry.abstract.DataModel {
 		const base = this.baseDocument;
 		// eslint-disable-next-line no-prototype-builtins
 		if (!base.hasOwnProperty('_schema')) {
-			const schema = new foundry.data.fields.SchemaField(Object.freeze(base.defineSchema()));
+			const schema = new foundry.data.fields.DataModelSchemaField(base);
 			Object.defineProperty(base, '_schema', { value: schema, writable: false });
 		}
 		Object.defineProperty(this, '_schema', { value: base._schema, writable: false });
@@ -468,11 +468,18 @@ export class BasePseudoDocument extends foundry.abstract.DataModel {
 		const preArgs = [changes, options, game.userId];
 		parentDocument._dispatchDescendantDocumentEvents?.('preUpdate', collection.name, preArgs);
 
+		const oldSourceStates = documents.reduce((acc, doc) => {
+			acc[doc.id] = doc.toObject(true);
+			return acc;
+		}, {});
+
 		await parentFoundryDocument.update(changeObject);
 		const updated = updates.map((value) => collection.get(value._id));
 		setTimeout(() => {
 			updated.forEach((document) => {
-				document._onUpdate(updates.find((value) => value._id === document.id) ?? {}, options, game.userId);
+				const oldSourceState = oldSourceStates[document.id] ?? {};
+				const diff = foundry.utils.diffObject(oldSourceState, document.toObject(true));
+				document._onUpdate(diff, options, game.userId);
 			});
 			const postArgs = [updated, changes, options, game.userId];
 			parentDocument._dispatchDescendantDocumentEvents?.('onUpdate', collection.name, postArgs);
@@ -1185,7 +1192,7 @@ export class BasePseudoDocument extends foundry.abstract.DataModel {
 			.join('.');
 		const nestedCollection = traversalLog.findLast((value) => Array.isArray(value.value));
 		return {
-			changeObject: { [baseKey]: traversalLog[firstArray].value },
+			changeObject: { [baseKey]: new foundry.data.operators.ForcedReplacement(traversalLog[firstArray].value) },
 			nestedCollection: nestedCollection.value,
 		};
 	}

--- a/module/documents/pseudo/enable-pseudo-documents-mixin.mjs
+++ b/module/documents/pseudo/enable-pseudo-documents-mixin.mjs
@@ -20,6 +20,7 @@ export function EnablePseudoDocumentsMixin(ClientDocument) {
 			super.prepareEmbeddedDocuments();
 			for (const collectionName of Object.keys(this.nestedCollections || {})) {
 				for (const e of this.getEmbeddedCollection(collectionName)) {
+					e._initialize();
 					e._safePrepareData();
 				}
 			}

--- a/module/documents/pseudo/pseudo-document-collection-field.mjs
+++ b/module/documents/pseudo/pseudo-document-collection-field.mjs
@@ -98,7 +98,7 @@ export class PseudoDocumentCollectionField extends foundry.data.fields.ArrayFiel
 
 	/** @override */
 	_validateRecursive(value, options) {
-		const collectionFailure = new foundry.data.validation.DataModelValidationFailure('EmbeddedCollectionField#_validateRecursive', { fieldPath: this.fieldPath, unresolved: false });
+		const collectionFailure = new foundry.data.validation.DataModelValidationFailure('PseudoDocumentCollectionField#_validateRecursive', { fieldPath: this.fieldPath, unresolved: false });
 		const collection = options.model?.[this.fieldPath];
 		for (let i = value.length - 1; i >= 0; i--) {
 			// Iterate backwards so we can splice as we go

--- a/module/documents/pseudo/pseudo-document-collection.mjs
+++ b/module/documents/pseudo/pseudo-document-collection.mjs
@@ -102,15 +102,6 @@ export default class PseudoDocumentCollection extends foundry.utils.Collection {
 		this._initialized = true;
 	}
 
-	/**
-	 * @param {(foundry.abstract.DataModel | object)[]} data
-	 * @param options
-	 */
-	updateSource(data, options = {}) {
-		this._source.splice(0, this._source.length, ...data);
-		this.initialize(options);
-	}
-
 	/* -------------------------------------------- */
 
 	/**

--- a/module/documents/pseudo/pseudo-document-enabled-type-data-model.mjs
+++ b/module/documents/pseudo/pseudo-document-enabled-type-data-model.mjs
@@ -39,13 +39,6 @@ export class PseudoDocumentEnabledTypeDataModel extends foundry.abstract.TypeDat
 		Object.defineProperty(this, 'collections', { value: Object.seal(collections), writable: false });
 	}
 
-	_initialize(options = {}) {
-		super._initialize(options);
-		Object.entries(this.collections).forEach(([fieldName, collection]) => {
-			collection.updateSource(this._source[fieldName]);
-		});
-	}
-
 	/**
 	 * A compatibility method that returns the appropriate name of a pseudo collection within this Document.
 	 * @param {string} name    An existing collection name or a document name.

--- a/module/documents/pseudo/pseudo-document.mjs
+++ b/module/documents/pseudo/pseudo-document.mjs
@@ -31,20 +31,6 @@ export class PseudoDocument extends BasePseudoDocument {
 
 	static name = 'PseudoDocument';
 
-	_initialize(options) {
-		super._initialize(options);
-		if (!game._documentsReady) return;
-		if (this.parent?.collections[this.parentCollection]?._initialized === false) {
-			return; // Skip documents in uninitialized embedded collections
-		}
-		Object.entries(this.collections).forEach(([fieldName, collection]) => {
-			collection.updateSource(this._source[fieldName]);
-		});
-		// TODO: still needed?
-		// setTimeout(() => this.render());
-		this._safePrepareData();
-	}
-
 	/**
 	 * Return a reference to the parent Collection instance that contains this Document.
 	 * @this {PseudoDocument}
@@ -182,8 +168,7 @@ export class PseudoDocument extends BasePseudoDocument {
 		// Default sheet selection for the type
 		const classes = Object.values(sheets);
 		// it's a foundry global
-		// eslint-disable-next-line no-undef
-		if (!classes.length) return BaseSheet;
+		if (!classes.length) return foundry.applications.sheets.BaseSheet;
 		return (classes.find((s) => s.default) ?? classes.pop()).cls;
 	}
 
@@ -236,11 +221,13 @@ export class PseudoDocument extends BasePseudoDocument {
 	prepareEmbeddedDocuments() {
 		for (const collectionName of Object.keys(this.collections || {})) {
 			for (let e of this.collections[collectionName]) {
+				e._initialize();
 				e._safePrepareData();
 			}
 		}
 		for (const collectionName of Object.keys(this.nestedCollections || {})) {
 			for (let e of this.nestedCollections[collectionName]) {
+				e._initialize();
 				e._safePrepareData();
 			}
 		}


### PR DESCRIPTION
- align pseudo-active-effect.mjs with core implementation
- align item active effect application with core implementation for actors
- remove vestigial template getter from rule-element-data-model.mjs
- fix (hopefully) pseudo documents not working correctly