### PR TITLE
Refactor/data model operations

### DIFF
--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -319,7 +319,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 			return this.document.update({
 				system: {
 					rules: {
-						elements: new foundry.data.operators.ForcedReplacement({}),
+						elements: foundry.data.operators.ForcedReplacement.create({}),
 					},
 				},
 			});
@@ -342,7 +342,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 					rules: {
 						elements: {
 							[id]: {
-								trigger: new foundry.data.operators.ForcedReplacement({ type: type }),
+								trigger: foundry.data.operators.ForcedReplacement.create({ type: type }),
 							},
 						},
 					},

--- a/module/documents/effects/active-effect-config.mjs
+++ b/module/documents/effects/active-effect-config.mjs
@@ -299,7 +299,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 					system: {
 						rules: {
 							elements: {
-								[id]: new foundry.data.operators.ForcedDeletion(),
+								[id]: foundry.data.operators.ForcedDeletion.create(),
 							},
 						},
 					},
@@ -407,7 +407,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 							elements: {
 								[id]: {
 									actions: {
-										[actionId]: new foundry.data.operators.ForcedDeletion(),
+										[actionId]: foundry.data.operators.ForcedDeletion.create(),
 									},
 								},
 							},
@@ -474,7 +474,7 @@ export class FUActiveEffectConfig extends foundry.applications.sheets.ActiveEffe
 							elements: {
 								[id]: {
 									predicates: {
-										[predicateId]: new foundry.data.operators.ForcedDeletion(),
+										[predicateId]: foundry.data.operators.ForcedDeletion.create(),
 									},
 								},
 							},

--- a/module/documents/pseudo/base-pseudo-document.mjs
+++ b/module/documents/pseudo/base-pseudo-document.mjs
@@ -784,7 +784,7 @@ export class BasePseudoDocument extends foundry.abstract.DataModel {
 			throw new Error(`Flag scope "${scope}" is not valid or not currently active`);
 		}
 		key = ['flags', scope, key].join('.');
