### PR TITLE
Incorrect selectOptions context path for AE rules template

### DIFF
--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -288,12 +288,12 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 	 * @returns {Promise<void>}
 	 */
 	static async #deleteRuleElement(event, target) {
-		const { id } = target.dataset;
+		const id = target.closest('[data-rule-element]')?.dataset.ruleElement;
 		console.debug(`Deleting rule element ${id}`);
 		/** @type RuleElementDataModel **/
 		const re = this.document.system.getRuleElement(id);
 		if (re) {
-			const confirm = await FoundryUtils.confirmDialog('FU.Remove', StringUtils.localize('FU.DialogRemoveMessage', { label: re.localization }));
+			const confirm = await FoundryUtils.confirmDialog('FU.Remove', _loc('FU.DialogRemoveMessage', { label: _loc(re.trigger.constructor.localization) }));
 			if (confirm) {
 				return this.document.update({
 					system: {
@@ -332,7 +332,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 	 * @returns {Promise<void>}
 	 */
 	async #updateRuleTrigger(event, target) {
-		const { id } = target.dataset;
+		const id = target.closest('[data-rule-element]')?.dataset.ruleElement;
 		const type = target.value;
 		console.debug(`Updating rule trigger of ${id} to: ${type} (${event.type})`);
 		const re = this.document.system.getRuleElement(id);
@@ -357,7 +357,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 	 * @returns {Promise<void>}
 	 */
 	static async #addRuleAction(event, target) {
-		const { id } = target.dataset;
+		const id = target.closest('[data-rule-element]')?.dataset.ruleElement;
 		console.debug(`Adding rule action to ${id}`);
 		const re = this.document.system.getRuleElement(id);
 		if (re) {
@@ -393,25 +393,28 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 	 * @returns {Promise<void>}
 	 */
 	static async #removeRuleAction(event, target) {
-		const { id, actionId } = target.dataset;
-		console.debug(`Removing rule action ${actionId} from ${id}`);
+		const actionId = target.dataset.actionId;
+		const id = target.closest('[data-rule-element]')?.dataset.ruleElement;
 		const re = this.document.system.getRuleElement(id);
-		const action = re.getAction(actionId);
-		const confirm = await FoundryUtils.confirmDialog('FU.Remove', StringUtils.localize('FU.DialogRemoveMessage', { label: action.localization }));
-		if (confirm) {
-			return this.document.update({
-				system: {
-					rules: {
-						elements: {
-							[id]: {
-								actions: {
-									[actionId]: new foundry.data.operators.ForcedDeletion(),
+		const action = re?.getAction(actionId);
+		if (action) {
+			console.debug(`Removing rule action ${actionId} from ${id}`);
+			const confirm = await FoundryUtils.confirmDialog('FU.Remove', _loc('FU.DialogRemoveMessage', { label: _loc(action.constructor.localization) }));
+			if (confirm) {
+				return this.document.update({
+					system: {
+						rules: {
+							elements: {
+								[id]: {
+									actions: {
+										[actionId]: new foundry.data.operators.ForcedDeletion(),
+									},
 								},
 							},
 						},
 					},
-				},
-			});
+				});
+			}
 		}
 	}
 
@@ -421,31 +424,33 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 	 * @returns {Promise<void>}
 	 */
 	static async #addRulePredicate(event, target) {
-		const { id } = target.dataset;
+		const id = target.closest('[data-rule-element]')?.dataset.ruleElement;
 		console.debug(`Adding rule predicate to ${id}`);
 		const re = this.document.system.getRuleElement(id);
-		const subTypes = re.getMatchingSubTypes(RulePredicateRegistry.instance);
-		const options = FoundryUtils.generateConfigOptions(subTypes);
-		const type = await FoundryUtils.selectOptionDialog(
-			StringUtils.localize('FU.AddElement', {
-				element: StringUtils.localize('FU.RulePredicates'),
-			}),
-			options,
-		);
-		if (type) {
-			return this.document.update({
-				system: {
-					rules: {
-						elements: {
-							[id]: {
-								predicates: {
-									[foundry.utils.randomID()]: { type: type },
+		if (re) {
+			const subTypes = re.getMatchingSubTypes(RulePredicateRegistry.instance);
+			const options = FoundryUtils.generateConfigOptions(subTypes);
+			const type = await FoundryUtils.selectOptionDialog(
+				StringUtils.localize('FU.AddElement', {
+					element: StringUtils.localize('FU.RulePredicates'),
+				}),
+				options,
+			);
+			if (type) {
+				return this.document.update({
+					system: {
+						rules: {
+							elements: {
+								[id]: {
+									predicates: {
+										[foundry.utils.randomID()]: { type: type },
+									},
 								},
 							},
 						},
 					},
-				},
-			});
+				});
+			}
 		}
 	}
 
@@ -455,25 +460,28 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 	 * @returns {Promise<void>}
 	 */
 	static async #removeRulePredicate(event, target) {
-		const { id, predicateId } = target.dataset;
+		const predicateId = target.dataset.predicateId;
+		const id = target.closest('[data-rule-element]')?.dataset.ruleElement;
 		console.debug(`Removing rule predicate ${predicateId} from ${id}`);
 		const re = this.document.system.getRuleElement(id);
-		const predicate = re.getPredicate(predicateId);
-		const confirm = await FoundryUtils.confirmDialog('FU.Remove', StringUtils.localize('FU.DialogRemoveMessage', { label: predicate.localization }));
-		if (confirm) {
-			return this.document.update({
-				system: {
-					rules: {
-						elements: {
-							[id]: {
-								predicates: {
-									[predicateId]: new foundry.data.operators.ForcedDeletion(),
+		const predicate = re?.getPredicate(predicateId);
+		if (predicate) {
+			const confirm = await FoundryUtils.confirmDialog('FU.Remove', _loc('FU.DialogRemoveMessage', { label: _loc(predicate.constructor.localization) }));
+			if (confirm) {
+				return this.document.update({
+					system: {
+						rules: {
+							elements: {
+								[id]: {
+									predicates: {
+										[predicateId]: new foundry.data.operators.ForcedDeletion(),
+									},
 								},
 							},
 						},
 					},
-				},
-			});
+				});
+			}
 		}
 	}
 

--- a/module/documents/effects/rule-element-data-model.mjs
+++ b/module/documents/effects/rule-element-data-model.mjs
@@ -32,7 +32,7 @@ export class RuleElementDataModel extends foundry.abstract.DataModel {
 	 * @returns {RuleActionDataModel}
 	 */
 	getAction(id) {
-		return this.actions.get(id);
+		return this.actions[id];
 	}
 
 	/**
@@ -40,7 +40,7 @@ export class RuleElementDataModel extends foundry.abstract.DataModel {
 	 * @returns {RulePredicateDataModel}
 	 */
 	getPredicate(id) {
-		return this.predicates.get(id);
+		return this.predicates[id];
 	}
 
 	/**
@@ -54,8 +54,8 @@ export class RuleElementDataModel extends foundry.abstract.DataModel {
 			subTypes = Object.fromEntries(
 				Object.entries(subTypes).filter(([key]) => {
 					const model = registry.qualifiedTypes[key];
-					if (model.eventTypes) {
-						return model.eventTypes.has(triggerEventType);
+					if (model.eventTypes && model.eventTypes.length > 0) {
+						return model.eventTypes.includes(triggerEventType);
 					}
 					return true;
 				}),

--- a/module/documents/items/common/traits-data-model.mjs
+++ b/module/documents/items/common/traits-data-model.mjs
@@ -3,13 +3,6 @@
  * @property {Set<String>} entries
  */
 export class TraitsDataModel extends foundry.abstract.DataModel {
-	/**
-	 * @param {Object} data
-	 */
-	constructor(data = {}) {
-		super(data);
-	}
-
 	static defineSchema() {
 		const { SetField, StringField } = foundry.data.fields;
 		return {

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -426,10 +426,17 @@ function traits(model, path, options) {
 	const html =
 		typeof template === 'function'
 			? template({
-					model: model,
-					path: path,
-					traitOptions: model.schema.options?.options ?? {},
-					quantifierOptions: FU.predicateQuantifier,
+					traitField: model.schema.getField('entries'),
+					traitFieldPath: path + '.entries',
+					traitFieldValue: model.entries,
+					traitOptions: model.schema.options?.options ?? [],
+					quantifier: model.schema.getField('quantifier')
+						? {
+								path: path + '.quantifier',
+								value: model.quantifier,
+								options: FU.predicateQuantifier,
+							}
+						: undefined,
 					showLabel: options.showLabel ?? false,
 				})
 			: '';

--- a/templates/common/traits.hbs
+++ b/templates/common/traits.hbs
@@ -1,4 +1,4 @@
-{{#if model.quantifier}}
+{{#if quantifier}}
 	<div class="fu-form__group">
 		{{#if showLabel}}
 			<label class="fu-form__group__header flex-group-center">
@@ -9,13 +9,13 @@
 			{{#if showLabel}}
 				<span>{{localize 'FU.Traits'}}</span>
 			{{/if}}
-			{{formGroup model.schema.fields.entries value=model.entries name=(pfuConcat path ".entries") options=traitOptions classes="fu-form__set stacked"}}
+			{{formGroup traitField name=traitFieldPath value=traitFieldValue options=traitOptions classes="fu-form__set stacked"}}
 		</div>
 
 		<label class="fu-form__property">
 			<span>{{localize 'FU.Quantifier'}}</span>
-			<select name="{{pfuConcat path ".quantifier"}}">
-				{{selectOptions quantifierOptions selected=model.quantifier localize=true}}
+			<select name="{{quantifier.path}}">
+				{{selectOptions quantifier.options selected=quantifier.value localize=true}}
 			</select>
 		</label>
 	</div>
@@ -24,6 +24,6 @@
 		{{#if showLabel}}
 			<span>{{localize 'FU.Traits'}}</span>
 		{{/if}}
-		{{formGroup model.schema.fields.entries value=model.entries name=(pfuConcat path ".entries") options=traitOptions classes="fu-form__set stacked"}}
+		{{formGroup traitField name=traitFieldPath value=traitFieldValue options=traitOptions classes="fu-form__set stacked"}}
 	</div>
 {{/if}}

--- a/templates/effects/active-effect-rules.hbs
+++ b/templates/effects/active-effect-rules.hbs
@@ -87,7 +87,7 @@
 							{{formGroup element.schema.fields.enabled value=element.enabled
 										name=(concat "system.rules.elements." elementId ".enabled")}}
 							<!-- Delete Action -->
-							<a class="" data-id="{{elementId}}" data-action="deleteRuleElement">
+							<a data-action="deleteRuleElement">
 								<i class="icon fas fa-circle-trash"></i>
 							</a>
 						</span>
@@ -106,7 +106,7 @@
 								<label>
 									{{~localize 'FU.Type'}}
 									<select data-action="updateRuleTrigger" data-type="{{element.trigger.type}}"
-											data-id="{{elementId}}" class="resource-inputs select-dropdown-l">
+											 class="resource-inputs select-dropdown-l">
 										{{selectOptions @root.options.ruleTriggers selected=element.trigger.type
 														localize=true}}
 									</select>
@@ -133,7 +133,7 @@
 								<div>
 									<span data-tooltip="{{localize 'FU.RulePredicatesHint'}}">{{localize
 									 'FU.RulePredicates'}}</span>
-									<a data-action="addRulePredicate" data-id="{{elementId}}">
+									<a data-action="addRulePredicate" >
 										<i class="fas fa-plus icon"></i>
 									</a>
 								</div>
@@ -158,8 +158,7 @@
 										</select>
 									</label>
 								{{/if}}
-												<a class="" data-action="removeRulePredicate"
-												   data-id="{{elementId}}" data-predicate-id="{{predicateId}}">
+												<a data-action="removeRulePredicate" data-predicate-id="{{predicateId}}">
 									<i class="icon fas fa-circle-minus"></i>
 								</a>
 							</span>
@@ -177,7 +176,7 @@
 								<div>
 									<span data-tooltip="{{localize 'FU.RuleActionsHint'}}">{{localize
 									 'FU.RuleActions'}}</span>
-									<a data-action="addRuleAction" data-id="{{element.id}}">
+									<a data-action="addRuleAction" >
 										<i class="fas fa-plus icon"></i>
 									</a>
 								</div>
@@ -200,8 +199,7 @@
 												{{localize
 												 (lookup (lookup (lookup action "schema") "model") "localization")}}
 											</label>
-											<a class="" data-action="removeRuleAction" data-id="{{elementId}}"
-											   data-action-id="{{actionId}}">
+											<a data-action="removeRuleAction" data-action-id="{{actionId}}">
 												<i class="icon fas fa-circle-minus"></i>
 											</a>
 										</div>

--- a/templates/effects/active-effect-rules.hbs
+++ b/templates/effects/active-effect-rules.hbs
@@ -153,7 +153,7 @@
 									 'FU.Selector'}}
 										<select name="{{pfuConcat ../path ".predicates." predicate.id ".selector"}}"
 												class="resource-inputs select-dropdown-m">
-											{{selectOptions ../options.targetSelector selected=predicate.selector
+											{{selectOptions @root.options.targetSelector selected=predicate.selector
 															localize=true}}
 										</select>
 									</label>


### PR DESCRIPTION
Addresses an issue with rendering the ActiveEffect sheet for effects with rule elements
- `selectOptions` helper to render target drop-down was referring to context by incorrect path

<img width="1121" height="558" alt="Screenshot From 2026-08-28 18-15-54" src="https://github.com/user-attachments/assets/20422881-57f0-4292-b1c7-663accd3bea4" />
