### PR TITLE
fix: Remove Foundry v14 deprecation warnings for ActiveEffect modes

### DIFF
--- a/module/documents/effects/active-effect.mjs
+++ b/module/documents/effects/active-effect.mjs
@@ -97,7 +97,7 @@ Hooks.on('preCreateActiveEffect', (effect, options, userId) => {
 
 Hooks.on('updateActiveEffect', (effect, changes, options, userId) => {
 	if (game.userId === userId && effect.target instanceof FUActor && effect.target.canUserModify(game.user, 'update')) {
-		if (effect.changes.some((change) => change.key.startsWith('system.resources.hp'))) {
+		if (effect.system.changes.some((change) => change.key.startsWith('system.resources.hp'))) {
 			effect.target.applyCrisis();
 		}
 		if ('disabled' in changes) {

--- a/module/documents/effects/pseudo-active-effect.mjs
+++ b/module/documents/effects/pseudo-active-effect.mjs
@@ -16,7 +16,7 @@ class BasePseudoActiveEffect extends PseudoDocument {
 				new fields.SchemaField({
 					key: new fields.StringField({ required: true }),
 					value: new fields.StringField({ required: true }),
-					mode: new fields.NumberField({ required: true, nullable: false, integer: true, initial: CONST.ACTIVE_EFFECT_MODES.ADD }),
+					type: new fields.StringField({ required: true, initial: 'add' }),
 					priority: new fields.NumberField(),
 				}),
 			),

--- a/module/documents/effects/pseudo-active-effect.mjs
+++ b/module/documents/effects/pseudo-active-effect.mjs
@@ -12,29 +12,35 @@ class BasePseudoActiveEffect extends PseudoDocument {
 			img: new fields.FilePathField({ categories: ['IMAGE'] }),
 			type: new fields.DocumentTypeField(this, { initial: CONST.BASE_DOCUMENT_TYPE }),
 			system: new fields.TypeDataField(this),
-			changes: new fields.ArrayField(
-				new fields.SchemaField({
-					key: new fields.StringField({ required: true }),
-					value: new fields.StringField({ required: true }),
-					type: new fields.StringField({ required: true, initial: 'add' }),
-					priority: new fields.NumberField(),
-				}),
-			),
 			disabled: new fields.BooleanField(),
+			start: new fields.SchemaField(
+				{
+					combat: new fields.ForeignDocumentField(foundry.documents.BaseCombat),
+					combatant: new fields.ForeignDocumentField(foundry.documents.BaseCombatant, { idOnly: true }),
+					initiative: new fields.NumberField({ required: true }),
+					round: new fields.NumberField({ required: true, integer: true, min: 0 }),
+					turn: new fields.NumberField({ required: true, integer: true, min: 0 }),
+					time: new fields.NumberField({ required: true, nullable: false, integer: true }),
+				},
+				{ nullable: true },
+			),
 			duration: new fields.SchemaField({
-				startTime: new fields.NumberField({ initial: null }),
-				seconds: new fields.NumberField({ integer: true, min: 0 }),
-				combat: new fields.ForeignDocumentField(foundry.documents.BaseCombat),
-				rounds: new fields.NumberField({ integer: true, min: 0 }),
-				turns: new fields.NumberField({ integer: true, min: 0 }),
-				startRound: new fields.NumberField({ integer: true, min: 0 }),
-				startTurn: new fields.NumberField({ integer: true, min: 0 }),
+				value: new fields.NumberField({ required: true, nullable: true, integer: true, min: 0 }),
+				units: new fields.StringField({ required: true, choices: CONST.ACTIVE_EFFECT_DURATION_UNITS, initial: 'seconds' }),
+				expiry: new fields.StringField({ required: true, blank: false, nullable: true, initial: (d) => (typeof d?.duration?.value === 'number' ? 'turnStart' : null) }),
+				expired: new fields.BooleanField(),
 			}),
 			description: new fields.HTMLField({ textSearch: true }),
 			origin: new fields.StringField({ nullable: true, blank: false, initial: null }),
 			tint: new fields.ColorField({ nullable: false, initial: '#ffffff' }),
 			transfer: new fields.BooleanField({ initial: true }),
 			statuses: new fields.SetField(new fields.StringField({ required: true, blank: false })),
+			showIcon: new fields.NumberField({
+				required: true,
+				nullable: false,
+				choices: Object.values(CONST.ACTIVE_EFFECT_SHOW_ICON),
+				initial: CONST.ACTIVE_EFFECT_SHOW_ICON.CONDITIONAL,
+			}),
 			sort: new fields.IntegerSortField(),
 			flags: new fields.DocumentFlagsField(),
 		};
@@ -52,6 +58,183 @@ class BasePseudoActiveEffect extends PseudoDocument {
 	);
 
 	static LOCALIZATION_PREFIXES = foundry.documents.ActiveEffect.LOCALIZATION_PREFIXES;
+
+	static DEFAULT_ICON = foundry.documents.ActiveEffect.DEFAULT_ICON;
+
+	async _preCreate(data, options, user) {
+		const allowed = await super._preCreate(data, options, user);
+		if (allowed === false) return false;
+		const updates = {};
+		if (!this.parent || this.parent instanceof foundry.documents.BaseActor) {
+			updates.transfer = false;
+			if (!this.parent) updates.start = null;
+		}
+		this.updateSource(updates);
+	}
+
+	static #MODES_TO_TYPES = {
+		0: 'custom',
+		1: 'multiply',
+		2: 'add',
+		3: 'downgrade',
+		4: 'upgrade',
+		5: 'override',
+	};
+
+	static #TYPES_TO_MODES = Object.entries(BasePseudoActiveEffect.#MODES_TO_TYPES).reduce((types, [mode, type]) => {
+		types[type] = Number(mode);
+		return types;
+	}, {});
+
+	static migrateData(source, options) {
+		/**
+		 * Migrate origin
+		 * @deprecated since v14
+		 */
+		if (typeof source.origin === 'string') {
+			const parseOptions = source.origin.startsWith('.') ? { relative: new foundry.documents.ActiveEffect({ name: 'ABC' }) } : {};
+			const parsed = foundry.utils.parseUuid(source.origin, parseOptions);
+			if (!parsed || (parsed.type && !CONST.ALL_DOCUMENT_TYPES.includes(parsed.type))) {
+				foundry.utils.mergeObject((source.flags ??= {}), { core: { originText: source.origin } });
+				source.origin = null;
+			}
+		}
+
+		/**
+		 * Migrate changes
+		 * @deprecated since v14
+		 */
+		if (Array.isArray(source.changes)) {
+			source.system ??= {};
+			this._addDataFieldMigration(source, 'changes', 'system.changes');
+			if (Array.isArray(source.system.changes)) {
+				for (const change of source.system.changes) {
+					if (!Object.hasOwn(change, 'type') && typeof change.mode === 'number') {
+						change.type = BasePseudoActiveEffect.#MODES_TO_TYPES[change.mode] ?? `custom.${change.mode}`;
+						delete change.mode;
+					}
+					if (foundry.utils.isPlainObject(change) && typeof change.value === 'string') {
+						change.value = BasePseudoActiveEffect.#migrateChangeValue(change.value);
+					}
+				}
+			}
+		}
+
+		/**
+		 * Migrate start data
+		 * @deprecated since v14
+		 */
+		const duration = source.duration;
+		if (foundry.utils.isPlainObject(duration) && Object.hasOwn(duration, 'startTime') && !Object.hasOwn(source, 'start')) {
+			source.start = typeof duration.startTime === 'number' ? {} : null;
+			if (source.start) {
+				this._addDataFieldMigration(source, 'duration.combat', 'start.combat');
+				this._addDataFieldMigration(source, 'duration.startRound', 'start.round');
+				this._addDataFieldMigration(source, 'duration.startTime', 'start.time');
+				this._addDataFieldMigration(source, 'duration.startTurn', 'start.turn');
+			}
+		}
+		BasePseudoActiveEffect.#migrateDuration(source);
+
+		return super.migrateData(source, options);
+	}
+
+	static #migrateChangeValue(value) {
+		if (typeof value !== 'string' || value === '') return value;
+		try {
+			return BasePseudoActiveEffect.#migrateChangeValue(JSON.parse(value));
+		} catch {
+			return value;
+		}
+	}
+
+	static #migrateDuration(source) {
+		const duration = source.duration;
+		if (!foundry.utils.isPlainObject(duration)) return;
+		for (const unit of ['seconds', 'turns', 'rounds']) {
+			const hasRealProperty = Object.hasOwn(duration, unit) && !Object.getOwnPropertyDescriptor(duration, unit)?.get;
+			if (hasRealProperty && typeof duration[unit] === 'number') {
+				if (!Object.hasOwn(duration, 'value')) duration.value = duration[unit];
+				if (!Object.hasOwn(duration, 'units')) duration.units = unit;
+				break;
+			}
+		}
+	}
+
+	static shimData(data, options) {
+		if (Object.isSealed(data)) return super.shimData(data, options);
+		if (!Object.hasOwn(data, 'changes') && Object.hasOwn(data.system ?? {}, 'changes')) {
+			Object.defineProperty(data, 'changes', {
+				get: () => data.system.changes,
+				set: (changes) => {
+					data.system.changes = changes;
+				},
+				configurable: true,
+				enumerable: false,
+			});
+		}
+		const changes = Array.isArray(data.system?.changes) ? data.system.changes : [];
+		this._shimChanges(changes);
+
+		if (!foundry.utils.isPlainObject(data.duration)) return super.shimData(data, options);
+		if (foundry.utils.isPlainObject(data.start)) {
+			this._addDataFieldShim(data, 'duration.combat', 'start.combat', { since: 14, until: 16, once: true });
+		}
+		for (const key of ['startTime', 'startRound', 'startTurn']) {
+			const newKey = key
+				.split(/(?=[A-Z])/)
+				.map((k) => k.toLocaleLowerCase('en'))
+				.join('.');
+			this._addDataFieldShim(data, `duration.${key}`, newKey, { since: 14, until: 16, once: true });
+		}
+		const getSeconds = () => {
+			if (typeof data.duration.value !== 'number') return null;
+			if (data.duration.units === 'seconds') return data.duration.value;
+			if (game.view === 'game' && CONST.ACTIVE_EFFECT_TIME_DURATION_UNITS.includes(data.duration.units)) {
+				const componentUnit = data.duration.units.replace(/s$/, '');
+				return game.time.calendar.componentsToTime({ [componentUnit]: data.duration.value });
+			}
+			return null;
+		};
+		BasePseudoActiveEffect.#shimDurationField(data.duration, 'seconds', getSeconds);
+		BasePseudoActiveEffect.#shimDurationField(data.duration, 'rounds');
+		BasePseudoActiveEffect.#shimDurationField(data.duration, 'turns');
+		return super.shimData(data, options);
+	}
+
+	static _shimChanges(changes) {
+		for (const change of changes) {
+			if (Object.getOwnPropertyDescriptor(change, 'mode')?.get) continue;
+			Object.defineProperty(change, 'mode', {
+				get: () => {
+					const message = 'You are accessing the numeric #mode of an ActiveEffect change. Use the string #type instead.';
+					foundry.utils.logCompatibilityWarning(message, { since: 14, until: 16, once: true });
+					return BasePseudoActiveEffect.#TYPES_TO_MODES[change.type] ?? (Number(/^custom\.(-?\d+)$/.exec(change.type)?.[1]) || 0);
+				},
+				set: (mode) => {
+					mode = Number(mode);
+					if (Number.isInteger(mode)) change.type = BasePseudoActiveEffect.#MODES_TO_TYPES[mode] ?? `custom.${mode}`;
+				},
+				configurable: true,
+				enumerable: false,
+			});
+		}
+	}
+
+	static #shimDurationField(duration, oldKey, get) {
+		if (Object.hasOwn(duration, oldKey)) return;
+		get ??= () => (duration.units === oldKey ? duration.value : null);
+		const propertyPath = oldKey.replaceAll('.', '#');
+		const message = `You are accessing ${this.name}#${propertyPath}. Duration data now has value and units fields.`;
+		Object.defineProperty(duration, oldKey, {
+			get: () => {
+				foundry.utils.logCompatibilityWarning(message, { since: 14, until: 16, once: true });
+				return get();
+			},
+			configurable: true,
+			enumerable: false,
+		});
+	}
 
 	/**
 	 * A cached compilation of core and registered application phases, along with their labels

--- a/module/documents/items/classFeature/dancer/dance-data-model.mjs
+++ b/module/documents/items/classFeature/dancer/dance-data-model.mjs
@@ -103,8 +103,8 @@ export class DanceDataModel extends RollableClassFeatureDataModel {
 					event: 'endOfTurn',
 					interval: 2,
 				},
+				changes: [FlagUtility.getEffectChange(Flags.State.PreviousDance, currentDance)],
 			},
-			changes: [FlagUtility.getEffectChange(Flags.State.PreviousDance, currentDance)],
 			description: effectDescription,
 		});
 

--- a/module/enrichers/inline-effect-configuration.mjs
+++ b/module/enrichers/inline-effect-configuration.mjs
@@ -40,7 +40,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ attribute }) => ({
 			key: `system.attributes.${attribute}`,
-			mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+			type: 'custom',
 			value: 'upgrade',
 		}),
 	},
@@ -52,7 +52,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ attribute }) => ({
 			key: `system.attributes.${attribute}.current`,
-			mode: CONST.ACTIVE_EFFECT_MODES.DOWNGRADE,
+			type: 'downgrade',
 			value: `@system.attributes.${attribute}.base`,
 		}),
 	},
@@ -68,9 +68,9 @@ const SUPPORTED_CHANGE_TYPES = {
 			},
 		},
 		toChange: ({ damageType, value }) => {
-			const createChange = (type, value) => ({
-				key: `system.bonuses.damage.${type}`,
-				mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+			const createChange = (damType, value) => ({
+				key: `system.bonuses.damage.${damType}`,
+				type: 'add',
 				value,
 			});
 			if (damageType === 'all') {
@@ -93,7 +93,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		toChange: ({ check, value }) => {
 			const createChange = (check, value) => ({
 				key: `system.bonuses.accuracy.${check}`,
-				mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+				type: 'add',
 				value,
 			});
 
@@ -111,7 +111,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ defense, value }) => ({
 			key: `system.derived.${defense}.value`,
-			mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+			type: 'add',
 			value,
 		}),
 	},
@@ -123,7 +123,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ damageType }) => ({
 			key: `system.affinities.${damageType}`,
-			mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+			type: 'custom',
 			value: 'downgrade',
 		}),
 	},
@@ -135,7 +135,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ damageType }) => ({
 			key: `system.affinities.${damageType}`,
-			mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+			type: 'custom',
 			value: 'upgrade',
 		}),
 	},
@@ -147,7 +147,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ damageType }) => ({
 			key: `system.affinities.${damageType}.current`,
-			mode: CONST.ACTIVE_EFFECT_MODES.UPGRADE,
+			type: 'upgrade',
 			value: String(FU.affValue.immunity),
 		}),
 	},
@@ -159,7 +159,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ damageType }) => ({
 			key: `system.affinities.${damageType}.current`,
-			mode: CONST.ACTIVE_EFFECT_MODES.UPGRADE,
+			type: 'upgrade',
 			value: String(FU.affValue.absorption),
 		}),
 	},
@@ -171,7 +171,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ temporaryEffect }) => ({
 			key: `system.immunities.${temporaryEffect}.base`,
-			mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+			type: 'override',
 			value: true,
 		}),
 	},

--- a/module/enrichers/inline-effect-configuration.mjs
+++ b/module/enrichers/inline-effect-configuration.mjs
@@ -40,7 +40,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ attribute }) => ({
 			key: `system.attributes.${attribute}`,
-			type: 'custom',
+			type: FU.changeTypes.apply,
 			value: 'upgrade',
 		}),
 	},
@@ -123,7 +123,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ damageType }) => ({
 			key: `system.affinities.${damageType}`,
-			type: 'custom',
+			type: FU.changeTypes.apply,
 			value: 'downgrade',
 		}),
 	},
@@ -135,7 +135,7 @@ const SUPPORTED_CHANGE_TYPES = {
 		},
 		toChange: ({ damageType }) => ({
 			key: `system.affinities.${damageType}`,
-			type: 'custom',
+			type: FU.changeTypes.apply,
 			value: 'upgrade',
 		}),
 	},
@@ -320,7 +320,10 @@ export class InlineEffectConfiguration extends FUApplication {
 			}
 			if (this.#object.type === 'guided') {
 				const effectData = { ...this.#object.guided };
-				effectData.changes = (effectData.changes ?? []).flatMap((value) => SUPPORTED_CHANGE_TYPES[value.type].toChange(value));
+				const preparedChanges = (effectData.changes ?? []).flatMap((value) => SUPPORTED_CHANGE_TYPES[value.type].toChange(value));
+				delete effectData.changes;
+				effectData.system ??= {};
+				effectData.system.changes = preparedChanges;
 				const encodedEffect = StringUtils.toBase64(effectData);
 				this.#dispatch(this.#state.tr.insertText(` @EFFECT[${encodedEffect}] `));
 			}

--- a/module/enrichers/inline-effects.mjs
+++ b/module/enrichers/inline-effects.mjs
@@ -151,7 +151,7 @@ async function inlineEffectEnricher(match, options) {
 
 		// TODO: Deprecate someday
 		const decodedEffect = StringUtils.fromBase64(id);
-		if (decodedEffect && decodedEffect.name && decodedEffect.changes) {
+		if (decodedEffect && decodedEffect.name && (decodedEffect.system?.changes || decodedEffect.changes)) {
 			return createEffectAnchor(decodedEffect, label);
 		}
 	}

--- a/module/enrichers/inline-type.mjs
+++ b/module/enrichers/inline-type.mjs
@@ -188,7 +188,7 @@ function composeEffectData(type, args) {
 				changes = [
 					{
 						key: attributeKey,
-						mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+						type: 'override',
 						value: attributeValue,
 					},
 				];
@@ -217,7 +217,7 @@ function composeEffectData(type, args) {
 					}
 					changes.push({
 						key: attributeKey,
-						mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+						type: 'override',
 						value: attributeValue,
 					});
 				}

--- a/module/enrichers/inline-weapon.mjs
+++ b/module/enrichers/inline-weapon.mjs
@@ -117,7 +117,7 @@ function createAlterDamageTypeEffect(weapon, type, label) {
 	if (key) {
 		changes.push({
 			key: key,
-			mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+			type: 'override',
 			value: type,
 		});
 	}

--- a/module/helpers/chat-builder.mjs
+++ b/module/helpers/chat-builder.mjs
@@ -225,7 +225,7 @@ export class FUChatBuilder {
 		// OPTION: Roll data
 		if (this.#rolls) {
 			chatMessage.rolls = this.#rolls;
-			options.messageMode = true;
+			options.messageMode = game.settings.get('core', 'messageMode');
 		}
 
 		// Render to chat

--- a/module/helpers/flags.mjs
+++ b/module/helpers/flags.mjs
@@ -74,7 +74,7 @@ export const FlagUtility = Object.freeze({
 	getEffectChange: (flag, value) => {
 		return {
 			key: `flags.${systemId}.${flag}`,
-			mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+			type: 'override',
 			value: value,
 		};
 	},

--- a/module/helpers/foundry-utils.mjs
+++ b/module/helpers/foundry-utils.mjs
@@ -828,7 +828,6 @@ export default class FoundryUtils {
 		const targetEffectsByLabel = new Map(targetItem.effects.map((e) => [e.label, e]));
 		for (const sourceEffect of sourceItem.effects) {
 			const data = foundry.utils.deepClone(sourceEffect.toObject());
-
 			// Never reuse IDs or origins
 			delete data._id;
 			delete data.origin;
@@ -837,7 +836,6 @@ export default class FoundryUtils {
 			if (targetEffect) {
 				updates.push({
 					_id: targetEffect.id,
-					changes: data.changes,
 					duration: data.duration,
 					flags: data.flags,
 					disabled: data.disabled,

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -460,7 +460,7 @@ function removeEffect(document, source, effect) {
 			e.getFlag(SYSTEM, Flags.ActiveEffect.Temporary) &&
 			e.sourceItem === source &&
 			e.changes.length === effect.changes.length &&
-			e.changes.every((change, index) => change.key === effect.changes[index].key && change.mode === effect.changes[index].mode && change.value === effect.changes[index].value),
+			e.changes.every((change, index) => change.key === effect.changes[index].key && change.type === effect.changes[index].type && change.value === effect.changes[index].value),
 	);
 
 	if (existingEffect) {

--- a/module/pipelines/effects.mjs
+++ b/module/pipelines/effects.mjs
@@ -431,6 +431,11 @@ async function applyEffect(document, effect, sourceInfo, config = undefined) {
 			return;
 		}
 		const flags = createEffectFlags(effect, sourceInfo, sourceInfo?.fuid);
+		if (effect.changes) {
+			effect.system ??= {};
+			effect.system.changes = effect.changes;
+			delete effect.changes;
+		}
 		const instance = await ActiveEffect.create(
 			{
 				...effect,
@@ -459,8 +464,8 @@ function removeEffect(document, source, effect) {
 		(e) =>
 			e.getFlag(SYSTEM, Flags.ActiveEffect.Temporary) &&
 			e.sourceItem === source &&
-			e.changes.length === effect.changes.length &&
-			e.changes.every((change, index) => change.key === effect.changes[index].key && change.type === effect.changes[index].type && change.value === effect.changes[index].value),
+			e.system.changes.length === effect.system.changes.length &&
+			e.system.changes.every((change, index) => change.key === effect.system.changes[index].key && change.type === effect.system.changes[index].type && change.value === effect.system.changes[index].value),
 	);
 
 	if (existingEffect) {

--- a/module/systems/pressure-system.mjs
+++ b/module/systems/pressure-system.mjs
@@ -48,20 +48,22 @@ async function processVulnerability(context) {
 		if (stagger) {
 			/** @type NpcDataModel **/
 			const npcData = context.actor.system;
-			const changes = [];
+			const changes = [...stagger.system.changes];
 			for (const [type, affinity] of Object.entries(npcData.affinities.all)) {
-				if (affinity.current !== FU.affValue.immunity) {
+				if (affinity.current < FU.affValue.immunity) {
 					changes.push({
 						key: `system.affinities.${type}.current`,
 						type: 'override',
-						value: '-1',
+						value: `${FU.affValue.vulnerability}`,
 						priority: 100,
 					});
 				}
 			}
 			staggered = true;
 			await stagger.update({
-				changes: changes,
+				system: {
+					changes: foundry.data.operators.ForcedReplacement(changes),
+				},
 			});
 		}
 	}