-		return this.update({ [key]: new foundry.data.operators.ForcedDeletion() });
+		return this.update({ [key]: foundry.data.operators.ForcedDeletion.create() });
 	}
 
 	/**

--- a/module/documents/pseudo/base-pseudo-document.mjs
+++ b/module/documents/pseudo/base-pseudo-document.mjs
@@ -1192,7 +1192,7 @@ export class BasePseudoDocument extends foundry.abstract.DataModel {
 			.join('.');
 		const nestedCollection = traversalLog.findLast((value) => Array.isArray(value.value));
 		return {
-			changeObject: { [baseKey]: new foundry.data.operators.ForcedReplacement(traversalLog[firstArray].value) },
+			changeObject: { [baseKey]: foundry.data.operators.ForcedReplacement.create(traversalLog[firstArray].value) },
 			nestedCollection: nestedCollection.value,
 		};
 	}

--- a/module/helpers/tables/mnemosphere-heroics-table-renderer.mjs
+++ b/module/helpers/tables/mnemosphere-heroics-table-renderer.mjs
@@ -8,7 +8,7 @@ export class MnemosphereHeroicsTableRenderer extends HeroicsTableRenderer {
 		getItems: (item) => item.system.heroics,
 		columns: {
 			name: { headerSpan: 1 },
-			resourcePoints: new foundry.data.operators.ForcedDeletion(),
+			resourcePoints: foundry.data.operators.ForcedDeletion.create(),
 			controls: CommonColumns.itemControlsColumn(
 				{ type: 'heroic', label: 'FU.Heroic' },
 				{

--- a/module/helpers/tables/mnemosphere-skills-table-renderer.mjs
+++ b/module/helpers/tables/mnemosphere-skills-table-renderer.mjs
@@ -8,7 +8,7 @@ export class MnemosphereSkillsTableRenderer extends SkillsTableRenderer {
 		getItems: (item) => item.system.skills,
 		columns: {
 			name: { headerSpan: 1 },
-			resourcePoints: new foundry.data.operators.ForcedDeletion(),
+			resourcePoints: foundry.data.operators.ForcedDeletion.create(),
 			controls: CommonColumns.itemControlsColumn(
 				{ type: 'skill', label: 'FU.Skill' },
 				{

--- a/module/helpers/tables/npc-profile-abilities-table-renderer.mjs
+++ b/module/helpers/tables/npc-profile-abilities-table-renderer.mjs
@@ -6,8 +6,8 @@ export class NpcProfileAbilitiesTableRenderer extends AbilitiesTableRenderer {
 		cssClass: 'npc-profile-abilities-table',
 		hideIfEmpty: true,
 		columns: {
-			combinedProgress: new foundry.data.operators.ForcedDeletion(),
-			controls: new foundry.data.operators.ForcedDeletion(),
+			combinedProgress: foundry.data.operators.ForcedDeletion.create(),
+			controls: foundry.data.operators.ForcedDeletion.create(),
 		},
 		getItems: NpcProfileAbilitiesTableRenderer.#getItems,
 	};

--- a/module/helpers/tables/npc-profile-basic-attacks-table-renderer.mjs
+++ b/module/helpers/tables/npc-profile-basic-attacks-table-renderer.mjs
@@ -5,7 +5,7 @@ export class NpcProfileBasicAttacksTableRenderer extends BasicAttacksTableRender
 	static TABLE_CONFIG = {
 		cssClass: 'npc-profile-basic-attacks-table',
 		columns: {
-			controls: new foundry.data.operators.ForcedDeletion(),
+			controls: foundry.data.operators.ForcedDeletion.create(),
 		},
 	};
 }

--- a/module/helpers/tables/npc-profile-rules-table-renderer.mjs
+++ b/module/helpers/tables/npc-profile-rules-table-renderer.mjs
@@ -6,8 +6,8 @@ export class NpcProfileRulesTableRenderer extends AbilitiesTableRenderer {
 		cssClass: 'npc-profile-rules-table',
 		hideIfEmpty: true,
 		columns: {
-			clock: new foundry.data.operators.ForcedDeletion(),
-			controls: new foundry.data.operators.ForcedDeletion(),
+			clock: foundry.data.operators.ForcedDeletion.create(),
+			controls: foundry.data.operators.ForcedDeletion.create(),
 		},
 		getItems: NpcProfileRulesTableRenderer.#getItems,
 	};

--- a/module/helpers/tables/npc-profile-spells-table-renderer.mjs
+++ b/module/helpers/tables/npc-profile-spells-table-renderer.mjs
@@ -5,7 +5,7 @@ export class NpcProfileSpellsTableRenderer extends SpellsTableRenderer {
 	static TABLE_CONFIG = {
 		cssClass: 'npc-profile-spells-table',
 		columns: {
-			controls: new foundry.data.operators.ForcedDeletion(),
+			controls: foundry.data.operators.ForcedDeletion.create(),
 		},
 	};
 }

--- a/module/helpers/tables/npc-profile-weapons-table-renderer.mjs
+++ b/module/helpers/tables/npc-profile-weapons-table-renderer.mjs
@@ -5,8 +5,8 @@ export class NpcProfileWeaponsTableRenderer extends WeaponsTableRenderer {
 	static TABLE_CONFIG = {
 		cssClass: 'npc-profile-weapons-table',
 		columns: {
-			controls: new foundry.data.operators.ForcedDeletion(),
-			equipStatus: new foundry.data.operators.ForcedDeletion(),
+			controls: foundry.data.operators.ForcedDeletion.create(),
+			equipStatus: foundry.data.operators.ForcedDeletion.create(),
 		},
 	};
 }

--- a/module/sheets/item-feature-sheet.mjs
+++ b/module/sheets/item-feature-sheet.mjs
@@ -220,7 +220,7 @@ export class FUFeatureSheet extends FUItemSheet {
 					console.debug(`Changing subtype to ${selectedType} from ${currentType}`);
 					const updates = {
 						system: {
-							data: new foundry.data.operators.ForcedReplacement({ type: selectedType }),
+							data: foundry.data.operators.ForcedReplacement.create({ type: selectedType }),
 						},
 					};
 					await this.item.update(updates);
@@ -238,7 +238,7 @@ export class FUFeatureSheet extends FUItemSheet {
 					console.debug(`Changing subtype to ${selectedType} from ${currentType}`);
 					const updates = {
 						system: {
-							data: new foundry.data.operators.ForcedReplacement({ type: selectedType }),
+							data: foundry.data.operators.ForcedReplacement.create({ type: selectedType }),
 						},
 					};
 					await this.item.update(updates);

--- a/module/systems/pressure-system.mjs
+++ b/module/systems/pressure-system.mjs
@@ -62,7 +62,7 @@ async function processVulnerability(context) {
 			staggered = true;
 			await stagger.update({
 				system: {
-					changes: foundry.data.operators.ForcedReplacement(changes),
+					changes: foundry.data.operators.ForcedReplacement.create(changes),
 				},
 			});
 		}

--- a/module/ui/npc-profile.mjs
+++ b/module/ui/npc-profile.mjs
@@ -357,8 +357,7 @@ export class NpcProfileWindow extends FUApplication {
 			if (changedAdversary.revealed.traits) {
 				changedAdversary.revealed.traits = changedAdversary.revealed.traits.filter((t) => traitsArray.includes(t));
 				if (changedAdversary.revealed.traits.length === 0) {
-					delete changedAdversary.revealed.traits;
-					changedAdversary.revealed['-=traits'] = null;
+					changedAdversary.revealed.traits = new foundry.data.operators.ForcedDeletion();
 				}
 			}
 			await party.parent.update({ system: { adversaries: adversaries } });

--- a/module/ui/npc-profile.mjs
+++ b/module/ui/npc-profile.mjs
@@ -357,7 +357,7 @@ export class NpcProfileWindow extends FUApplication {
 			if (changedAdversary.revealed.traits) {
 				changedAdversary.revealed.traits = changedAdversary.revealed.traits.filter((t) => traitsArray.includes(t));
 				if (changedAdversary.revealed.traits.length === 0) {
-					changedAdversary.revealed.traits = new foundry.data.operators.ForcedDeletion();
+					changedAdversary.revealed.traits = foundry.data.operators.ForcedDeletion.create();
 				}
 			}
 			await party.parent.update({ system: { adversaries: adversaries } });


### PR DESCRIPTION
Remove  deprecated operators for DataModel updates as described in #1127 

The only old key I found was in `module/ui/npc-profile.mjs`

For consistency's sake I also updated the use of `ForcedReplacement` as per the api docs linked in the issue. 

`module/systems/pressure-system.mjs` whas throwing a TypeError, that should be fixed with the correct use of the constructor.

