### PR TITLE
Bugfix: Chat damage application broken

### DIFF
--- a/module/helpers/chat-builder.mjs
+++ b/module/helpers/chat-builder.mjs
@@ -218,16 +218,18 @@ export class FUChatBuilder {
 			speaker: speaker,
 			flags: flags,
 		};
-		const options = {};
+		const options = {
+			chatBubble: false,
+		};
 
 		// OPTION: Roll data
 		if (this.#rolls) {
 			chatMessage.rolls = this.#rolls;
-			options.rollMode = 'roll';
+			options.messageMode = true;
 		}
 
 		// Render to chat
-		await ChatMessage.create(chatMessage, options);
+		await ChatMessage.create(foundry.utils.duplicate(chatMessage), options);
 
 		// Execute post-render actions
 		for (let postRenderAction of this.#renderData.postRenderActions) {


### PR DESCRIPTION
- run message creation data through `foundry.utils.duplicate()` to replace class instances with plain objects
- replace deprecated `rollMode` with `messageMode`
- prevent system chat cards from showing up as chat bubbles