--- a/module/systems/pressure-system.mjs
+++ b/module/systems/pressure-system.mjs
@@ -53,7 +53,7 @@ async function processVulnerability(context) {
 				if (affinity.current !== FU.affValue.immunity) {
 					changes.push({
 						key: `system.affinities.${type}.current`,
-						mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+						type: 'override',
 						value: '-1',
 						priority: 100,
 					});


### PR DESCRIPTION
I attempted to remove the v14 deprecation warnings for active effect modes

The old CONST.ACTIVE_EFFECT_MODES constant is deprecated (removal in v16) and triggers a console warning on every access. These were replaced with the corresponding string type. 

I'm not sure if PseudoActiveEffect need a migration after this or not. I can look into that if its needed.

Additionally I discoverd an error in Foundry v14.363 that caused the following error. 
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'handler')
    at ChatMessage.applyMode (foundry.mjs:48538:21)
    at ChatMessage.applyMode (foundry.mjs:48568:22)
    at ChatMessage._preCreate (foundry.mjs:48919:37)
    at async #preCreateDocumentArray (foundry.mjs:80409:29)
    at async ClientDatabaseBackend._createDocuments (foundry.mjs:80361:5)
    at async ChatMessage.create (foundry.mjs:15107:21)
    at async FUChatBuilder.create (chat-builder.mjs:232:3)
    at async performCheck (checks.mjs:589:2)
    at async ActionHandler.promptHinderCheck (action-handler.mjs:126:3)
    at async FUStandardActorSheet.PerformAction (actor-standard-sheet.mjs:912:3)
```
Because messageMode expects a string and not a boolean. Note that this error doesn't happen on 14.367+ but that is because foundry added a check that does the parsing with a boolean is sent, but from what I've gathered the correct way is to send the message mode from settings. It is optional but will give compatibility for pre 14.367 builds
